### PR TITLE
fix(peacock): DNS-independent ad suppression — Sky SDK addon OkHttp client + New Relic agent kill

### DIFF
--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/peacock/ads/PeacockAdPatchHelper.kt
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/peacock/ads/PeacockAdPatchHelper.kt
@@ -36,4 +36,26 @@ object PeacockAdPatchHelper {
             .addInterceptor(OkHttpWorkaroundInterceptor())
             .build()
     }
+
+    /**
+     * Adds AdBlockInterceptor to the Sky Core Player SDK's addon-network
+     * OkHttpClient.Builder (com.sky.core.player.sdk.addon.networkLayer.
+     * NativeNetworkApi) before it's built.
+     *
+     * This client is independent from NetworkingKt.getOkHttpClient() above —
+     * it's derived via OkHttpClient.newBuilder() inside NativeNetworkApi's
+     * own constructor and carries all Sky SDK addon traffic (FreeWheel ad
+     * decisioning, Conviva/Comscore/Nielsen measurement pixels delivered
+     * dynamically via the ad-config response, MediaTailor telemetry).
+     * AdBlockInterceptor was previously only wired into the app's main
+     * client, leaving this entire addon traffic path unfiltered — confirmed
+     * via AdGuard Home query logs showing sas.peacocktv.com, fwmrm.net, and
+     * third-party measurement domains still resolving and being requested
+     * with the patched APK installed, even though those hostnames were
+     * already present in AdBlockInterceptor's domain lists.
+     */
+    @JvmStatic
+    fun addAdBlockInterceptor(builder: OkHttpClient.Builder): OkHttpClient.Builder {
+        return builder.addInterceptor(AdBlockInterceptor())
+    }
 }

--- a/extensions/proguard-rules.pro
+++ b/extensions/proguard-rules.pro
@@ -31,8 +31,14 @@
 # smali via invoke-static {}. R8 must not rename or remove this method.
 # OkHttpWorkaroundInterceptor is also instantiated here — kept via its own
 # existing rule elsewhere; confirm it has one if the build strips it.
+#
+# Layer 9: addAdBlockInterceptor(OkHttpClient.Builder) is likewise called
+# only from injected smali (in NativeNetworkApi.<init>), so it must be kept
+# explicitly too — without this R8 sees it as unreferenced and would strip
+# or rename it, breaking the Sky SDK addon-client interception at runtime.
 -keep class ajstrick81.morphe.extension.peacock.ads.PeacockAdPatchHelper {
     public static okhttp3.OkHttpClient buildOkHttpClient();
+    public static okhttp3.OkHttpClient$Builder addAdBlockInterceptor(okhttp3.OkHttpClient$Builder);
 }
 # Layer 7 — WebView shouldInterceptRequest wrapper
 -keep class ajstrick81.morphe.extension.peacock.ads.PeacockWebViewHelper {

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/Fingerprints.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/Fingerprints.kt
@@ -178,3 +178,44 @@ internal object FreewheelModuleSkipFingerprint : Fingerprint(
             classDef.type == "Lcom/sky/core/player/sdk/addon/di/AddonInjectorImpl;"
     },
 )
