### PR TITLE
feat(primevideo): Clone patch + additional Volley ad hosts

### DIFF
--- a/experimental/primevideo-speed-control/EnableSpeedPatch.kt
+++ b/experimental/primevideo-speed-control/EnableSpeedPatch.kt
@@ -1,0 +1,95 @@
+package ajstrick81.morphe.patches.primevideo.speed
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import ajstrick81.morphe.patches.primevideo.misc.extension.primeVideoExtensionPatch
+import ajstrick81.morphe.patches.primevideo.shared.Constants
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+
+private const val EXTENSION_CLASS =
+    "Lajstrick81/morphe/extension/primevideo/speed/SpeedControlPatch;"
+
+@Suppress("unused")
+val playbackSpeedPatch = bytecodePatch(
+    name = "Enable speed control",
+    description = "Experimental playback-speed control for the ATV player. " +
+        "Remote fast-forward cycles speed up (1x→1.5x→2x→4x→8x→16x), rewind " +
+        "cycles down. Useful for blowing through ad segments that survive the " +
+        "SkipAds and DNS layers (media3 never gated setPlaybackSpeed on ad state).",
+) {
+    compatibleWith(Constants.COMPATIBILITY)
+
+    // Pulls in the compiled extension dex that carries SpeedControlPatch.
+    dependsOn(primeVideoExtensionPatch)
+
+    execute {
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Hook 1 — capture the ExoPlayer instance.
+        //
+        // MediaPipelineBackendEngine.lambda$init$5 builds the player with
+        // ExoPlayer$Builder and stores it:
+        //     iput-object vX, vThis, ...->player Landroidx/media3/exoplayer/ExoPlayer;
+        // We inject setCurrentPlayer(vX) immediately after that store, while the
+        // freshly-built player is still in register vX (the app reuses it right
+        // after, so the insertion point matters). The register is located
+        // dynamically since it can shift between builds.
+        // ─────────────────────────────────────────────────────────────────────
+        InitExoPlayerFingerprint.method.apply {
+            val instructions = implementation!!.instructions
+            val putIndex = instructions.indexOfFirst { instruction ->
+                instruction.opcode == Opcode.IPUT_OBJECT &&
+                    ((instruction as ReferenceInstruction).reference as? FieldReference)?.name == "player"
+            }
+            // registerA of the iput-object is the source value — the freshly
+            // built player. It is a reused local here (< 16), and our injected
+            // invoke-static allocates no new registers, so the raw vN number is
+            // stable and unambiguous.
+            val playerRegister =
+                (instructions[putIndex] as TwoRegisterInstruction).registerA
+
+            addInstructions(
+                putIndex + 1,
+                "invoke-static {v$playerRegister}, " +
+                    "$EXTENSION_CLASS->setCurrentPlayer(Landroidx/media3/common/Player;)V",
+            )
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Hook 2 — drop the reference when the player is released.
+        //
+        // releasePlayerInternal() calls player.release() then nulls the field.
+        // Clearing our static holder at entry prevents a late key press from
+        // touching a released player. index 0 is safe: no registers are live.
+        // ─────────────────────────────────────────────────────────────────────
+        ReleaseExoPlayerFingerprint.method.addInstructions(
+            0,
+            "invoke-static {}, $EXTENSION_CLASS->clearCurrentPlayer()V",
+        )
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Hook 3 — intercept remote keys before the WASM layer.
+        //
+        // IgniteRenderer$EventHandler.onKey(View p1, int p2 keyCode, KeyEvent p3)
+        // forwards every key into native Ignite. We call onKeyEvent(keyCode,
+        // event) first; if it returns true we consumed the key (a speed change)
+        // and return true immediately so the app never seeks. Otherwise we fall
+        // through to the original body untouched.
+        // ─────────────────────────────────────────────────────────────────────
+        OnKeyFingerprint.method.addInstructions(
+            0,
+            """
+                invoke-static {p2, p3}, $EXTENSION_CLASS->onKeyEvent(ILandroid/view/KeyEvent;)Z
+                move-result v0
+                if-eqz v0, :speed_not_consumed
+                const/4 v0, 0x1
+                return v0
+                :speed_not_consumed
+                nop
+            """,
+        )
+    }
+}

--- a/experimental/primevideo-speed-control/Fingerprints.kt
+++ b/experimental/primevideo-speed-control/Fingerprints.kt
@@ -1,0 +1,52 @@
+package ajstrick81.morphe.patches.primevideo.speed
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.string
+
+// ─────────────────────────────────────────────────────────────────────────────
+// NOTE: hoodles' original fingerprints targeted
+// com.amazon.video.sdk.stores.overlays.settings.* — that package exists ONLY in
+// the Prime Video PHONE app (com.amazon.avod.thirdpartyclient). The ATV build
+// (com.amazon.amazonvideo.livingroom) has zero classes under com/amazon/video/sdk,
+// so the "flip the feature flag" approach has nothing to unlock here. Confirmed
+// by disassembling all 4 ATV dex files vs. all 12 phone dex files.
+//
+// The ATV app instead owns its media3 ExoPlayer inside MediaPipelineBackendEngine
+// and routes remote keys through IgniteRenderer$EventHandler.onKey before handing
+// them to the native/WASM layer. These fingerprints target that path.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// classes.dex — MediaPipelineBackendEngine.lambda$init$5(J)Ljava/lang/Integer;
+// Builds the ExoPlayer via ExoPlayer$Builder and stores it in the `player` field.
+// The log string "Initialising ExoPlayer" is unique to this method, so it anchors
+// the match without depending on the synthetic lambda name (which can shift
+// between builds).
+object InitExoPlayerFingerprint : Fingerprint(
+    definingClass = "Lcom/amazon/livingroom/mediapipelinebackend/MediaPipelineBackendEngine;",
+    filters = listOf(
+        string("Initialising ExoPlayer")
+    )
+)
+
+// classes.dex — MediaPipelineBackendEngine.releasePlayerInternal()V
+// Calls player.release() then nulls the field. Anchored by "Releasing ExoPlayer".
+object ReleaseExoPlayerFingerprint : Fingerprint(
+    definingClass = "Lcom/amazon/livingroom/mediapipelinebackend/MediaPipelineBackendEngine;",
+    filters = listOf(
+        string("Releasing ExoPlayer")
+    )
+)
+
+// classes.dex — IgniteRenderer$EventHandler.onKey(View, int, KeyEvent)Z
+// The View.OnKeyListener that forwards every remote key event into the native
+// Ignite/WASM renderer. The single Java-side key chokepoint in the ATV app.
+object OnKeyFingerprint : Fingerprint(
+    definingClass = "Lcom/amazon/ignitionshared/IgniteRenderer\$EventHandler;",
+    name = "onKey",
+    parameters = listOf(
+        "Landroid/view/View;",
+        "I",
+        "Landroid/view/KeyEvent;"
+    ),
+    returnType = "Z"
+)

--- a/experimental/primevideo-speed-control/README.md
+++ b/experimental/primevideo-speed-control/README.md
@@ -1,0 +1,48 @@
+# Prime Video ATV — playback-speed control (SHELVED)
+
+**Status:** shelved 2026-07-01. Not part of the build. Kept for reference and
+possible reactivation against a future Prime Video build.
+
+## What it was
+An experimental patch to add remote fast-forward / rewind speed cycling
+(1x→1.5x→2x→4x→8x→16x) to the ATV player, intended to blow through ad segments
+that survive the SkipAds + DNS layers. It hooks the media3 `ExoPlayer` the app
+builds inside `MediaPipelineBackendEngine` and calls `setPlaybackSpeed()`.
+
+Files:
+- `EnableSpeedPatch.kt` — bytecode patch (3 hooks: capture player, clear player, intercept onKey)
+- `Fingerprints.kt` — fingerprints for `MediaPipelineBackendEngine` init/release + `IgniteRenderer$EventHandler.onKey`
+- `SpeedControlPatch.java` — extension (the actual speed logic)
+
+## Why it was shelved (tested on-device 2026-07-01, Onn 4K Plus, app v6.23.23)
+The patch compiled, applied (all fingerprints resolved), the class survived R8,
+and the app ran stably — but the feature is **inert on this build**:
+
+1. **The native engine doesn't support playback speed.** media3's
+   `ExoPlayer.setPlaybackSpeed()` is bridged to a native MPB-v3 property. The
+   app's *own* attempts to set it fail at runtime:
+   - `setProperty("playbackSpeed","1")` → `_av_mpb_v3_instance_set_property failed with error code: 50040`
+   - `get_property(playbackSpeed)` → `property not recognized` (logged continuously)
+   - The engine's advertised MPBv3 capabilities list contains no speed/trick-play entry.
+
+   So even a perfectly wired hook forwards speed into a native call the engine
+   rejects. This is the same sealed native stack that caps ad suppression.
+
+2. **Hook 1 also didn't fire** (`setCurrentPlayer` never logged even though
+   `Initialising ExoPlayer` did). The `player`-field/register match in
+   `EnableSpeedPatch.kt` likely needs correcting — but this is moot until (1)
+   is solved.
+
+## Reactivation checklist (if a future build changes the pipeline)
+1. Move the 3 files back:
+   - `EnableSpeedPatch.kt`, `Fingerprints.kt` → `patches/src/main/kotlin/ajstrick81/morphe/patches/primevideo/speed/`
+   - `SpeedControlPatch.java` → `extensions/extension/src/main/java/ajstrick81/morphe/extension/primevideo/speed/`
+2. Re-add the R8 `-keep` rule for `SpeedControlPatch` (setCurrentPlayer /
+   clearCurrentPlayer / onKeyEvent) to `extensions/proguard-rules.pro`.
+3. First confirm the native layer accepts `playbackSpeed` (logcat: no
+   `50040` / `property not recognized`), otherwise it's still a dead end.
+4. Fix Hook 1 so `setCurrentPlayer` actually fires (verify via the
+   `PVSpeedControl: captured player=` log on playback start).
+
+See project memory `primevideo-native-speed-deadend` and the
+`Ad_Suppression_Methodology` doc for the full findings.

