### PR TITLE
feat(pluto): add Clone and Disable auto-updates patches

### DIFF
--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/pluto/misc/clone/CloneAppPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/pluto/misc/clone/CloneAppPatch.kt
@@ -1,0 +1,137 @@
+package ajstrick81.morphe.patches.pluto.misc.clone
+
+import app.morphe.patcher.patch.resourcePatch
+import ajstrick81.morphe.patches.pluto.shared.Constants
+import org.w3c.dom.Element
+
+// Suffix appended to the original applicationId for the cloned package, e.g.
+// tv.pluto.android -> tv.pluto.android.mod
+private const val CLONE_SUFFIX = "mod"
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Clone Pluto TV (side-by-side install)
+//
+// Many Android TVs / TV boxes — and notably Amazon Fire TV devices — ship
+// Pluto TV as a SYSTEM app that cannot be uninstalled without root. Installing a
+// patched build over the stock system app is impossible, and installing the
+// patched build UNDER a new applicationId still fails, because renaming the
+// applicationId alone is NOT enough:
+//
+//   A ContentProvider's android:authorities and any custom <permission>
+//   android:name must be UNIQUE device-wide, independent of applicationId.
+//   They stay pinned to the original package string, so PackageManager rejects
+//   the install with INSTALL_FAILED_CONFLICTING_PROVIDER (or a duplicate-
+//   permission error) as long as the stock app is present.
+//
+// This patch renames the package AND every package-scoped identifier that must
+// be device-unique (provider authorities + custom permissions), so the clone
+// installs cleanly alongside the stock app. The rewrite is generic: it rewrites
+// any authority/permission whose name is prefixed with the app's own package,
+// and defers @string-backed authorities to the strings.xml pass. It therefore
+// adapts to whatever Pluto's manifest declares in a given build, without a
+// hardcoded list of identifiers.
+//
+// Intent actions and <queries> package targets are left untouched: they are not
+// device-unique and are matched by literal string on both ends, so rewriting
+// them would break internal messaging without helping installation.
+//
+// Runs in finalize {} so the rename happens after all other patches, at manifest
+// write time. Opt-in (default = false): only clone when explicitly selected.
+// ─────────────────────────────────────────────────────────────────────────────
+@Suppress("unused")
+val cloneAppPatch = resourcePatch(
+    name = "Clone Pluto TV",
+    description = "Installs the patched Pluto TV as a separate app alongside the stock one, " +
+        "instead of replacing it. Enable this when Pluto TV is a preinstalled system app that " +
+        "can't be uninstalled — most commonly on Amazon Fire TV, and on some Android TV boxes " +
+        "and Onn devices. The clone gets its own package (suffix .$CLONE_SUFFIX), so it shows " +
+        "up as a second Pluto TV icon and keeps its own settings. Leave OFF if you were able to " +
+        "uninstall the original Pluto TV first (a normal in-place install is cleaner). Opt-in.",
+    default = false,
+) {
+    compatibleWith(Constants.COMPATIBILITY)
+
+    finalize {
+        val packageName = packageMetadata.packageName
+        val newPackageName = "$packageName.$CLONE_SUFFIX"
+
+        // Authorities may be an @string/... reference rather than a literal; any
+        // such string resource names are collected here and rewritten below.
+        val providerStringResources = mutableSetOf<String>()
+
+        document("AndroidManifest.xml").use { document ->
+            document.documentElement.setAttribute("package", newPackageName)
+
+            // ── Custom permissions ──────────────────────────────────────────
+            // A <permission> android:name must be device-unique. Rename each
+            // declaration prefixed with the old package, and keep any matching
+            // <uses-permission> in sync so the app can still request its own.
+            val permissions = document.getElementsByTagName("permission")
+            val usesPermissions = document.getElementsByTagName("uses-permission")
+
+            for (i in 0 until permissions.length) {
+                val permission = permissions.item(i) as? Element ?: continue
+                val oldName = permission.getAttribute("android:name")
+                val newName = when {
+                    oldName.startsWith('.') -> continue
+                    oldName.startsWith("$packageName.") ->
+                        oldName.replaceFirst(packageName, newPackageName)
+                    else -> "${newPackageName}_$oldName"
+                }
+                permission.setAttribute("android:name", newName)
+
+                for (j in 0 until usesPermissions.length) {
+                    val usePerm = usesPermissions.item(j) as? Element ?: continue
+                    if (usePerm.getAttribute("android:name") == oldName) {
+                        usePerm.setAttribute("android:name", newName)
+                        break
+                    }
+                }
+            }
+
+            // ── Provider authorities ────────────────────────────────────────
+            // android:authorities is a ';'-separated list; each entry must be
+            // device-unique. Rewrite literals prefixed with the old package and
+            // defer @string references to the strings.xml pass below.
+            val providers = document.getElementsByTagName("provider")
+
+            for (i in 0 until providers.length) {
+                val provider = providers.item(i) as? Element ?: continue
+                val authorities = provider.getAttribute("android:authorities").split(';')
+                val newAuthorities = authorities.map {
+                    when {
+                        it.startsWith("$packageName.") ->
+                            it.replaceFirst(packageName, newPackageName)
+                        it.startsWith('@') -> {
+                            providerStringResources.add(it.removePrefix("@string/"))
+                            it
+                        }
+                        else -> "${newPackageName}_$it"
+                    }
+                }
+                provider.setAttribute("android:authorities", newAuthorities.joinToString(";"))
+            }
+        }
+
+        // ── @string-backed authorities ──────────────────────────────────────
+        // Rewrite any provider authorities that were declared as @string/...
+        // references rather than manifest literals.
+        if (providerStringResources.isNotEmpty()) {
+            document("res/values/strings.xml").use { document ->
+                val children = document.documentElement.childNodes
+                for (i in 0 until children.length) {
+                    val node = children.item(i) as? Element ?: continue
+
+                    if (node.getAttribute("name") in providerStringResources) {
+                        val authority = node.textContent
+                        node.textContent = if (authority.startsWith("$packageName.")) {
+                            authority.replaceFirst(packageName, newPackageName)
+                        } else {
+                            "${newPackageName}_$authority"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/pluto/misc/security/DisableAutoUpdatesPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/pluto/misc/security/DisableAutoUpdatesPatch.kt
@@ -1,0 +1,68 @@
+package ajstrick81.morphe.patches.pluto.misc.security
+
+import app.morphe.patcher.patch.resourcePatch
+import ajstrick81.morphe.patches.pluto.shared.Constants
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Disable Auto Updates
+//
+// Prevents Google Play Store from automatically updating and replacing the
+// patched APK with the official unpatched version.
+//
+// Without this patch, if the user has Pluto TV in their Play Store library, an
+// automatic update would silently reinstall the official APK and remove the
+// patch entirely — restoring the ad stack — with no warning to the user.
+//
+// Implementation:
+//   There is no manifest attribute that turns off Play Store auto-updates —
+//   update eligibility is decided entirely by Play Store comparing versionCode
+//   against what's installed, not by anything the app declares about itself.
+//   So instead, this patch bumps android:versionCode on the <manifest> root
+//   well past the real app's current value. Play Store only offers/pushes an
+//   update when its listed versionCode is higher than what's installed, so
+//   keeping the patched build's versionCode artificially ahead makes Play
+//   Store treat it as already up to date.
+//
+// Note: This does not block manually installing a different APK. To update the
+// patched APK, users need to download a new version and re-patch it via Morphe.
+// Also note (per the upstream reference): this technique does not help when the
+// app is installed by mounting.
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Suppress("unused")
+val disableAutoUpdatesPatch = resourcePatch(
+    name = "Disable auto-updates",
+    description = "Stops the Google Play Store from silently updating Pluto TV back to the " +
+        "official version and wiping out the patch (which would bring the ads back). Works by " +
+        "setting the patched build's version number far ahead of anything on the Store, so it's " +
+        "treated as already up to date. You can still update deliberately by re-patching a newer " +
+        "APK in Morphe. Recommended to leave ON. Does not apply to mount-installed apps.",
+) {
+    compatibleWith(Constants.COMPATIBILITY)
+
+    execute {
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Bump android:versionCode on <manifest> past Play Store's real value
+        //
+        // Play Store only offers an update when its versionCode is higher than
+        // what's installed, so pushing this far ahead keeps the patched build
+        // looking newer than anything Play Store could offer for a long time.
+        // Clamped to Int.MAX_VALUE since versionCode is a 32-bit signed field.
+        // ─────────────────────────────────────────────────────────────────────
+        document("AndroidManifest.xml").use { document ->
+            val manifestNode = document
+                .getElementsByTagName("manifest")
+                .item(0)
+
+            val versionCodeAttr = manifestNode
+                .attributes
+                .getNamedItem("android:versionCode")
+
+            val bumpedVersionCode = (versionCodeAttr.nodeValue.toLong() + 10_000_000L)
+                .coerceAtMost(Int.MAX_VALUE.toLong())
+
+            versionCodeAttr.nodeValue = bumpedVersionCode.toString()
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds two install/lifecycle patches to the Pluto TV target, mirroring the existing Peacock/Prime Video pair:

- **Clone Pluto TV** (opt-in) — renames the package to `tv.pluto.android.mod` plus every package-scoped provider authority and custom permission, so the patched build installs **side-by-side** with a non-removable system Pluto (Amazon Fire TV, some Android TV boxes / Onn devices).
- **Disable auto-updates** (default on) — bumps `android:versionCode` beyond the Play Store's value so Play can't silently reinstall the unpatched APK and bring the ad stack back.

## Testing

Verified on-device (Onn 4K, `tv.pluto.android` **5.66.0-leanback**): the clone (`tv.pluto.android.mod`) installs cleanly **alongside** stock Pluto with no `INSTALL_FAILED_CONFLICTING_PROVIDER`, launches clean (no `NoClassDefFound`/`NoSuchMethodError`), and playback works.

## Known limitation — VOD movie ads (not a regression)

Full ad suppression is **not** achieved on Pluto **video-on-demand movies**. The shipped "Skip ads" patch empties `StitcherSession.getAdBreaks()`, which removes the client-side ad-break timeline that drives **live channels and on-demand episodes** — but full-length movies deliver their ads via a different path: **in-band ID3 timed-metadata baked into a server-side-stitched (SSAI) stream** (`service-stitcher` / `siloh.pluto.tv`, played through the Paramount Avia/media3 pipeline). That ad video is stitched into the stream server-side and isn't described by any client-side timeline the bytecode can empty, so it still plays. The **good news**: these VOD movie ad slots are **fully fast-forwardable** — a viewer can simply FF through the ad pod (~30s per slot) and resume content with no seek-blocking. So the experience is not ad-free on movies, but the ads are trivially skippable rather than forced. Removing them outright would require either HLS-manifest surgery or an auto-skip integration and is tracked as separate future work; it is intentionally **out of scope** here and does not affect the live/episode ad suppression already shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