+
+// ── Layer 9 ──────────────────────────────────────────────────────────────────
+// Target: NativeNetworkApi.<init>(DeviceContext, OkHttpClient)
+//
+// The Sky Core Player SDK's addon network stack (FreeWheel ad decisioning,
+// Conviva/Comscore/Nielsen measurement — delivered dynamically via the
+// ad-config response rather than hardcoded, so no literal domain strings for
+// them exist anywhere in the dex) is entirely independent from the app's
+// main NetworkingKt.getOkHttpClient() client that Layer 6 patches. This
+// constructor derives its own child OkHttpClient via newBuilder()/build()
+// and was the unfiltered gap: AdGuard Home DNS logs showed sas.peacocktv.com
+// and fwmrm.net still being requested with the patched APK installed, even
+// though both hostnames were already in AdBlockInterceptor's lists — the
+// interceptor just wasn't wired into this client.
+// Confirmed matching v7.6.100 via direct smali inspection.
+internal object NativeNetworkApiConstructorFingerprint : Fingerprint(
+    custom = { method, classDef ->
+        method.name == "<init>" &&
+            method.parameters.size == 2 &&
+            method.parameters[0].type == "Lcom/sky/core/player/addon/common/DeviceContext;" &&
+            method.parameters[1].type == "Lokhttp3/OkHttpClient;" &&
+            classDef.type == "Lcom/sky/core/player/sdk/addon/networkLayer/NativeNetworkApi;"
+    },
+)
+
+// ── Layer 10 ─────────────────────────────────────────────────────────────────
+// Target: NewRelicManager.e(Context) — the app's New Relic init wrapper,
+// which launches a coroutine (initialiseNewRelic) that calls
+// NewRelic.withApplicationToken(...).start(context). New Relic's mobile
+// agent harvester uses its own HTTP path, not OkHttp, so no interceptor can
+// ever catch mobile-collector.newrelic.com / nr-data.net traffic — the only
+// way to stop it from the patch side is to prevent the agent from starting.
+// Anchor: only method in NewRelicManager taking a single Context parameter.
+// Confirmed matching v7.6.100 via direct smali inspection.
+internal object NewRelicInitFingerprint : Fingerprint(
+    returnType = "V",
+    parameters = listOf("Landroid/content/Context;"),
+    custom = { method, classDef ->
+        classDef.type == "Lcom/peacock/peacocktv/analytics/NewRelicManager;"
+    },
+)

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/SkipAdsPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/SkipAdsPatch.kt
@@ -14,8 +14,10 @@ import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 val skipAdsPatch = bytecodePatch(
     name = "Skip ads",
     description = "Disables ad delivery via Sky SDK surgical targets (FreeWheel DI module " +
-        "skip, MediaTailor SSAI layers, ad-break-started no-op), OkHttp interceptor, and " +
-        "WebView shouldInterceptRequest wrapper. Validated v7.5.102 and v7.6.100.",
+        "skip, MediaTailor SSAI layers, ad-break-started no-op), dual OkHttp interceptor " +
+        "wiring (app's main client and the Sky SDK addon network client), New Relic agent " +
+        "init no-op, and WebView shouldInterceptRequest wrapper. Validated v7.5.102 and " +
+        "v7.6.100.",
 ) {
     compatibleWith(Constants.COMPATIBILITY)
 
@@ -196,5 +198,53 @@ val skipAdsPatch = bytecodePatch(
             removeInstruction(16) // iget-object v0, freewheelModule
             removeInstruction(16) // import$default(...) — now shifted to 16
         }
+
+        // ── Layer 9 ─────────────────────────────────────────────────────────
+        // NativeNetworkApi.<init> derives its own child OkHttpClient via
+        // newBuilder()/build() — a client Layer 6 never touches. Locate the
+        // OkHttpClient$Builder.build() call dynamically (same approach as
+        // wrapXtvClientSetter) and inject a call to
+        // PeacockAdPatchHelper.addAdBlockInterceptor(builder) immediately
+        // before it, reassigning the same register the builder already
+        // lives in. No extra temp register is needed since the helper takes
+        // and returns the Builder directly — same pattern as Layer 6's
+        // buildOkHttpClient() body replacement.
+        NativeNetworkApiConstructorFingerprint.method.apply {
+            val instructions = implementation!!.instructions
+            val buildIndex = instructions.indexOfFirst { instruction ->
+                instruction.opcode == Opcode.INVOKE_VIRTUAL &&
+                    ((instruction as ReferenceInstruction).reference as? MethodReference)?.let { ref ->
+                        ref.name == "build" && ref.definingClass == "Lokhttp3/OkHttpClient\$Builder;"
+                    } == true
+            }
+            val builderRegister = (instructions[buildIndex] as FiveRegisterInstruction).registerC
+            val totalRegisters = implementation!!.registerCount
+            val paramRegisters = parameters.size + 1 // +1 for implicit `this` (p0)
+            val firstParamRegister = totalRegisters - paramRegisters
+            val registerName = if (builderRegister >= firstParamRegister) {
+                "p${builderRegister - firstParamRegister}"
+            } else {
+                "v$builderRegister"
+            }
+
+            addInstructions(
+                buildIndex,
+                """
+                    invoke-static {$registerName}, Lajstrick81/morphe/extension/peacock/ads/PeacockAdPatchHelper;->addAdBlockInterceptor(Lokhttp3/OkHttpClient${'$'}Builder;)Lokhttp3/OkHttpClient${'$'}Builder;
+                    move-result-object $registerName
+                """.trimIndent(),
+            )
+        }
+
+        // ── Layer 10 ────────────────────────────────────────────────────────
+        // No-op NewRelicManager.e(Context) so the agent never starts —
+        // interceptors can't catch its harvester traffic since it doesn't
+        // go through OkHttp. Void return, offset 0 — always verifier-safe.
+        NewRelicInitFingerprint.method.addInstructions(
+            0,
+            """
+                return-void
+            """.trimIndent(),
+        )
     }
 }


