### PR TITLE
fix(peacock): real fix for Layer 7 VerifyError (named class, not anonymous)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew clean :patches:buildAndroid generatePatchesList
+
+      # Upload the built patch bundle so dev/PR builds can be sideloaded into
+      # Morphe Manager and verified on-device BEFORE merging to main. CI only
+      # proves the patch compiles/applies — it cannot prove the app launches,
+      # so on-device verification of this artifact is the real release gate.
+      - name: Upload patch bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: patches
+          path: |
+            patches/build/libs/patches-*.mpp
+            patches/build/libs/patches-*.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - dev
 
 jobs:
   release:

--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/peacock/ads/AdBlockInterceptor.java
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/peacock/ads/AdBlockInterceptor.java
@@ -18,8 +18,9 @@ import java.util.Random;
  * in FreeWheel's fraud detection system.
  *
  * Response strategy (matches PeacockWebViewHelper):
- *   - Ad CDN hosts:   75% 503, 25% 204, with occasional 50–200ms delay
- *   - Analytics hosts: 50% 204, 50% 200, with occasional delay
+ *   - Ad CDN hosts:   75% 503, 25% 204
+ *   - Analytics hosts: 50% 204, 50% 200
+ * No artificial delay is added — see randomAdResponse() below for why.
  *
  * Why 503 for ad CDN (not 200):
  *   503 triggers ExoPlayer's error/skip logic rather than the media parser.
