### PR TITLE
docs: link APK downloads directly to Android TV listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ I'm just like you — I enjoy watching TV and movies without being bored and ann
 | 🟢 Peacock | `com.peacocktv.peacockandroid` | Working - [Use with DNS filters:](https://github.com/ajstrick81/Peacock-Ads) | `v7.5.102` | 6/13/26 |
 | 🟢 Tubi | `com.tubitv` | Working | `v10.20.5000` | 5/20/26 |
 | 🟢 ViX | `com.univision.prendetv` | Working | `v4.46.0_tv` | 6/26/26 |
-| 🟡 Pluto TV | `tv.pluto.android` | Testing — ad tracking + pause ads suppressed; stitched (SSAI) video ads remain | `5.66.0-leanback` | 7/1/26 |
+| 🟢 Pluto TV | `tv.pluto.android` | Working — VOD ad breaks removed (video, markers, beacons); LIVE TV ads are broadcast time and remain | `5.66.0-leanback` | 7/3/26 |
 | 🔴 Paramount+ | `com.cbs.ott` | In Development | `v16.8 → v16.12` | — |
 | 🔴 Fox One | **Under Development** | — |
 | 🔴 MLB TV | **Under Development** | — |
@@ -35,20 +35,22 @@ I'm just like you — I enjoy watching TV and movies without being bored and ann
 
 All patches follow the same general workflow using **Morphe Manager**:
 
-1. Download the correct `.apkm` from [APKMirror](https://www.apkmirror.com)
+1. Download the correct **Android TV** `.apkm` from APKMirror — use the direct links below
 2. Open Morphe Manager and select the `.apkm` file
 3. Apply the patch
 
-> ⚠️ Always verify the publisher before downloading — details below.
+> ⚠️ **Get the Android TV build, not the phone or Fire TV build.** Each direct
+> link below points at the app's **Android TV** listing on APKMirror. Several of
+> these apps ship a separate phone build and/or a Fire TV build under the *same*
+> package name — those will patch incorrectly or not at all. On the listing,
+> match the **exact version** named below and download the **`.apkm`** (App
+> Bundle), not a single-arch `.apk`.
 
 ---
 
 ### 🎬 Disney+
 
-1. Go to [apkmirror.com](https://www.apkmirror.com) and search for:
-   ```
-   Disney+ 26.9.2+rc1-2026.06.12 (Android TV)
-   ```
+1. Open the **[Disney+ (Android TV) listing on APKMirror](https://www.apkmirror.com/apk/disney/disney-android-tv/)** and select version **`26.9.2+rc1-2026.06.12`**
 2. Download the `.apkm` file
 3. Select it in Morphe Manager
 4. Apply the patch
@@ -57,10 +59,7 @@ All patches follow the same general workflow using **Morphe Manager**:
 
 ### 🎭 HBO Max
 
-1. Go to [apkmirror.com](https://www.apkmirror.com) and search for:
-   ```
-   HBO Max v7.5.0.73 (Android TV)
-   ```
+1. Open the **[HBO Max (Android TV) listing on APKMirror](https://www.apkmirror.com/apk/warnermedia-direct-llc/max-stream-hbo-tv-movies-android-tv/)** and select version **`7.5.0.73`** (or the fallback `7.2.0.41`)
 2. Download the `.apkm` file
 3. Select it in Morphe Manager
 4. Apply the patch
@@ -69,10 +68,7 @@ All patches follow the same general workflow using **Morphe Manager**:
 
 ### ▶️ Prime Video
 
-1. Go to [apkmirror.com](https://www.apkmirror.com) and search for:
-   ```
-   Prime Video 6.23.23+v15.5.0.70-armv7a (Android TV)
-   ```
+1. Open the **[Prime Video (Android TV) listing on APKMirror](https://www.apkmirror.com/apk/amazon-mobile-llc/prime-video-android-tv-android-tv/)** and select version **`6.23.23+v15.5.0.70-armv7a`**
 2. Download the `.apkm` file
 3. Select it in Morphe Manager
 4. Apply the patch
@@ -88,11 +84,8 @@ All patches follow the same general workflow using **Morphe Manager**:
 
 > 🔴 **Currently under development.** The transition from `v16.8` to `v16.12` introduced issues that are still being debugged. Use `v16.8` in the meantime.
 
-1. Go to [apkmirror.com](https://www.apkmirror.com) and search for:
-   ```
-   Paramount+ v16.8 (Android TV)
-   ```
-2. ⚠️ Download only the version published by **CBS Interactive** — DO **NOT** download the **Viacom** version
+1. Open the **[Paramount+ (Android TV) listing on APKMirror](https://www.apkmirror.com/apk/cbs-interactive-inc/paramount-2/)** and select version **`16.8.0`**
+2. ⚠️ This listing is published by **CBS Interactive, Inc.** — the correct publisher. Do **not** use the separate Viacom-published build.
 3. Download the `.apkm` file
 4. Select it in Morphe Manager
 5. Apply the patch
@@ -101,22 +94,17 @@ All patches follow the same general workflow using **Morphe Manager**:
 
 ### 📺 Tubi
 
-1. Go to [apkmirror.com](https://www.apkmirror.com) and search for:
-   ```
-   Tubi v10.20.5000 (Android TV)
-   ```
-2. Download the `.apkm` file
-3. Select it in Morphe Manager
-4. Apply the patch
+1. Open the **[Tubi (Android TV) listing on APKMirror](https://www.apkmirror.com/apk/tubi-tv/tubi-free-movies-live-tv-android-tv/)** and select version **`10.20.5000`**
+2. ⚠️ Use this **Android TV** listing — not the "Tubi (Fire TV)" or the phone listing
+3. Download the `.apkm` file
+4. Select it in Morphe Manager
+5. Apply the patch
 
 ---
 
 ### 🌐 ViX
 
-1. Go to [apkmirror.com](https://www.apkmirror.com) and search for:
-   ```
-   ViX v4.46.0_tv (Android TV)
-   ```
+1. Open the **[ViX (Fire TV / Android TV) listing on APKMirror](https://www.apkmirror.com/apk/univision-communications-inc/vix-tv-deportes-y-noticias-fire-tv-android-tv/)** and select version **`4.46.0_tv`**
 2. Download the `.apkm` file
 3. Select it in Morphe Manager
 4. Apply the patch
@@ -125,30 +113,25 @@ All patches follow the same general workflow using **Morphe Manager**:
 
 ### 📡 Pluto TV
 
-> 🟡 **Testing.** Pluto is a free, 100% ad-supported (FAST) service that uses
-> **server-side ad stitching (SSAI)** — ads are baked directly into the video
-> stream from the same CDN as the content, so there is no ad domain to block
-> and no ad-free tier to unlock. This patch neuters the ad *tracking beacons*
-> and the *pause-ad* overlay. The stitched video ads themselves still occupy
-> their slot in the timeline; a VOD auto-skip pass is planned. DNS filters do
-> **not** help here.
+> 🟢 **Working.** Pluto is a free, 100% ad-supported (FAST) service that uses
+> **server-side ad stitching (SSAI)** — ads are baked into the same stream as
+> the content, so there is no ad domain to block and no ad-free tier to unlock.
+> This patch empties the client-side ad-break timeline, which removes **on-demand
+> (VOD)** ad breaks entirely: ad video, timeline markers, overlays, and tracking
+> beacons. **LIVE TV** ads are real broadcast time in the linear feed and are not
+> removable. DNS filters do **not** help here.
 
-1. Go to [apkmirror.com](https://www.apkmirror.com) and search for:
-   ```
-   Pluto TV 5.66.0-leanback (Android TV)
-   ```
-2. Download the `.apkm` file
-3. Select it in Morphe Manager
-4. Apply the patch
+1. Open the **[Pluto TV (Android TV) listing on APKMirror](https://www.apkmirror.com/apk/pluto-inc/pluto-tv-android-tv/)** and select version **`5.66.0-leanback`**
+2. ⚠️ Use this **Android TV** listing and pick a **`-leanback`** build — not the phone or Fire TV build
+3. Download the `.apkm` file
+4. Select it in Morphe Manager
+5. Apply the patch
 
 ---
 
 ### 🦚 Peacock
 
-1. Go to [apkmirror.com](https://www.apkmirror.com) and search for:
-   ```
-   Peacock v7.5.102 (Android TV)
-   ```
+1. Open the **[Peacock TV (Android TV) listing on APKMirror](https://www.apkmirror.com/apk/peacock-tv-llc/peacock-tv-android-tv/)** and select version **`7.5.102`**
 2. Download the `.apkm` file
 3. Select it in Morphe Manager
 4. Apply the patch


### PR DESCRIPTION
## What
A user reported the Pluto TV "help me find an APK" flow landed on the **Fire TV** APK on apkmirror.com instead of the **`-leanback` (Android TV)** build. Auditing the README's install guide, every app used a **generic `apkmirror.com` homepage + search string**, not a direct link — so for any app whose phone/Fire TV/Android-TV builds share a package name, the user could easily grab the wrong form factor.

## Change
Replaced all 8 "search apkmirror for X" steps with **direct links to each app's Android-TV-specific APKMirror listing**, each verified via search this session:

| App | Version | Listing |
|-----|---------|---------|
| Disney+ | `26.9.2+rc1-2026.06.12` | `disney/disney-android-tv` |
| HBO Max | `7.5.0.73` | `warnermedia-direct-llc/max-stream-hbo-tv-movies-android-tv` |
| Prime Video | `6.23.23+v15.5.0.70-armv7a` | `amazon-mobile-llc/prime-video-android-tv-android-tv` |
| Paramount+ | `16.8.0` | `cbs-interactive-inc/paramount-2` (CBS Interactive publisher) |
| Tubi | `10.20.5000` | `tubi-tv/tubi-free-movies-live-tv-android-tv` |
| ViX | `4.46.0_tv` | `univision-communications-inc/vix-tv-deportes-y-noticias-fire-tv-android-tv` |
| Pluto TV | `5.66.0-leanback` | `pluto-inc/pluto-tv-android-tv` |
| Peacock | `7.5.102` | `peacock-tv-llc/peacock-tv-android-tv` |

Plus: explicit "Android TV, not phone/Fire TV" cautions for the multi-build packages (Pluto, Tubi), and a correction to the now-stale Pluto capability note — the shipped patch removes VOD ad breaks entirely (device-verified 5.66.0-leanback), so its status is 🟡→🟢.

## Note
This fixes the **README** (one of the two link surfaces). The in-app "Yes, help me find an APK" **button is generated by the Morphe Manager app** from patch metadata (package name + version) and lives in a separate repo — that half still needs a fix there (the app can't distinguish the Pluto Fire TV vs leanback build from `tv.pluto.android` alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)