--- a/experimental/primevideo-speed-control/SpeedControlPatch.java
+++ b/experimental/primevideo-speed-control/SpeedControlPatch.java
@@ -1,0 +1,149 @@
+package ajstrick81.morphe.extension.primevideo.speed;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+import android.view.KeyEvent;
+
+import androidx.media3.common.Player;
+
+/**
+ * Prime Video ATV — experimental playback-speed control.
+ *
+ * Unlike the phone app (com.amazon.avod.thirdpartyclient), the ATV build
+ * (com.amazon.amazonvideo.livingroom) ships NO com.amazon.video.sdk settings
+ * overlay, so hoodles' "flip the PlaybackSpeedFeatureConfig flag" technique
+ * has nothing to unlock here — that whole feature is simply absent from the
+ * ATV dex set. This extension instead drives ExoPlayer directly.
+ *
+ * The ATV app renders its player UI through the native/WASM Ignite engine and
+ * owns its media3 ExoPlayer instance inside
+ * com.amazon.livingroom.mediapipelinebackend.MediaPipelineBackendEngine.
+ * Playback commands (play/pause/seek) are invoked from native via JNI, so
+ * there is no Java-side transport control to reuse — but the ExoPlayer object
+ * itself is a stock androidx.media3 Player.
+ *
+ * Wiring (see EnableSpeedPatch.kt):
+ *
+ *   setCurrentPlayer  — captured right after the ExoPlayer is built in
+ *                       MediaPipelineBackendEngine.lambda$init$5.
+ *   clearCurrentPlayer— cleared in releasePlayerInternal when the player is
+ *                       released, so we never touch a dead instance.
+ *   onKeyEvent        — invoked at the top of
+ *                       IgniteRenderer$EventHandler.onKey(View,int,KeyEvent),
+ *                       the single Java chokepoint where remote key events are
+ *                       forwarded into WASM. Returning true consumes the key so
+ *                       the WASM layer never sees it.
+ *
+ * Why speed control matters for ads: media3's SSAI ad enforcement only ever
+ * gated seekTo() while isPlayingAd() is true — it was never wired to
+ * setPlaybackSpeed(). So cranking speed during an ad segment that survives the
+ * SkipAds/DNS layers (e.g. the WASM-rendered ones) collapses it to a few
+ * seconds of wall-clock time. This is a viewing-experience workaround, not an
+ * additional impression-suppression layer.
+ */
+@SuppressWarnings({"unused", "UnnecessaryLocalVariable"})
+public final class SpeedControlPatch {
+
+    private static final String TAG = "PVSpeedControl";
+
+    // Speed ladder cycled through by the fast-forward / rewind remote keys.
+    // Index 0 (1.0x) is normal speed.
+    private static final float[] SPEEDS = {1.0f, 1.5f, 2.0f, 4.0f, 8.0f, 16.0f};
+
+    private static volatile Player currentPlayer;
+    private static volatile int speedIndex = 0;
+
+    private SpeedControlPatch() {}
+
+    /**
+     * Captures the live ExoPlayer instance immediately after it is built.
+     * Called from MediaPipelineBackendEngine.lambda$init$5.
+     */
+    public static void setCurrentPlayer(Player player) {
+        currentPlayer = player;
+        speedIndex = 0;
+        Log.i(TAG, "captured player=" + player);
+    }
+
+    /**
+     * Drops the reference when the player is released, so a stale key press
+     * can never reach a dead player. Called from
+     * MediaPipelineBackendEngine.releasePlayerInternal.
+     */
+    public static void clearCurrentPlayer() {
+        currentPlayer = null;
+        speedIndex = 0;
+        Log.i(TAG, "cleared player");
+    }
+
+    /**
+     * Intercepts remote key events before they reach the WASM Ignite layer.
+     *
+     * @return true if we handled the key (caller must return true / consume it),
+     *         false to let the app process it normally.
+     */
+    public static boolean onKeyEvent(int keyCode, KeyEvent event) {
+        try {
+            if (event == null || event.getAction() != KeyEvent.ACTION_DOWN) {
+                return false;
+            }
+
+            final Player player = currentPlayer;
+            if (player == null) {
+                return false;
+            }
+
+            final int delta;
+            switch (keyCode) {
+                case KeyEvent.KEYCODE_MEDIA_FAST_FORWARD:
+                    delta = 1;
+                    break;
+                case KeyEvent.KEYCODE_MEDIA_REWIND:
+                    delta = -1;
+                    break;
+                default:
+                    return false;
+            }
+
+            int next = speedIndex + delta;
+            if (next < 0) next = 0;
+            if (next > SPEEDS.length - 1) next = SPEEDS.length - 1;
+            speedIndex = next;
+            final float speed = SPEEDS[speedIndex];
+
+            // ExoPlayer enforces thread affinity — mutations must run on the
+            // looper the player was created with, not the (main) thread this
+            // key event arrives on.
+            final Looper looper = player.getApplicationLooper();
+            new Handler(looper).post(new SetSpeedTask(player, speed));
+
+            Log.i(TAG, "key=" + keyCode + " -> requested speed=" + speed);
+            return true;
+        } catch (Exception e) {
+            Log.e(TAG, "onKeyEvent failed", e);
+            return false;
+        }
+    }
+
+    /** Applies the speed change on the player's own looper thread. */
+    private static final class SetSpeedTask implements Runnable {
+        private final Player player;
+        private final float speed;
+
+        SetSpeedTask(Player player, float speed) {
+            this.player = player;
+            this.speed = speed;
+        }
+
+        @Override
+        public void run() {
+            try {
+                player.setPlaybackSpeed(speed);
+                Log.i(TAG, "applied playback speed=" + speed);
+            } catch (Exception e) {
+                Log.e(TAG, "setPlaybackSpeed failed", e);
+            }
+        }
+    }
+}

