### PR TITLE
fix(peacock): revert Layer 11 + SAS/VAC matcher that broke playback on v7.5.100 (#29)

### DIFF
--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/peacock/ads/AdBlockInterceptor.java
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/peacock/ads/AdBlockInterceptor.java
@@ -81,16 +81,17 @@ public class AdBlockInterceptor implements Interceptor {
 
     // Analytics and ad decision endpoints reachable via OkHttp.
     //
-    // Peacock's own ad-decision hosts (sas/vac.peacocktv.com) are intentionally
-    // NOT listed here as flat strings — they ship from regional shards like
-    // sas.f.peacocktv.com / sas.a.peacocktv.com that a "sas.peacocktv.com"
-    // substring never matches (and which would then fall through to the
-    // peacocktv.com safe path). They're handled by isPeacockAdDecisionHost()
-    // below, which matches every shard by leftmost label.
+    // sas.peacocktv.com (Streaming Ad Service) / vac.peacocktv.com (Video Ad
+    // Config) are matched here as flat substrings — the proven form shipped
+    // through the 1.4.x line. A structural leftmost-label matcher was tried in
+    // v1.5.3 to also catch regional shards (sas.f / sas.a) but was reverted
+    // after it regressed core screen loading on v7.5.100 (issue #29).
     private static final String[] ANALYTICS_DOMAINS = {
         "fwmrm.net",
         "video-ads-module.ad-tech.nbcuni.com",
         "mediatailor.",
+        "sas.peacocktv.com",
+        "vac.peacocktv.com",
         "scorecardresearch.com",
         "conviva.com",
         "imrworldwide.com",
@@ -112,30 +113,9 @@ public class AdBlockInterceptor implements Interceptor {
         "firebaselogging.googleapis.com", // full host only — must not catch play*.googleapis.com
     };
 
-    /**
-     * Matches Peacock's own ad-decision services across all regional shards:
-     * sas.peacocktv.com, sas.&lt;region&gt;.peacocktv.com (SAS = Streaming Ad
-     * Service), vac.peacocktv.com, vac.&lt;region&gt;.peacocktv.com (Video Ad
-     * Config). Matching the leftmost host label rather than a fixed substring
-     * catches every shard while leaving content subdomains
-     * (play.clients/atom/imageservice.peacocktv.com) untouched.
-     *
-     * Blocking the ad DECISION call is the highest-value cut: with no ad
-     * schedule returned, the downstream cascade of (often algorithmically named)
-     * ad-creative and measurement domains is never generated in the first place.
-     */
-    static boolean isPeacockAdDecisionHost(final String host) {
-        if (!host.endsWith("peacocktv.com")) return false;
-        return host.startsWith("sas.") || host.startsWith("vac.");
-    }
-
     @Override
     public Response intercept(Chain chain) throws IOException {
         final String host = chain.request().url().host();
-
-        if (isPeacockAdDecisionHost(host)) {
-            return randomAnalyticsResponse(chain);
-        }
 
         for (final String suffix : AD_CDN_SUFFIXES) {
             if (host.endsWith(suffix)) {

--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/peacock/ads/PeacockWebViewHelper.java
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/peacock/ads/PeacockWebViewHelper.java
@@ -1,6 +1,5 @@
 package ajstrick81.morphe.extension.peacock.ads;
 
-import android.net.Uri;
 import android.util.Log;
 import android.webkit.ClientCertRequest;
 import android.webkit.WebResourceRequest;
@@ -52,11 +51,13 @@ public class PeacockWebViewHelper {
     };
 
     private static final String[] AD_HOSTS = {
-        // ── Ad config — Peacock's own ad-decision hosts (sas/vac.peacocktv.com
-        // and their regional shards sas.f / sas.a / vac.<region>) are handled by
-        // isPeacockAdDecisionHost() rather than listed here, since a flat
-        // substring misses the shards and the peacocktv.com safe-list would then
-        // allow them through.
+        // ── Ad config — Peacock's own ad-decision hosts. Flat substrings (the
+        // proven 1.4.x form). A structural leftmost-label matcher was tried in
+        // v1.5.3 to also catch regional shards but was reverted after it
+        // regressed core screen loading on v7.5.100 (issue #29). These are
+        // listed BEFORE the SAFE_HOSTS "peacocktv.com" entry is consulted.
+        "sas.peacocktv.com",
+        "vac.peacocktv.com",
 
         // ── FreeWheel CSAI
         "fwmrm.net",
@@ -138,18 +139,6 @@ public class PeacockWebViewHelper {
         );
     }
 
-    /**
-     * Matches Peacock's own ad-decision services across all regional shards:
-     * sas.peacocktv.com, sas.&lt;region&gt;.peacocktv.com (Streaming Ad Service),
-     * vac.peacocktv.com, vac.&lt;region&gt;.peacocktv.com (Video Ad Config).
-     * Matching the leftmost host label catches every shard while leaving content
-     * subdomains (play.clients/atom/imageservice.peacocktv.com) untouched.
-     */
-    private static boolean isPeacockAdDecisionHost(String host) {
-        if (host == null || !host.endsWith("peacocktv.com")) return false;
-        return host.startsWith("sas.") || host.startsWith("vac.");
-    }
-
     private static boolean isAnalyticsHost(String url) {
         return url.contains("scorecardresearch.com")
             || url.contains("imrworldwide.com")
@@ -165,11 +154,6 @@ public class PeacockWebViewHelper {
     }
 
     private static boolean shouldBlock(String url) {
-        // Peacock ad-decision shards (sas/vac.<region>.peacocktv.com) — checked
-        // before everything, since the SAFE_HOSTS "peacocktv.com" entry below
-        // would otherwise allow them through.
-        if (isPeacockAdDecisionHost(Uri.parse(url).getHost())) return true;
-
         // Ad hosts are checked FIRST. SAFE_HOSTS below uses broad substring
         // matching ("nbcuni.com", "peacocktv.com") that would otherwise
         // shadow ad hosts living under those same parent domains.

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/Fingerprints.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/Fingerprints.kt
@@ -203,26 +203,6 @@ internal object NativeNetworkApiConstructorFingerprint : Fingerprint(
     },
 )
 
-// ── Layer 11 ─────────────────────────────────────────────────────────────────
-// Target: the CVSDK init lambda (an R8 synthetic, currently class `p0`) that
-// builds the Sky Player SDK's ROOT OkHttpClient and passes it into both
-// Configuration and InitializedCoreSdk. That root is a fresh `new OkHttpClient()`
-// carrying only the SDK's own OkHttpWorkaroundInterceptor — it is neither the
-// app's NetworkingKt client (Layer 6) nor the addon NativeNetworkApi client
-// (Layer 9). Every media/manifest fetch (Comcast Helio's PlayerComponentProvider
-// → media3 OkHttpDataSource) and the SDK's DI-provided clients are derived from
-// this root via OkHttpClient.newBuilder(), which COPIES interceptors — so
-// injecting AdBlockInterceptor here propagates across the entire SDK network
-// graph from a single point.
-//
-// Anchor: the log string "initializing CVSDK", confirmed unique to this method
-// across the whole APK. A string anchor is essential because the holder class is
-// renamed to a single-letter synthetic (`p0`) that drifts between builds.
-// Confirmed unique + matching v7.6.100 via direct smali inspection.
-internal object SdkRootOkHttpClientFingerprint : Fingerprint(
-    strings = listOf("initializing CVSDK"),
-)
-
 // ── Layer 10 ─────────────────────────────────────────────────────────────────
 // Target: NewRelicManager.e(Context) — the app's New Relic init wrapper,
 // which launches a coroutine (initialiseNewRelic) that calls

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/SkipAdsPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/SkipAdsPatch.kt
@@ -15,9 +15,9 @@ val skipAdsPatch = bytecodePatch(
     name = "Skip ads",
     description = "Disables ad delivery via Sky SDK surgical targets (FreeWheel DI module " +
         "skip, MediaTailor SSAI layers, ad-break-started no-op), AdBlockInterceptor wiring " +
-        "across all three OkHttp surfaces (app NetworkingKt client, Sky SDK addon network " +
-        "client, and the SDK root/media client), New Relic agent init no-op, and WebView " +
-        "shouldInterceptRequest wrapper. Validated v7.5.102 and v7.6.100.",
+        "across the app NetworkingKt client and the Sky SDK addon network client, New Relic " +
+        "agent init no-op, and WebView shouldInterceptRequest wrapper. " +
+        "Validated v7.5.102 and v7.6.100.",
 ) {
     compatibleWith(Constants.COMPATIBILITY)
 
@@ -70,12 +70,12 @@ val skipAdsPatch = bytecodePatch(
         // Finds the single okhttp3.OkHttpClient$Builder.build() call in the
         // matched method and injects PeacockAdPatchHelper.addAdBlockInterceptor()
         // immediately before it, reusing the builder's own register. Used for
-        // every OkHttpClient that is *constructed* (rather than body-replaced
-        // like Layer 6's getOkHttpClient): the Sky SDK addon client (Layer 9)
-        // and the SDK root client (Layer 11). Locating the build() and its
-        // register dynamically — rather than via a fixed offset — keeps this
-        // stable across register-allocation and field-layout drift between
-        // versions, the same resilience rationale as wrapXtvClientSetter above.
+        // the Sky SDK addon client (Layer 9), which is *constructed* via
+        // newBuilder()/build() rather than body-replaced like Layer 6's
+        // getOkHttpClient(). Locating the build() and its register dynamically —
+        // rather than via a fixed offset — keeps this stable across
+        // register-allocation and field-layout drift between versions, the same
+        // resilience rationale as wrapXtvClientSetter above.
         fun injectAdBlockBeforeOkHttpBuild(fingerprint: Fingerprint) {
             fingerprint.method.apply {
                 val instructions = implementation!!.instructions
@@ -243,17 +243,6 @@ val skipAdsPatch = bytecodePatch(
         // decisioning, Conviva/Comscore/Nielsen measurement, MediaTailor
         // telemetry) that Layer 6 never touches. Add AdBlockInterceptor to it.
         injectAdBlockBeforeOkHttpBuild(NativeNetworkApiConstructorFingerprint)
-
-        // ── Layer 11 ────────────────────────────────────────────────────────
-        // The CVSDK init lambda builds the Sky SDK's ROOT OkHttpClient (fresh
-        // `new OkHttpClient()` + the SDK's own OkHttpWorkaroundInterceptor) and
-        // feeds it to Configuration/InitializedCoreSdk. The media DataSource
-        // client (Comcast Helio → media3 OkHttpDataSource) and the SDK's
-        // DI-provided clients are all derived from this root via newBuilder(),
-        // which copies interceptors — so adding AdBlockInterceptor here closes
-        // the media/manifest fetch path (the last OkHttp surface neither Layer 6
-        // nor Layer 9 reached) from a single injection point.
-        injectAdBlockBeforeOkHttpBuild(SdkRootOkHttpClientFingerprint)
 
         // ── Layer 10 ────────────────────────────────────────────────────────
         // No-op NewRelicManager.e(Context) so the agent never starts —


### PR DESCRIPTION
## Problem

Issue #29: v1.5.3 makes Peacock virtually unusable on **v7.5.100** (Google TV Streamer) — screens barely load, app crashes, **independent of DNS filtering**. The maintainer has already told the reporter to roll back.

## Root cause

v1.5.3 (PR #27) shipped two aggressive changes that were only ever validated against a **v7.6.100** disassembly — but the reporter is on **v7.5.100**, a version never inspected and not in the compatibility list:

1. **Layer 11** injected `AdBlockInterceptor` into the CVSDK init lambda (the Sky Player SDK's *root* OkHttpClient), anchored solely by the `"initializing CVSDK"` string. Re-checking the 7.6.100 disassembly confirms it injected *cleanly there* (exactly one `OkHttpClient$Builder.build()`, local register v7) — which proves the logic was keyed to one version's bytecode shape. On 7.5.100 the method's register layout / `build()` count almost certainly differs, so the dynamic finder + register math misfired and corrupted SDK init → "barely loads / crashes / DNS-independent." It also routed the interceptor onto the core media/API client.

2. **SAS/VAC structural matcher** (`host.startsWith("sas."/"vac.") && endsWith("peacocktv.com")`) replaced the proven 1.4.x flat-substring entries, risking 503'ing legitimate core hosts.

## Fix

Revert both to the last-known-good **v1.5.2 surface** (Layers 1–10, flat `sas/vac.peacocktv.com` entries). Kept the harmless specific ad/analytics domains added alongside (`flashtalking`, `researchnow`, `firebaselogging`). Verified on the 7.6.100 disassembly that the kept **Layer 9** injection (now the only user of the shared `injectAdBlockBeforeOkHttpBuild` helper) is sound: single `build()`, register p1 resolves correctly.

Layer 11 should be re-attempted only after a proper v7.5.100 disassembly confirms the fingerprint/injection or a version guard is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01492m4Nok9muG2dEab8ihhc

---
_Generated by [Claude Code](https://claude.ai/code/session_01492m4Nok9muG2dEab8ihhc)_