### PR TITLE
fix(peacock): fix Layer 7 VerifyError launch crash + re-add Layers 9-11

### DIFF
--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/peacock/ads/PeacockWebViewHelper.java
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/peacock/ads/PeacockWebViewHelper.java
@@ -177,7 +177,7 @@ public class PeacockWebViewHelper {
 
     public static WebViewClient wrapClient(final WebViewClient original) {
         Log.d(TAG, "PeacockWebViewHelper.wrapClient() — Layer 7 active (randomized responses)");
-        return new WebViewClient() {
+        WebViewClient wrapped = new WebViewClient() {
 
             @Override
             public WebResourceResponse shouldInterceptRequest(
@@ -246,5 +246,16 @@ public class PeacockWebViewHelper {
                 return original.onRenderProcessGone(view, detail);
             }
         };
+
+        // ART rejected a bare `return new WebViewClient() {...}` here with
+        // VerifyError: "[0xC] returning 'Precise Reference: <anon>', but
+        // expected ... 'Reference: android.webkit.WebViewClient'" — confirmed
+        // via on-device logcat on v7.6.100, 100% reproducible, fatal on every
+        // launch (this is what actually broke v1.5.2 through v1.5.5; Layers
+        // 9-11 were never the cause). The double cast through Object forces
+        // javac to emit a real checkcast instruction instead of eliding it,
+        // which satisfies the verifier when this extension's separately-dexed
+        // class is merged into the host APK via extendWith().
+        return (WebViewClient) (Object) wrapped;
     }
 }

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/Fingerprints.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/Fingerprints.kt
@@ -179,8 +179,63 @@ internal object FreewheelModuleSkipFingerprint : Fingerprint(
     },
 )
 
-// NOTE: NativeNetworkApiConstructorFingerprint (Layer 9) and
-// NewRelicInitFingerprint (Layer 10) were removed in v1.5.5 — see the rollback
-// note in SkipAdsPatch.kt. They are intentionally not re-added until their
-// injections can be device-verified, since they broke app launch on the
-// fully-validated v7.6.100 target despite matching cleanly.
+// ── Layer 9 ──────────────────────────────────────────────────────────────────
+// Target: NativeNetworkApi.<init>(DeviceContext, OkHttpClient)
+//
+// The Sky Core Player SDK's addon network stack (FreeWheel ad decisioning,
+// Conviva/Comscore/Nielsen measurement — delivered dynamically via the
+// ad-config response rather than hardcoded, so no literal domain strings for
+// them exist anywhere in the dex) is entirely independent from the app's
+// main NetworkingKt.getOkHttpClient() client that Layer 6 patches. This
+// constructor derives its own child OkHttpClient via newBuilder()/build()
+// and was the unfiltered gap: AdGuard Home DNS logs showed sas.peacocktv.com
+// and fwmrm.net still being requested with the patched APK installed, even
+// though both hostnames were already in AdBlockInterceptor's lists — the
+// interceptor just wasn't wired into this client.
+// Confirmed matching v7.6.100 via direct smali inspection.
+internal object NativeNetworkApiConstructorFingerprint : Fingerprint(
+    custom = { method, classDef ->
+        method.name == "<init>" &&
+            method.parameters.size == 2 &&
+            method.parameters[0].type == "Lcom/sky/core/player/addon/common/DeviceContext;" &&
+            method.parameters[1].type == "Lokhttp3/OkHttpClient;" &&
+            classDef.type == "Lcom/sky/core/player/sdk/addon/networkLayer/NativeNetworkApi;"
+    },
+)
+
+// ── Layer 11 ─────────────────────────────────────────────────────────────────
+// Target: the CVSDK init lambda (an R8 synthetic, currently class `p0`) that
+// builds the Sky Player SDK's ROOT OkHttpClient and passes it into both
+// Configuration and InitializedCoreSdk. That root is a fresh `new OkHttpClient()`
+// carrying only the SDK's own OkHttpWorkaroundInterceptor — it is neither the
+// app's NetworkingKt client (Layer 6) nor the addon NativeNetworkApi client
+// (Layer 9). Every media/manifest fetch (Comcast Helio's PlayerComponentProvider
+// → media3 OkHttpDataSource) and the SDK's DI-provided clients are derived from
+// this root via OkHttpClient.newBuilder(), which COPIES interceptors — so
+// injecting AdBlockInterceptor here propagates across the entire SDK network
+// graph from a single point.
+//
+// Anchor: the log string "initializing CVSDK", confirmed unique to this method
+// across the whole APK. A string anchor is essential because the holder class is
+// renamed to a single-letter synthetic (`p0`) that drifts between builds.
+// Confirmed unique + matching v7.6.100 via direct smali inspection.
+internal object SdkRootOkHttpClientFingerprint : Fingerprint(
+    strings = listOf("initializing CVSDK"),
+)
+
+// ── Layer 10 ─────────────────────────────────────────────────────────────────
+// Target: NewRelicManager.e(Context) — the app's New Relic init wrapper,
+// which launches a coroutine (initialiseNewRelic) that calls
+// NewRelic.withApplicationToken(...).start(context). New Relic's mobile
+// agent harvester uses its own HTTP path, not OkHttp, so no interceptor can
+// ever catch mobile-collector.newrelic.com / nr-data.net traffic — the only
+// way to stop it from the patch side is to prevent the agent from starting.
+// Anchor: only method in NewRelicManager taking a single Context parameter.
+// Confirmed matching v7.6.100 via direct smali inspection.
+internal object NewRelicInitFingerprint : Fingerprint(
+    returnType = "V",
+    parameters = listOf("Landroid/content/Context;"),
+    custom = { method, classDef ->
+        classDef.type == "Lcom/peacock/peacocktv/analytics/NewRelicManager;"
+    },
+)

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/SkipAdsPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/SkipAdsPatch.kt
@@ -15,8 +15,9 @@ val skipAdsPatch = bytecodePatch(
     name = "Skip ads",
     description = "Disables ad delivery via Sky SDK surgical targets (FreeWheel DI module " +
         "skip, MediaTailor SSAI layers, ad-break-started no-op), AdBlockInterceptor wiring " +
-        "on the app NetworkingKt OkHttp client, and a WebView shouldInterceptRequest wrapper. " +
-        "Pair with DNS filtering for full ad suppression. Validated v7.5.102 and v7.6.100.",
+        "across all three OkHttp surfaces (app NetworkingKt client, Sky SDK addon network " +
+        "client, and the SDK root/media client), New Relic agent init no-op, and a WebView " +
+        "shouldInterceptRequest wrapper. Validated v7.5.102 and v7.6.100.",
 ) {
     compatibleWith(Constants.COMPATIBILITY)
 
@@ -64,6 +65,44 @@ val skipAdsPatch = bytecodePatch(
                     move-result-object $registerName
                 """.trimIndent(),
             )
+        }
+
+        // Finds the single okhttp3.OkHttpClient$Builder.build() call in the
+        // matched method and injects PeacockAdPatchHelper.addAdBlockInterceptor()
+        // immediately before it, reusing the builder's own register. Used for
+        // every OkHttpClient that is *constructed* (rather than body-replaced
+        // like Layer 6's getOkHttpClient): the Sky SDK addon client (Layer 9)
+        // and the SDK root client (Layer 11). Locating the build() and its
+        // register dynamically — rather than via a fixed offset — keeps this
+        // stable across register-allocation and field-layout drift between
+        // versions, the same resilience rationale as wrapXtvClientSetter above.
+        fun injectAdBlockBeforeOkHttpBuild(fingerprint: Fingerprint) {
+            fingerprint.method.apply {
+                val instructions = implementation!!.instructions
+                val buildIndex = instructions.indexOfFirst { instruction ->
+                    instruction.opcode == Opcode.INVOKE_VIRTUAL &&
+                        ((instruction as ReferenceInstruction).reference as? MethodReference)?.let { ref ->
+                            ref.name == "build" && ref.definingClass == "Lokhttp3/OkHttpClient\$Builder;"
+                        } == true
+                }
+                val builderRegister = (instructions[buildIndex] as FiveRegisterInstruction).registerC
+                val totalRegisters = implementation!!.registerCount
+                val paramRegisters = parameters.size + 1 // +1 for implicit `this` (p0)
+                val firstParamRegister = totalRegisters - paramRegisters
+                val registerName = if (builderRegister >= firstParamRegister) {
+                    "p${builderRegister - firstParamRegister}"
+                } else {
+                    "v$builderRegister"
+                }
+
+                addInstructions(
+                    buildIndex,
+                    """
+                        invoke-static {$registerName}, Lajstrick81/morphe/extension/peacock/ads/PeacockAdPatchHelper;->addAdBlockInterceptor(Lokhttp3/OkHttpClient${'$'}Builder;)Lokhttp3/OkHttpClient${'$'}Builder;
+                        move-result-object $registerName
+                    """.trimIndent(),
+                )
+            }
         }
 
         // ── Layer 1 ─────────────────────────────────────────────────────────
@@ -198,16 +237,45 @@ val skipAdsPatch = bytecodePatch(
             removeInstruction(16) // import$default(...) — now shifted to 16
         }
 
-        // NOTE: Layers 9–11 (Sky SDK addon-client interceptor, New Relic init
-        // no-op, and SDK root-client interceptor) were removed in v1.5.5. That
-        // "DNS-independent suppression" push broke app launch — v1.5.3 on
-        // v7.5.100 (issue #29) and then v1.5.4 still failed with Peacock's
-        // "Something went wrong" screen on v7.6.100, the fully-validated target.
-        // CI only proves the patch applies, not that the app launches, so those
-        // layers shipped without on-device verification. The patch is rolled
-        // back to the last known-good Layers 1–8 surface (app launches and
-        // plays; ads partially suppressed, fully suppressed when paired with
-        // DNS filtering). Any future re-attempt of addon/SDK-client interception
-        // must be device-verified one layer at a time before release.
+        // ── Layers 9–11 re-added in v1.5.6 ──────────────────────────────────
+        // These were rolled back in v1.5.4/v1.5.5 on the belief that they broke
+        // app launch. On-device logcat (v7.6.100) later proved otherwise: the
+        // launch crash was a java.lang.VerifyError in PeacockWebViewHelper
+        // .wrapClient() (Layer 7), present since v1.4.105 — three releases
+        // before these layers existed — and it fires at setContentView, before
+        // the app ever reaches the Sky SDK / addon / New Relic init code these
+        // layers touch. With that VerifyError now fixed, Layers 9–11 are
+        // restored. They were never observed running in a launchable app, so
+        // they remain unverified for *correctness* on-device even though they
+        // are cleared of causing the launch crash.
+
+        // ── Layer 9 ─────────────────────────────────────────────────────────
+        // NativeNetworkApi.<init> derives its own child OkHttpClient via
+        // newBuilder()/build() — the Sky SDK addon network path (FreeWheel ad
+        // decisioning, Conviva/Comscore/Nielsen measurement, MediaTailor
+        // telemetry) that Layer 6 never touches. Add AdBlockInterceptor to it.
+        injectAdBlockBeforeOkHttpBuild(NativeNetworkApiConstructorFingerprint)
+
+        // ── Layer 11 ────────────────────────────────────────────────────────
+        // The CVSDK init lambda builds the Sky SDK's ROOT OkHttpClient (fresh
+        // `new OkHttpClient()` + the SDK's own OkHttpWorkaroundInterceptor) and
+        // feeds it to Configuration/InitializedCoreSdk. The media DataSource
+        // client (Comcast Helio → media3 OkHttpDataSource) and the SDK's
+        // DI-provided clients are all derived from this root via newBuilder(),
+        // which copies interceptors — so adding AdBlockInterceptor here closes
+        // the media/manifest fetch path (the last OkHttp surface neither Layer 6
+        // nor Layer 9 reached) from a single injection point.
+        injectAdBlockBeforeOkHttpBuild(SdkRootOkHttpClientFingerprint)
+
+        // ── Layer 10 ────────────────────────────────────────────────────────
+        // No-op NewRelicManager.e(Context) so the agent never starts —
+        // interceptors can't catch its harvester traffic since it doesn't
+        // go through OkHttp. Void return, offset 0 — always verifier-safe.
+        NewRelicInitFingerprint.method.addInstructions(
+            0,
+            """
+                return-void
+            """.trimIndent(),
+        )
     }
 }


### PR DESCRIPTION
## Root cause (from on-device logcat, v7.6.100)

The app-launch crash that drove the v1.5.4 and v1.5.5 rollbacks was **never Layers 9/10/11**. The logcat shows a 100%-reproducible `java.lang.VerifyError` in `PeacockWebViewHelper.wrapClient()` (Layer 7):

```
Caused by: java.lang.VerifyError: Verifier rejected class ...PeacockWebViewHelper:
... wrapClient(...) failed to verify: [0xC] returning 'Precise Reference: d',
but expected from declaration 'Reference: android.webkit.WebViewClient'
  at com.peacock.peacocktv.web.XTVWebView.<init>(...:204)
  at com.peacock.peacocktv.web.VirtualDpadXTVWebView.<init>(...:14)
```

ART rejects the bare `return new WebViewClient() {...}` because the verifier sees the precise anonymous-subclass type instead of the declared `WebViewClient` return type — a known gap when an extension class is dexed separately and merged in via `extendWith()` rather than compiled through the host app's own D8 pass.

This fires at `MainActivity.onCreate → setContentView → XTVWebView.<init>` — the very first thing the activity does, **before** the app ever reaches the Sky SDK / addon / New Relic init code. Git blame confirms the offending bytecode shipped in **v1.4.105** (the commit that began wrapping the 2-arg constructor the app actually inflates), three releases **before** Layers 9/10/11 existed. Those layers were convicted on circumstantial "newest untested change" evidence the logcat now overturns.

## Changes

1. **Layer 7 VerifyError fix** (`0e1969a`) — assign the anonymous client to a local and `return (WebViewClient) (Object) wrapped;`, forcing javac to emit a real `checkcast` instead of eliding it.
2. **Re-add Layers 9-11** (`f281409`) — restored bundled with the fix now that they're cleared of causing the crash:
   - Layer 9: `AdBlockInterceptor` on `NativeNetworkApi`'s addon OkHttp client
   - Layer 11: `AdBlockInterceptor` on the CVSDK root OkHttp client
   - Layer 10: no-op `NewRelicManager.e(Context)` so the agent never starts

   Injection logic is byte-identical to the v1.5.3 originals; the `addAdBlockInterceptor` helper and its ProGuard rule were never removed during rollback.

## Verification status

⚠️ CI proves only that the patch **applies and builds** — the same green light that waved v1.5.2–v1.5.5 through while the app was crash-on-launch. **The Layer 7 fix has not been built or launched on a device, and Layers 9/10/11 have never run in a launchable app**, so their correctness is unverified. This PR is intended to be **on-device verified from the branch build before merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01492m4Nok9muG2dEab8ihhc)_