--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/primevideo/ads/SkipAdsPatch.java
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/primevideo/ads/SkipAdsPatch.java
@@ -55,10 +55,15 @@ import java.util.Map;
  * specific response shape.
  *
  * This hook does NOT suppress mid-roll ad segments — those are fetched by
- * ExoPlayer/media3's own DefaultHttpDataSource, a completely separate HTTP
- * stack that never touches Volley.
+ * Amazon's native MediaPipelineBackend (libcurl), a completely separate HTTP
+ * stack that never touches Volley. Confirmed via on-device logcat: the
+ * DOWNLOADER tag (native) fetches manifests/segments directly, including ad
+ * segments delivered at an /iad_X/ path (where X is a segment ID) on the SAME safe-harbored content
+ * CDN host as the movie itself - a path-only distinction invisible to both
+ * this hook and DNS blocking. No bytecode-reachable mitigation exists for
+ * that delivery mode on this build.
  *
- * All methods wrapped in try/catch — failures are logged to TAG below instead
+ * All methods wrapped in try/catch - failures are logged to TAG below instead
  * of silently swallowed, so logcat can confirm whether the hook fired and
  * whether the strip actually took effect.
  */
@@ -195,9 +200,19 @@ public class SkipAdsPatch {
                     // ad-free sessions). Exact match keeps the rest of weblab
                     // in the safe harbor. Prime suspect for persisting prerolls.
                     || host.equals("zoar.triggers-v1.prod.mobile.weblab.a2z.com")
+                    || host.equals("hercule.triggers-v1.prod.mobile.weblab.a2z.com")
                     // Ad orchestration endpoints on the video API.
                     || host.matches("threeplr[a-z0-9.-]*\\.api\\.amazonvideo\\.com")
-                    || host.matches("nit[a-z0-9.-]*\\.api\\.amazonvideo\\.com");
+                    || host.matches("nit[a-z0-9.-]*\\.api\\.amazonvideo\\.com")
+                    // s0s7: fires every ad cycle per on-device DNS log; never seen
+                    // in any PC/web capture, so its transport layer (Volley vs.
+                    // native libcurl) on this app is unconfirmed. Mirrored here as
+                    // a no-cost safety net for patch-only users without AGH — if
+                    // it's native-only this branch simply never fires.
+                    || host.equals("s0s7.api.amazonvideo.com")
+                    // Pause-screen ad endpoint surfaced via GetVodPlaybackResources
+                    // -> pauseAdsResolutionUrl (/getAds?...&format=PAUSE_ADS_STATIC).
+                    || host.equals("regolith.prime-video.amazon.dev");
 
             if (blocked) {
                 Log.i(TAG, "enforceAdBlock: blocking " + host);

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/primevideo/misc/clone/CloneAppPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/primevideo/misc/clone/CloneAppPatch.kt
@@ -1,0 +1,140 @@
+package ajstrick81.morphe.patches.primevideo.misc.clone
+
+import app.morphe.patcher.patch.resourcePatch
+import ajstrick81.morphe.patches.primevideo.shared.Constants
+import org.w3c.dom.Element
+
+// Suffix appended to the original applicationId for the cloned package, e.g.
+// com.amazon.amazonvideo.livingroom -> com.amazon.amazonvideo.livingroom.mod
+// Matches the value confirmed working in the field report (manual apktool edit).
+private const val CLONE_SUFFIX = "mod"
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Clone Prime Video (side-by-side install)
+//
+// Many Android TVs / TV boxes ship Prime Video as a SYSTEM app that cannot be
+// uninstalled without root. Installing a patched build over it is impossible,
+// and installing the patched build UNDER a new applicationId fails with:
+//
+//   INSTALL_FAILED_CONFLICTING_PROVIDER: ... provider name
+//   com.amazon.amazonvideo.livingroom.mobileadsinitprovider (in package
+//   ...livingroom.mod) is already used by com.amazon.amazonvideo.livingroom
+//
+// Renaming the applicationId alone is NOT enough: a ContentProvider's
+// android:authorities and any custom <permission> android:name must be UNIQUE
+// device-wide, independent of applicationId. They stay pinned to the original
+// package string, so PackageManager rejects the install as long as the stock
+// app is present.
+//
+// This patch renames the package AND every package-scoped identifier that must
+// be device-unique, so the clone installs cleanly alongside the stock app.
+//
+// Confirmed package-coupled identifiers in this build's manifest:
+//   providers (android:authorities):
+//     - com.amazon.amazonvideo.livingroom.provider
+//     - com.amazon.amazonvideo.livingroom.mobileadsinitprovider  (GMS Ads)
+//   permission (android:name):
+//     - com.amazon.amazonvideo.livingroom.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION
+//
+// Intent actions (e.g. ...AMAZON_BUTTON) and <queries> package targets are left
+// untouched: they are not device-unique and are matched by literal string on
+// both ends, so rewriting them would break internal messaging without helping
+// installation.
+//
+// Runs in finalize {} so the rename happens after all other patches, at manifest
+// write time. Opt-in (default = false): only clone when explicitly selected.
+// ─────────────────────────────────────────────────────────────────────────────
+@Suppress("unused")
+val cloneAppPatch = resourcePatch(
+    name = "Clone Prime Video",
+    description = "Renames the package to <original>.$CLONE_SUFFIX (and its provider " +
+        "authorities / custom permissions) so the patched app installs side-by-side " +
+        "with a non-removable system Prime Video. Opt-in.",
+    default = false,
+) {
+    compatibleWith(Constants.COMPATIBILITY)
+
+    finalize {
+        val packageName = packageMetadata.packageName
+        val newPackageName = "$packageName.$CLONE_SUFFIX"
+
+        // Authorities may be an @string/... reference rather than a literal; any
+        // such string resource names are collected here and rewritten below.
+        val providerStringResources = mutableSetOf<String>()
+
+        document("AndroidManifest.xml").use { document ->
+            document.documentElement.setAttribute("package", newPackageName)
+
+            // ── Custom permissions ──────────────────────────────────────────
+            // A <permission> android:name must be device-unique. Rename each
+            // declaration prefixed with the old package, and keep any matching
+            // <uses-permission> in sync so the app can still request its own.
+            val permissions = document.getElementsByTagName("permission")
+            val usesPermissions = document.getElementsByTagName("uses-permission")
+
+            for (i in 0 until permissions.length) {
+                val permission = permissions.item(i) as? Element ?: continue
+                val oldName = permission.getAttribute("android:name")
+                val newName = when {
+                    oldName.startsWith('.') -> continue
+                    oldName.startsWith("$packageName.") ->
+                        oldName.replaceFirst(packageName, newPackageName)
+                    else -> "${newPackageName}_$oldName"
+                }
+                permission.setAttribute("android:name", newName)
+
+                for (j in 0 until usesPermissions.length) {
+                    val usePerm = usesPermissions.item(j) as? Element ?: continue
+                    if (usePerm.getAttribute("android:name") == oldName) {
+                        usePerm.setAttribute("android:name", newName)
+                        break
+                    }
+                }
+            }
+
+            // ── Provider authorities ────────────────────────────────────────
+            // android:authorities is a ';'-separated list; each entry must be
+            // device-unique. Rewrite literals prefixed with the old package and
+            // defer @string references to the strings.xml pass below.
+            val providers = document.getElementsByTagName("provider")
+
+            for (i in 0 until providers.length) {
+                val provider = providers.item(i) as? Element ?: continue
+                val authorities = provider.getAttribute("android:authorities").split(';')
+                val newAuthorities = authorities.map {
+                    when {
+                        it.startsWith("$packageName.") ->
+                            it.replaceFirst(packageName, newPackageName)
+                        it.startsWith('@') -> {
+                            providerStringResources.add(it.removePrefix("@string/"))
+                            it
+                        }
+                        else -> "${newPackageName}_$it"
+                    }
+                }
+                provider.setAttribute("android:authorities", newAuthorities.joinToString(";"))
+            }
+        }
+
+        // ── @string-backed authorities ──────────────────────────────────────
+        // No-op for the current build (both authorities are literals), but kept
+        // so the patch survives a future build that moves them into strings.xml.
+        if (providerStringResources.isNotEmpty()) {
+            document("res/values/strings.xml").use { document ->
+                val children = document.documentElement.childNodes
+                for (i in 0 until children.length) {
+                    val node = children.item(i) as? Element ?: continue
+
+                    if (node.getAttribute("name") in providerStringResources) {
+                        val authority = node.textContent
+                        node.textContent = if (authority.startsWith("$packageName.")) {
+                            authority.replaceFirst(packageName, newPackageName)
+                        } else {
+                            "${newPackageName}_$authority"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **feat(primevideo):** Clone Prime Video side-by-side install patch (opt-in, `default=false`). Renames the package to `<original>.mod` plus its device-unique provider authorities and custom permissions, so a patched build installs alongside a non-removable **system** Prime Video instead of failing with `INSTALL_FAILED_UPDATE_INCOMPATIBLE` / `CONFLICTING_PROVIDER`.
- **fix(primevideo):** Block three additional Volley ad hosts in `enforceAdBlock` — `hercule.triggers-v1…weblab.a2z.com`, `s0s7.api.amazonvideo.com`, `regolith.prime-video.amazon.dev` — and correct the mid-roll comment (native MediaPipelineBackend/libcurl path).
- **docs(primevideo):** Archive the shelved playback-speed experiment to `experimental/primevideo-speed-control/` (kept, not built).

## Testing
- **Clone — verified on-device** (Onn 4K Plus, app v6.23.23): installs as `com.amazon.amazonvideo.livingroom.mod` beside the stock app, launches, plays, stable.
- **Ad hosts** — compile + R8-clean; additive blocklist entries, not runtime-verified this session.
- **Speed control** — shelved: the native MPB-v3 engine has no `playbackSpeed` property (`set` fails 50040, `get` "not recognized"), so the media3 `setPlaybackSpeed` hook is inert on this build. Retained for reference/reactivation.

## Release
The `feat` commit will have semantic-release cut **v1.8.0** on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
