### PR TITLE
fix(peacock): roll back to known-good Layers 1-8; remove launch-breaking Layers 9-10

### DIFF
--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/Fingerprints.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/Fingerprints.kt
@@ -179,43 +179,8 @@ internal object FreewheelModuleSkipFingerprint : Fingerprint(
     },
 )
 
-// ── Layer 9 ──────────────────────────────────────────────────────────────────
-// Target: NativeNetworkApi.<init>(DeviceContext, OkHttpClient)
-//
-// The Sky Core Player SDK's addon network stack (FreeWheel ad decisioning,
-// Conviva/Comscore/Nielsen measurement — delivered dynamically via the
-// ad-config response rather than hardcoded, so no literal domain strings for
-// them exist anywhere in the dex) is entirely independent from the app's
-// main NetworkingKt.getOkHttpClient() client that Layer 6 patches. This
-// constructor derives its own child OkHttpClient via newBuilder()/build()
-// and was the unfiltered gap: AdGuard Home DNS logs showed sas.peacocktv.com
-// and fwmrm.net still being requested with the patched APK installed, even
-// though both hostnames were already in AdBlockInterceptor's lists — the
-// interceptor just wasn't wired into this client.
-// Confirmed matching v7.6.100 via direct smali inspection.
-internal object NativeNetworkApiConstructorFingerprint : Fingerprint(
-    custom = { method, classDef ->
-        method.name == "<init>" &&
-            method.parameters.size == 2 &&
-            method.parameters[0].type == "Lcom/sky/core/player/addon/common/DeviceContext;" &&
-            method.parameters[1].type == "Lokhttp3/OkHttpClient;" &&
-            classDef.type == "Lcom/sky/core/player/sdk/addon/networkLayer/NativeNetworkApi;"
-    },
-)
-
-// ── Layer 10 ─────────────────────────────────────────────────────────────────
-// Target: NewRelicManager.e(Context) — the app's New Relic init wrapper,
-// which launches a coroutine (initialiseNewRelic) that calls
-// NewRelic.withApplicationToken(...).start(context). New Relic's mobile
-// agent harvester uses its own HTTP path, not OkHttp, so no interceptor can
-// ever catch mobile-collector.newrelic.com / nr-data.net traffic — the only
-// way to stop it from the patch side is to prevent the agent from starting.
-// Anchor: only method in NewRelicManager taking a single Context parameter.
-// Confirmed matching v7.6.100 via direct smali inspection.
-internal object NewRelicInitFingerprint : Fingerprint(
-    returnType = "V",
-    parameters = listOf("Landroid/content/Context;"),
-    custom = { method, classDef ->
-        classDef.type == "Lcom/peacock/peacocktv/analytics/NewRelicManager;"
-    },
-)
+// NOTE: NativeNetworkApiConstructorFingerprint (Layer 9) and
+// NewRelicInitFingerprint (Layer 10) were removed in v1.5.5 — see the rollback
+// note in SkipAdsPatch.kt. They are intentionally not re-added until their
+// injections can be device-verified, since they broke app launch on the
+// fully-validated v7.6.100 target despite matching cleanly.

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/SkipAdsPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/SkipAdsPatch.kt
@@ -15,9 +15,8 @@ val skipAdsPatch = bytecodePatch(
     name = "Skip ads",
     description = "Disables ad delivery via Sky SDK surgical targets (FreeWheel DI module " +
         "skip, MediaTailor SSAI layers, ad-break-started no-op), AdBlockInterceptor wiring " +
-        "across the app NetworkingKt client and the Sky SDK addon network client, New Relic " +
-        "agent init no-op, and WebView shouldInterceptRequest wrapper. " +
-        "Validated v7.5.102 and v7.6.100.",
+        "on the app NetworkingKt OkHttp client, and a WebView shouldInterceptRequest wrapper. " +
+        "Pair with DNS filtering for full ad suppression. Validated v7.5.102 and v7.6.100.",
 ) {
     compatibleWith(Constants.COMPATIBILITY)
 
@@ -65,44 +64,6 @@ val skipAdsPatch = bytecodePatch(
                     move-result-object $registerName
                 """.trimIndent(),
             )
-        }
-
-        // Finds the single okhttp3.OkHttpClient$Builder.build() call in the
-        // matched method and injects PeacockAdPatchHelper.addAdBlockInterceptor()
-        // immediately before it, reusing the builder's own register. Used for
-        // the Sky SDK addon client (Layer 9), which is *constructed* via
-        // newBuilder()/build() rather than body-replaced like Layer 6's
-        // getOkHttpClient(). Locating the build() and its register dynamically —
-        // rather than via a fixed offset — keeps this stable across
-        // register-allocation and field-layout drift between versions, the same
-        // resilience rationale as wrapXtvClientSetter above.
-        fun injectAdBlockBeforeOkHttpBuild(fingerprint: Fingerprint) {
-            fingerprint.method.apply {
-                val instructions = implementation!!.instructions
-                val buildIndex = instructions.indexOfFirst { instruction ->
-                    instruction.opcode == Opcode.INVOKE_VIRTUAL &&
-                        ((instruction as ReferenceInstruction).reference as? MethodReference)?.let { ref ->
-                            ref.name == "build" && ref.definingClass == "Lokhttp3/OkHttpClient\$Builder;"
-                        } == true
-                }
-                val builderRegister = (instructions[buildIndex] as FiveRegisterInstruction).registerC
-                val totalRegisters = implementation!!.registerCount
-                val paramRegisters = parameters.size + 1 // +1 for implicit `this` (p0)
-                val firstParamRegister = totalRegisters - paramRegisters
-                val registerName = if (builderRegister >= firstParamRegister) {
-                    "p${builderRegister - firstParamRegister}"
-                } else {
-                    "v$builderRegister"
-                }
-
-                addInstructions(
-                    buildIndex,
-                    """
-                        invoke-static {$registerName}, Lajstrick81/morphe/extension/peacock/ads/PeacockAdPatchHelper;->addAdBlockInterceptor(Lokhttp3/OkHttpClient${'$'}Builder;)Lokhttp3/OkHttpClient${'$'}Builder;
-                        move-result-object $registerName
-                    """.trimIndent(),
-                )
-            }
         }
 
         // ── Layer 1 ─────────────────────────────────────────────────────────
@@ -237,22 +198,16 @@ val skipAdsPatch = bytecodePatch(
             removeInstruction(16) // import$default(...) — now shifted to 16
         }
 
-        // ── Layer 9 ─────────────────────────────────────────────────────────
-        // NativeNetworkApi.<init> derives its own child OkHttpClient via
-        // newBuilder()/build() — the Sky SDK addon network path (FreeWheel ad
-        // decisioning, Conviva/Comscore/Nielsen measurement, MediaTailor
-        // telemetry) that Layer 6 never touches. Add AdBlockInterceptor to it.
-        injectAdBlockBeforeOkHttpBuild(NativeNetworkApiConstructorFingerprint)
-
-        // ── Layer 10 ────────────────────────────────────────────────────────
-        // No-op NewRelicManager.e(Context) so the agent never starts —
-        // interceptors can't catch its harvester traffic since it doesn't
-        // go through OkHttp. Void return, offset 0 — always verifier-safe.
-        NewRelicInitFingerprint.method.addInstructions(
-            0,
-            """
-                return-void
-            """.trimIndent(),
-        )
+        // NOTE: Layers 9–11 (Sky SDK addon-client interceptor, New Relic init
+        // no-op, and SDK root-client interceptor) were removed in v1.5.5. That
+        // "DNS-independent suppression" push broke app launch — v1.5.3 on
+        // v7.5.100 (issue #29) and then v1.5.4 still failed with Peacock's
+        // "Something went wrong" screen on v7.6.100, the fully-validated target.
+        // CI only proves the patch applies, not that the app launches, so those
+        // layers shipped without on-device verification. The patch is rolled
+        // back to the last known-good Layers 1–8 surface (app launches and
+        // plays; ads partially suppressed, fully suppressed when paired with
+        // DNS filtering). Any future re-attempt of addon/SDK-client interception
+        // must be device-verified one layer at a time before release.
     }
 }


### PR DESCRIPTION
## Problem

v1.5.4 **still fails to launch** on Peacock **v7.6.100** — the fully-validated target — showing Peacock's *"Something went wrong"* error screen immediately (confirmed on-device by the maintainer).

## Root cause

v1.5.4 had already reverted Layer 11, so the remaining suspects were **Layers 9–10**, the "DNS-independent suppression" additions from v1.5.2:

- **Layer 9** wired `AdBlockInterceptor` into the Sky SDK addon network client (`NativeNetworkApi.<init>`).
- **Layer 10** no-op'd `NewRelicManager.e(Context)`.

Both matched cleanly and passed CI — but **CI is build-only**: it proves the patch *applies*, not that the app *launches*. Neither layer was ever device-verified. Together they broke SDK/app initialization on startup.

## Fix

Roll the Peacock patch back to the **last known-good Layers 1–8** surface (MediaTailor/SSAI kills, FreeWheel DI removal, app `NetworkingKt` OkHttp interceptor, WebView `shouldInterceptRequest` wrapper) — the state that launched and played, with ads partially suppressed and **fully suppressed when paired with DNS filtering**.

Removed:
- Layer 9 + Layer 10 injection blocks
- the now-unused `injectAdBlockBeforeOkHttpBuild` helper
- the `NativeNetworkApiConstructorFingerprint` / `NewRelicInitFingerprint` fingerprints

The inert `addAdBlockInterceptor` extension method and its keep rule are left in place (kept but uncalled) to avoid touching the extension build.

## Follow-up

Re-attempting addon/SDK-client interception requires **on-device launch verification, one layer at a time**, before any release. Build-green is necessary but not sufficient for this patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01492m4Nok9muG2dEab8ihhc

---
_Generated by [Claude Code](https://claude.ai/code/session_01492m4Nok9muG2dEab8ihhc)_