@@ -145,16 +146,21 @@ public class AdBlockInterceptor implements Interceptor {
     /**
      * Randomized response for ad video CDN requests.
      * Uses 503 as primary to trigger ExoPlayer's error/skip path.
-     * Mixes in 204 and occasional delays to avoid uniform blocking pattern.
+     * Mixes in 204 to avoid a uniform blocking pattern.
+     *
+     * No artificial delay here (unlike the status-code mix, which is the
+     * actual anti-fraud-detection signal): NetworkingKt.getOkHttpClient()
+     * builds a brand-new OkHttpClient — with its own Dispatcher thread pool —
+     * on every call, confirmed via decompilation. Stock app tolerates this
+     * because requests on those ephemeral clients finish fast and the threads
+     * get reaped quickly. A Thread.sleep() here held those ephemeral worker
+     * threads open longer, and on a memory-constrained Android TV box the
+     * ephemeral clients piled up faster than they could be reaped, causing a
+     * sustained Java-heap GC pressure climb to OOM within ~2.5 minutes of
+     * launch (issue #29 follow-up) — never observed in the unpatched app.
      */
     private static Response randomAdResponse(final Chain chain) {
         int roll = RANDOM.nextInt(100);
-
-        if (roll < 15) {
-            try { Thread.sleep(50 + RANDOM.nextInt(150)); }
-            catch (InterruptedException ignored) {}
-        }
-
         int code = (roll < 25) ? 204 : 503;
         String message = (code == 204) ? "No Content" : "Service Unavailable";
 
@@ -172,15 +178,11 @@ public class AdBlockInterceptor implements Interceptor {
      * Randomized response for analytics/beacon endpoints.
      * Uses 204 as primary — normal server behaviour for accepted beacons.
      * Looks like server-side suppression rather than client-side blocking.
+     *
+     * No artificial delay — see randomAdResponse() above.
      */
     private static Response randomAnalyticsResponse(final Chain chain) {
         int roll = RANDOM.nextInt(100);
-
-        if (roll < 15) {
-            try { Thread.sleep(50 + RANDOM.nextInt(150)); }
-            catch (InterruptedException ignored) {}
-        }
-
         int code = (roll < 50) ? 204 : 200;
         String message = (code == 204) ? "No Content" : "OK";
 

--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/peacock/ads/PeacockWebViewHelper.java
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/peacock/ads/PeacockWebViewHelper.java
@@ -21,9 +21,9 @@ import java.util.Random;
  * detection system, which flags devices that never complete ad views.
  *
  * Response variation:
- *   - 60% empty 200 OK (normal load, no content)
- *   - 25% 204 No Content (server acknowledged, nothing to send)
- *   - 15% random delay 50-200ms then 200 (simulates slow CDN response)
+ *   - 60-75% empty 200 OK (normal load, no content)
+ *   - 25-40% 204 No Content (server acknowledged, nothing to send)
+ * No artificial delay is added (see randomResponse() below for why).
  *
  * Analytics hosts (scorecardresearch, imrworldwide, omtrdc) are still blocked
  * but with higher 204 probability to look like server-side suppression rather
@@ -104,12 +104,12 @@ public class PeacockWebViewHelper {
     private static WebResourceResponse randomResponse(boolean isAnalytics) {
         int roll = RANDOM.nextInt(100);
 
-        // Occasionally add a small delay to mimic slow/busy CDN
-        if (roll < 15) {
-            try {
-                Thread.sleep(50 + RANDOM.nextInt(150)); // 50–200ms
-            } catch (InterruptedException ignored) {}
-        }
+        // No artificial delay here. shouldInterceptRequest runs on Chromium's
+        // own IO thread pool, and blocking it on a memory-constrained device
+        // contributed to a sustained GC-pressure climb to OutOfMemoryError
+        // within ~2.5 minutes of launch — see AdBlockInterceptor.java's
+        // randomAdResponse() for the matching fix and full rationale on the
+        // OkHttp side, which is where this was actually root-caused.
 
         // Vary status code
         int statusCode;

--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/peacock/ads/PeacockWebViewHelper.java
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/peacock/ads/PeacockWebViewHelper.java
@@ -175,87 +175,99 @@ public class PeacockWebViewHelper {
         return false;
     }
 
+    /**
+     * Named (non-anonymous) subclass of WebViewClient.
+     *
+     * A previous version of wrapClient() returned an anonymous
+     * `new WebViewClient() {...}` instance directly, which ART rejected with
+     * a VerifyError ("[0xC] returning 'Precise Reference: <anon>', but
+     * expected ... 'Reference: android.webkit.WebViewClient'") on v7.6.100 —
+     * 100% reproducible, fatal on every launch. A follow-up attempt to fix
+     * this by adding `(WebViewClient) (Object) wrapped` was eliminated by R8
+     * as a redundant cast (wrapped was already statically WebViewClient),
+     * regenerating the same unguarded bytecode and shipping the identical
+     * crash in v1.5.6. Using a real named class instead of an anonymous one
+     * removes the synthetic-class ambiguity that the verifier choked on when
+     * this extension's separately-dexed code is merged into the host APK via
+     * extendWith(), and there is no optimizable cast for R8 to strip.
+     */
+    private static final class WrappedClient extends WebViewClient {
+        private final WebViewClient original;
+
+        WrappedClient(WebViewClient original) {
+            this.original = original;
+        }
+
+        @Override
+        public WebResourceResponse shouldInterceptRequest(
+                WebView view, WebResourceRequest request) {
+            try {
+                String url = request.getUrl().toString();
+                if (shouldBlock(url)) {
+                    boolean analytics = isAnalyticsHost(url);
+                    Log.d(TAG, "BLOCKED [" + (analytics ? "analytics" : "ad") + "]: " + url);
+                    return randomResponse(analytics);
+                }
+                return null;
+            } catch (Exception e) {
+                Log.e(TAG, "shouldInterceptRequest error: " + e.getMessage());
+                return null;
+            }
+        }
+
+        // ── Critical: mutual TLS client certificate ───────────────────────
+        @Override
+        public void onReceivedClientCertRequest(WebView view,
+                ClientCertRequest certRequest) {
+            original.onReceivedClientCertRequest(view, certRequest);
+        }
+
+        // ── Delegate all xtvClient overrides ─────────────────────────────
+        @Override
+        public void onPageStarted(WebView view, String url,
+                android.graphics.Bitmap favicon) {
+            original.onPageStarted(view, url, favicon);
+        }
+
+        @Override
+        public void onPageFinished(WebView view, String url) {
+            original.onPageFinished(view, url);
+        }
+
+        @Override
+        public void onLoadResource(WebView view, String url) {
+            original.onLoadResource(view, url);
+        }
+
+        @Override
+        public void onReceivedError(WebView view, int errorCode,
+                String description, String failingUrl) {
+            original.onReceivedError(view, errorCode, description, failingUrl);
+        }
+
+        @Override
+        public void onReceivedHttpError(WebView view,
+                WebResourceRequest request,
+                WebResourceResponse errorResponse) {
+            original.onReceivedHttpError(view, request, errorResponse);
+        }
+
+        @Override
+        public void onReceivedSslError(WebView view,
+                android.webkit.SslErrorHandler handler,
+                android.net.http.SslError error) {
+            original.onReceivedSslError(view, handler, error);
+        }
+
+        @Override
+        public boolean onRenderProcessGone(WebView view,
+                android.webkit.RenderProcessGoneDetail detail) {
+            return original.onRenderProcessGone(view, detail);
+        }
+    }
+
     public static WebViewClient wrapClient(final WebViewClient original) {
         Log.d(TAG, "PeacockWebViewHelper.wrapClient() — Layer 7 active (randomized responses)");
-        WebViewClient wrapped = new WebViewClient() {
-
-            @Override
-            public WebResourceResponse shouldInterceptRequest(
-                    WebView view, WebResourceRequest request) {
-                try {
-                    String url = request.getUrl().toString();
-                    if (shouldBlock(url)) {
-                        boolean analytics = isAnalyticsHost(url);
-                        Log.d(TAG, "BLOCKED [" + (analytics ? "analytics" : "ad") + "]: " + url);
-                        return randomResponse(analytics);
-                    }
-                    return null;
-                } catch (Exception e) {
-                    Log.e(TAG, "shouldInterceptRequest error: " + e.getMessage());
-                    return null;
-                }
-            }
-
-            // ── Critical: mutual TLS client certificate ───────────────────
-            @Override
-            public void onReceivedClientCertRequest(WebView view,
-                    ClientCertRequest certRequest) {
-                original.onReceivedClientCertRequest(view, certRequest);
-            }
-
-            // ── Delegate all xtvClient overrides ─────────────────────────
-            @Override
-            public void onPageStarted(WebView view, String url,
-                    android.graphics.Bitmap favicon) {
-                original.onPageStarted(view, url, favicon);
-            }
-
-            @Override
-            public void onPageFinished(WebView view, String url) {
-                original.onPageFinished(view, url);
-            }
-
-            @Override
-            public void onLoadResource(WebView view, String url) {
-                original.onLoadResource(view, url);
-            }
-
-            @Override
-            public void onReceivedError(WebView view, int errorCode,
-                    String description, String failingUrl) {
-                original.onReceivedError(view, errorCode, description, failingUrl);
-            }
-
-            @Override
-            public void onReceivedHttpError(WebView view,
-                    WebResourceRequest request,
-                    WebResourceResponse errorResponse) {
-                original.onReceivedHttpError(view, request, errorResponse);
-            }
-
-            @Override
-            public void onReceivedSslError(WebView view,
-                    android.webkit.SslErrorHandler handler,
-                    android.net.http.SslError error) {
-                original.onReceivedSslError(view, handler, error);
-            }
-
-            @Override
-            public boolean onRenderProcessGone(WebView view,
-                    android.webkit.RenderProcessGoneDetail detail) {
-                return original.onRenderProcessGone(view, detail);
-            }
-        };
-
-        // ART rejected a bare `return new WebViewClient() {...}` here with
-        // VerifyError: "[0xC] returning 'Precise Reference: <anon>', but
-        // expected ... 'Reference: android.webkit.WebViewClient'" — confirmed
-        // via on-device logcat on v7.6.100, 100% reproducible, fatal on every
-        // launch (this is what actually broke v1.5.2 through v1.5.5; Layers
-        // 9-11 were never the cause). The double cast through Object forces
-        // javac to emit a real checkcast instruction instead of eliding it,
-        // which satisfies the verifier when this extension's separately-dexed
-        // class is merged into the host APK via extendWith().
-        return (WebViewClient) (Object) wrapped;
+        return new WrappedClient(original);
     }
 }

--- a/extensions/proguard-rules.pro
+++ b/extensions/proguard-rules.pro
@@ -41,8 +41,17 @@
     public static okhttp3.OkHttpClient$Builder addAdBlockInterceptor(okhttp3.OkHttpClient$Builder);
 }
 # Layer 7 — WebView shouldInterceptRequest wrapper
+# wrapClient() returns a named WrappedClient instance (not an anonymous
+# class — ART's verifier rejected an anonymous WebViewClient subtype here
+# after extendWith()'s raw dex merge, see PeacockWebViewHelper.java). Keep
+# both the entry point and the named subclass intact so R8 cannot merge,
+# inline, or otherwise re-collapse it back into the unverifiable shape.
 -keep class ajstrick81.morphe.extension.peacock.ads.PeacockWebViewHelper {
     public static android.webkit.WebViewClient wrapClient(android.webkit.WebViewClient);
+}
+-keep class ajstrick81.morphe.extension.peacock.ads.PeacockWebViewHelper$WrappedClient {
+    <init>(android.webkit.WebViewClient);
+    *;
 }
 
 # MLB At Bat — ad-break overlay helper. Called directly from injected smali


### PR DESCRIPTION
## Background

v1.5.6 (merged in #32) was supposed to fix the `VerifyError` that crashed Peacock on launch on v7.6.100 (issue #29), by forcing a checkcast via `(WebViewClient) (Object) wrapped`. Fresh on-device logcat after shipping v1.5.6 shows the **exact same crash, same VerifyError signature, same bytecode offset (`[0xC]`)**:

```
Caused by: java.lang.VerifyError: Verifier rejected class ajstrick81.morphe.extension.peacock.ads.PeacockWebViewHelper: android.webkit.WebViewClient ajstrick81.morphe.extension.peacock.ads.PeacockWebViewHelper.wrapClient(android.webkit.WebViewClient) failed to verify: ... [0xC] returning 'Precise Reference: d', but expected from declaration 'Reference: android.webkit.WebViewClient'
```

## Root cause of why the v1.5.6 fix didn't work

The `-keep` rule for `wrapClient()` only protects the method's signature from removal/renaming — not its body from optimization. R8 correctly recognized `(WebViewClient) (Object) wrapped` as a redundant no-op cast (since `wrapped` was already statically typed `WebViewClient`) and eliminated it, regenerating bytecode equivalent to the original unguarded `return new WebViewClient() {...}`. The shipped v1.5.6 APK's compiled bytecode was unchanged from the broken versions before it.

## This fix

Replaces the anonymous `WebViewClient` subclass with a **named static nested class** (`PeacockWebViewHelper.WrappedClient`). This removes the synthetic-anonymous-class type-merge ambiguity that ART's verifier choked on when this extension's separately-dexed code gets merged into the host APK via `extendWith()`'s raw dex merge — and there's no optimizable cast left for R8 to strip away. Added explicit `-keep` rules for both the entry point and the new named class so R8 can't re-collapse it back into the unverifiable shape.

## Status

Not yet device-verified. Please test on-device against Peacock v7.6.100 before merging — given the last two releases shipped with this exact bug still present, CI passing is not sufficient signal by itself this time.


---
_Generated by [Claude Code](https://claude.ai/code/session_01492m4Nok9muG2dEab8ihhc)_