### PR TITLE
fix(peacock): Layer 11 media-client coverage + SAS/VAC shard matching (DNS-independent suppression)

### DIFF
--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/peacock/ads/AdBlockInterceptor.java
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/peacock/ads/AdBlockInterceptor.java
@@ -79,10 +79,15 @@ public class AdBlockInterceptor implements Interceptor {
         "2mdn.net",
     };
 
-    // Analytics and ad decision endpoints reachable via OkHttp
+    // Analytics and ad decision endpoints reachable via OkHttp.
+    //
+    // Peacock's own ad-decision hosts (sas/vac.peacocktv.com) are intentionally
+    // NOT listed here as flat strings — they ship from regional shards like
+    // sas.f.peacocktv.com / sas.a.peacocktv.com that a "sas.peacocktv.com"
+    // substring never matches (and which would then fall through to the
+    // peacocktv.com safe path). They're handled by isPeacockAdDecisionHost()
+    // below, which matches every shard by leftmost label.
     private static final String[] ANALYTICS_DOMAINS = {
-        "vac.peacocktv.com",
-        "sas.peacocktv.com",
         "fwmrm.net",
         "video-ads-module.ad-tech.nbcuni.com",
         "mediatailor.",
@@ -100,11 +105,37 @@ public class AdBlockInterceptor implements Interceptor {
         "rlcdn.com",
         "nbcuas.com",
         "mparticle.com",
+        // Added after AGH log analysis — confirmed contacted but previously
+        // unblocked at the OkHttp layer:
+        "flashtalking.com",
+        "researchnow.com",
+        "firebaselogging.googleapis.com", // full host only — must not catch play*.googleapis.com
     };
+
+    /**
+     * Matches Peacock's own ad-decision services across all regional shards:
+     * sas.peacocktv.com, sas.&lt;region&gt;.peacocktv.com (SAS = Streaming Ad
+     * Service), vac.peacocktv.com, vac.&lt;region&gt;.peacocktv.com (Video Ad
+     * Config). Matching the leftmost host label rather than a fixed substring
+     * catches every shard while leaving content subdomains
+     * (play.clients/atom/imageservice.peacocktv.com) untouched.
+     *
+     * Blocking the ad DECISION call is the highest-value cut: with no ad
+     * schedule returned, the downstream cascade of (often algorithmically named)
+     * ad-creative and measurement domains is never generated in the first place.
+     */
+    static boolean isPeacockAdDecisionHost(final String host) {
+        if (!host.endsWith("peacocktv.com")) return false;
+        return host.startsWith("sas.") || host.startsWith("vac.");
+    }
 
     @Override
     public Response intercept(Chain chain) throws IOException {
         final String host = chain.request().url().host();
+
+        if (isPeacockAdDecisionHost(host)) {
+            return randomAnalyticsResponse(chain);
+        }
 
         for (final String suffix : AD_CDN_SUFFIXES) {
             if (host.endsWith(suffix)) {

--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/peacock/ads/PeacockWebViewHelper.java
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/peacock/ads/PeacockWebViewHelper.java
@@ -1,5 +1,6 @@
 package ajstrick81.morphe.extension.peacock.ads;
 
+import android.net.Uri;
 import android.util.Log;
 import android.webkit.ClientCertRequest;
 import android.webkit.WebResourceRequest;
@@ -51,9 +52,11 @@ public class PeacockWebViewHelper {
     };
 
     private static final String[] AD_HOSTS = {
-        // ── Ad config — kills ad decision pipeline before FreeWheel is contacted
-        "vac.peacocktv.com",
-        "sas.peacocktv.com",
+        // ── Ad config — Peacock's own ad-decision hosts (sas/vac.peacocktv.com
+        // and their regional shards sas.f / sas.a / vac.<region>) are handled by
+        // isPeacockAdDecisionHost() rather than listed here, since a flat
+        // substring misses the shards and the peacocktv.com safe-list would then
+        // allow them through.
 
         // ── FreeWheel CSAI
         "fwmrm.net",
@@ -76,6 +79,11 @@ public class PeacockWebViewHelper {
         "rlcdn.com",
         "nbcuas.com",
         "mparticle.com",
+        // Added after AGH log analysis — confirmed contacted but previously
+        // unblocked at the WebView layer:
+        "flashtalking.com",
+        "researchnow.com",
+        "firebaselogging.googleapis.com", // full host only — must not catch play*.googleapis.com
 
         // ── Ad creative delivery — serves the actual ad asset, not a beacon
         "2mdn.net",
@@ -130,6 +138,18 @@ public class PeacockWebViewHelper {
         );
     }
 
+    /**
+     * Matches Peacock's own ad-decision services across all regional shards:
+     * sas.peacocktv.com, sas.&lt;region&gt;.peacocktv.com (Streaming Ad Service),
+     * vac.peacocktv.com, vac.&lt;region&gt;.peacocktv.com (Video Ad Config).
+     * Matching the leftmost host label catches every shard while leaving content
+     * subdomains (play.clients/atom/imageservice.peacocktv.com) untouched.
+     */
+    private static boolean isPeacockAdDecisionHost(String host) {
+        if (host == null || !host.endsWith("peacocktv.com")) return false;
+        return host.startsWith("sas.") || host.startsWith("vac.");
+    }
+
     private static boolean isAnalyticsHost(String url) {
         return url.contains("scorecardresearch.com")
             || url.contains("imrworldwide.com")
@@ -138,10 +158,18 @@ public class PeacockWebViewHelper {
             || url.contains("doubleverify.com")
             || url.contains("adsafeprotected.com")
             || url.contains("placed.com")
-            || url.contains("mparticle.com");
+            || url.contains("mparticle.com")
+            || url.contains("flashtalking.com")
+            || url.contains("researchnow.com")
+            || url.contains("firebaselogging.googleapis.com");
     }
 
     private static boolean shouldBlock(String url) {
+        // Peacock ad-decision shards (sas/vac.<region>.peacocktv.com) — checked
+        // before everything, since the SAFE_HOSTS "peacocktv.com" entry below
+        // would otherwise allow them through.
+        if (isPeacockAdDecisionHost(Uri.parse(url).getHost())) return true;
+
         // Ad hosts are checked FIRST. SAFE_HOSTS below uses broad substring
         // matching ("nbcuni.com", "peacocktv.com") that would otherwise
         // shadow ad hosts living under those same parent domains.

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/Fingerprints.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/Fingerprints.kt
@@ -203,6 +203,26 @@ internal object NativeNetworkApiConstructorFingerprint : Fingerprint(
     },
 )
 
+// ── Layer 11 ─────────────────────────────────────────────────────────────────
+// Target: the CVSDK init lambda (an R8 synthetic, currently class `p0`) that
+// builds the Sky Player SDK's ROOT OkHttpClient and passes it into both
+// Configuration and InitializedCoreSdk. That root is a fresh `new OkHttpClient()`
+// carrying only the SDK's own OkHttpWorkaroundInterceptor — it is neither the
+// app's NetworkingKt client (Layer 6) nor the addon NativeNetworkApi client
+// (Layer 9). Every media/manifest fetch (Comcast Helio's PlayerComponentProvider
+// → media3 OkHttpDataSource) and the SDK's DI-provided clients are derived from
+// this root via OkHttpClient.newBuilder(), which COPIES interceptors — so
+// injecting AdBlockInterceptor here propagates across the entire SDK network
+// graph from a single point.
+//
+// Anchor: the log string "initializing CVSDK", confirmed unique to this method
+// across the whole APK. A string anchor is essential because the holder class is
+// renamed to a single-letter synthetic (`p0`) that drifts between builds.
+// Confirmed unique + matching v7.6.100 via direct smali inspection.
+internal object SdkRootOkHttpClientFingerprint : Fingerprint(
+    strings = listOf("initializing CVSDK"),
+)
+
 // ── Layer 10 ─────────────────────────────────────────────────────────────────
 // Target: NewRelicManager.e(Context) — the app's New Relic init wrapper,
 // which launches a coroutine (initialiseNewRelic) that calls

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/SkipAdsPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/SkipAdsPatch.kt
@@ -14,10 +14,10 @@ import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 val skipAdsPatch = bytecodePatch(
     name = "Skip ads",
     description = "Disables ad delivery via Sky SDK surgical targets (FreeWheel DI module " +
-        "skip, MediaTailor SSAI layers, ad-break-started no-op), dual OkHttp interceptor " +
-        "wiring (app's main client and the Sky SDK addon network client), New Relic agent " +
-        "init no-op, and WebView shouldInterceptRequest wrapper. Validated v7.5.102 and " +
-        "v7.6.100.",
+        "skip, MediaTailor SSAI layers, ad-break-started no-op), AdBlockInterceptor wiring " +
+        "across all three OkHttp surfaces (app NetworkingKt client, Sky SDK addon network " +
+        "client, and the SDK root/media client), New Relic agent init no-op, and WebView " +
+        "shouldInterceptRequest wrapper. Validated v7.5.102 and v7.6.100.",
 ) {
     compatibleWith(Constants.COMPATIBILITY)
 
@@ -65,6 +65,44 @@ val skipAdsPatch = bytecodePatch(
                     move-result-object $registerName
                 """.trimIndent(),
             )
+        }
+
+        // Finds the single okhttp3.OkHttpClient$Builder.build() call in the
+        // matched method and injects PeacockAdPatchHelper.addAdBlockInterceptor()
+        // immediately before it, reusing the builder's own register. Used for
+        // every OkHttpClient that is *constructed* (rather than body-replaced
+        // like Layer 6's getOkHttpClient): the Sky SDK addon client (Layer 9)
+        // and the SDK root client (Layer 11). Locating the build() and its
+        // register dynamically — rather than via a fixed offset — keeps this
+        // stable across register-allocation and field-layout drift between
+        // versions, the same resilience rationale as wrapXtvClientSetter above.
+        fun injectAdBlockBeforeOkHttpBuild(fingerprint: Fingerprint) {
+            fingerprint.method.apply {
+                val instructions = implementation!!.instructions
+                val buildIndex = instructions.indexOfFirst { instruction ->
+                    instruction.opcode == Opcode.INVOKE_VIRTUAL &&
+                        ((instruction as ReferenceInstruction).reference as? MethodReference)?.let { ref ->
+                            ref.name == "build" && ref.definingClass == "Lokhttp3/OkHttpClient\$Builder;"
+                        } == true
+                }
+                val builderRegister = (instructions[buildIndex] as FiveRegisterInstruction).registerC
+                val totalRegisters = implementation!!.registerCount
+                val paramRegisters = parameters.size + 1 // +1 for implicit `this` (p0)
+                val firstParamRegister = totalRegisters - paramRegisters
+                val registerName = if (builderRegister >= firstParamRegister) {
+                    "p${builderRegister - firstParamRegister}"
+                } else {
+                    "v$builderRegister"
+                }
+
+                addInstructions(
+                    buildIndex,
+                    """
+                        invoke-static {$registerName}, Lajstrick81/morphe/extension/peacock/ads/PeacockAdPatchHelper;->addAdBlockInterceptor(Lokhttp3/OkHttpClient${'$'}Builder;)Lokhttp3/OkHttpClient${'$'}Builder;
+                        move-result-object $registerName
+                    """.trimIndent(),
+                )
+            }
         }
 
         // ── Layer 1 ─────────────────────────────────────────────────────────
@@ -201,40 +239,21 @@ val skipAdsPatch = bytecodePatch(
 
         // ── Layer 9 ─────────────────────────────────────────────────────────
         // NativeNetworkApi.<init> derives its own child OkHttpClient via
-        // newBuilder()/build() — a client Layer 6 never touches. Locate the
-        // OkHttpClient$Builder.build() call dynamically (same approach as
-        // wrapXtvClientSetter) and inject a call to
-        // PeacockAdPatchHelper.addAdBlockInterceptor(builder) immediately
-        // before it, reassigning the same register the builder already
-        // lives in. No extra temp register is needed since the helper takes
-        // and returns the Builder directly — same pattern as Layer 6's
-        // buildOkHttpClient() body replacement.
-        NativeNetworkApiConstructorFingerprint.method.apply {
-            val instructions = implementation!!.instructions
-            val buildIndex = instructions.indexOfFirst { instruction ->
-                instruction.opcode == Opcode.INVOKE_VIRTUAL &&
-                    ((instruction as ReferenceInstruction).reference as? MethodReference)?.let { ref ->
-                        ref.name == "build" && ref.definingClass == "Lokhttp3/OkHttpClient\$Builder;"
-                    } == true
-            }
-            val builderRegister = (instructions[buildIndex] as FiveRegisterInstruction).registerC
-            val totalRegisters = implementation!!.registerCount
-            val paramRegisters = parameters.size + 1 // +1 for implicit `this` (p0)
-            val firstParamRegister = totalRegisters - paramRegisters
-            val registerName = if (builderRegister >= firstParamRegister) {
-                "p${builderRegister - firstParamRegister}"
-            } else {
-                "v$builderRegister"
-            }
+        // newBuilder()/build() — the Sky SDK addon network path (FreeWheel ad
+        // decisioning, Conviva/Comscore/Nielsen measurement, MediaTailor
+        // telemetry) that Layer 6 never touches. Add AdBlockInterceptor to it.
+        injectAdBlockBeforeOkHttpBuild(NativeNetworkApiConstructorFingerprint)
 
-            addInstructions(
-                buildIndex,
-                """
-                    invoke-static {$registerName}, Lajstrick81/morphe/extension/peacock/ads/PeacockAdPatchHelper;->addAdBlockInterceptor(Lokhttp3/OkHttpClient${'$'}Builder;)Lokhttp3/OkHttpClient${'$'}Builder;
-                    move-result-object $registerName
-                """.trimIndent(),
-            )
-        }
+        // ── Layer 11 ────────────────────────────────────────────────────────
+        // The CVSDK init lambda builds the Sky SDK's ROOT OkHttpClient (fresh
+        // `new OkHttpClient()` + the SDK's own OkHttpWorkaroundInterceptor) and
+        // feeds it to Configuration/InitializedCoreSdk. The media DataSource
+        // client (Comcast Helio → media3 OkHttpDataSource) and the SDK's
+        // DI-provided clients are all derived from this root via newBuilder(),
+        // which copies interceptors — so adding AdBlockInterceptor here closes
+        // the media/manifest fetch path (the last OkHttp surface neither Layer 6
+        // nor Layer 9 reached) from a single injection point.
+        injectAdBlockBeforeOkHttpBuild(SdkRootOkHttpClientFingerprint)
 
         // ── Layer 10 ────────────────────────────────────────────────────────
         // No-op NewRelicManager.e(Context) so the agent never starts —


### PR DESCRIPTION
## Summary

Follow-up to #26. Closes the remaining gaps that kept DNS filtering necessary, found by tracing **every** OkHttp surface in the app + Sky SDK and re-auditing the domain lists against a live AdGuard Home query log. Goal: replicate DNS-level suppression while preserving playback.

### Layer 11 — SDK root / media client (the last uncovered OkHttp surface)
ExoPlayer media + manifest fetches run through media3's `OkHttpDataSource` (Comcast Helio's `PlayerComponentProvider`). I traced its client back through several `newBuilder()` copies to the Sky SDK's **root** `OkHttpClient` — a fresh `new OkHttpClient()` built in the CVSDK init lambda (R8 synthetic `p0`), carrying only the SDK's own `OkHttpWorkaroundInterceptor`. It is reached by **neither** Layer 6 (`NetworkingKt`) **nor** Layer 9 (`NativeNetworkApi`).

Layer 11 injects `AdBlockInterceptor` at that root. Because `newBuilder()` copies interceptors, one injection propagates to the media client **and** the SDK's DI-provided clients. Anchored on the unique `"initializing CVSDK"` string (resilient to the class-name obfuscation that renames the holder to `p0`). Layer 9's `build()`-finder is refactored into a shared `injectAdBlockBeforeOkHttpBuild()` helper used by both.

### SAS/VAC regional-shard matching (an active leak, not just a missing client)
This is likely *why* DNS was still needed. Peacock's own ad-decision services ship from regional shards — `sas.f.peacocktv.com`, `sas.a.peacocktv.com`, `vac.<region>.peacocktv.com` (SAS = Streaming Ad Service, VAC = Video Ad Config) — that the flat `sas.peacocktv.com` substring **never matched**, and which the `peacocktv.com` safe-list then **allowed through** on every client, including ones we already intercept. Replaced the literals with `isPeacockAdDecisionHost()`, matching the leftmost host label so all shards are caught while content subdomains (`play.clients`/`atom`/`imageservice`) are untouched.

Killing the ad *decision* call is the highest-value cut: with no ad schedule returned, the downstream cascade of (often algorithmically named, unpredictable) ad-creative and measurement domains is never generated — which is how this replicates DNS coverage without hardcoding an infinite list.

### Domain additions (confirmed in the AGH log, previously unblocked)
`flashtalking.com`, `researchnow.com`, `firebaselogging.googleapis.com` (full host only — `play*.googleapis.com` is unaffected).

## Coverage after this PR
| Surface | Layer | Status |
|---|---|---|
| App API (`NetworkingKt`) | 6 | ✅ |
| Sky SDK addon (ad-config/FreeWheel/measurement) | 9 | ✅ |
| SDK root → media/manifest + DI clients | **11** | ✅ |
| WebView (Chromium ad traffic) | 7 | ✅ |
| New Relic (non-OkHttp) | 10 | ✅ killed |
| Thumbnail/connectivity client (`s5`) | — | n/a (no ad traffic) |

Remaining theoretical residual: true SSAI ads stitched into the content manifest by the server (unblockable client-side by design; addressed upstream by Layers 1/3/4/8).

## Verification
All anchors confirmed against disassembled **v7.6.100**. SAS/VAC matcher and the build()-finder register logic hand-traced against the real smali.

⚠️ Not build-verified locally (no GitHub Packages credentials in sandbox) — this PR is for CI to compile.

## Test plan
- [ ] CI build passes
- [ ] **DNS filtering disabled**, packet capture shows no requests to `sas.*.peacocktv.com` / `fwmrm.net` / measurement domains
- [ ] Playback clean on VOD **and** live; no stalls at would-be ad breaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01492m4Nok9muG2dEab8ihhc)_