### PR DESCRIPTION
## Summary

Peacock's patched APK still leaked ad/telemetry traffic that only DNS filtering (AdGuard Home) was catching. Root-caused it to a **second, independent OkHttp client** the existing patches never touched, plus the New Relic agent which uses its own non-OkHttp transport. Adds two new layers to close the gap and move toward DNS-independent suppression.

### Layer 9 — wrap the Sky SDK addon network client
`com.sky.core.player.sdk.addon.networkLayer.NativeNetworkApi` derives its own child `OkHttpClient` via `newBuilder()/build()` inside its constructor — entirely separate from the app's main `NetworkingKt.getOkHttpClient()` that Layer 6 already wraps. This is the network path for the Sky SDK's pluggable addons: FreeWheel ad decisioning, plus Conviva/Comscore/Nielsen measurement pixels that are delivered *dynamically* via the ad-config response (which is why those domains appear nowhere as literal strings in the dex). AdGuard logs confirmed `sas.peacocktv.com` and `fwmrm.net` were still being requested with the patched APK installed, even though both were already in `AdBlockInterceptor`'s lists — the interceptor just wasn't on this client.

Layer 9 locates the `OkHttpClient$Builder.build()` call inside that constructor **dynamically** (same offset-independent approach as Layer 7's `wrapXtvClientSetter`, no hardcoded index) and injects `PeacockAdPatchHelper.addAdBlockInterceptor(builder)` immediately before it.

### Layer 10 — no-op New Relic agent init
`NewRelicManager.e(Context)` launches the New Relic agent. Its harvester (`mobile-collector.newrelic.com` / `nr-data.net`) doesn't go through OkHttp at all, so no interceptor can catch it — preventing the agent from starting is the only patch-side option. The init wrapper is no-op'd with `return-void`. Verified the `Deferred` it sets is only read internally and its two callers (`MainActivity`, `ErrorActivity`) are fire-and-forget, so this can't destabilize the app.

## Verification

All checks done by hand-tracing against the disassembled **v7.6.100** APK (no functional change to Layers 1–8; all their fingerprints re-confirmed against this release):

- Layer 9 register logic: `build()` is `invoke-virtual {p1}` (`.registers 5`, p1 = abs reg 3) → resolves to `p1`, interceptor lands before `build()`.
- Layer 10: `e(Context)V` is the unique single-Context void method in `NewRelicManager`; fingerprint is structural (not name-dependent).
- Added an R8 keep rule for `addAdBlockInterceptor` — it's called only from injected smali, so without the rule R8 would strip it (`NoSuchMethodError` at runtime). **This was a real bug caught during review.**

⚠️ **Not yet build-verified locally** — the `app.morphe.patches` plugin resolves from a private GitHub Packages registry and the dev sandbox lacked credentials, so this PR exists specifically to let CI compile it.

## Test plan
- [ ] CI build-only workflow compiles cleanly
- [ ] With DNS filtering **disabled**, confirm `sas.peacocktv.com` / `fwmrm.net` / measurement domains are no longer reached
- [ ] Confirm no New Relic traffic to `mobile-collector.newrelic.com` / `nr-data.net`
- [ ] Confirm playback (VOD + live) is unaffected and no crash on launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)