### PR TITLE
feat(vix): support 4.47.2_tv; re-anchor Innovid fingerprint on string

### DIFF
--- a/patches-list.json
+++ b/patches-list.json
@@ -331,7 +331,8 @@
       "dependencies": [],
       "compatiblePackages": {
         "com.univision.prendetv": [
-          "4.46.0_tv"
+          "4.46.0_tv",
+          "4.47.2_tv"
         ]
       },
       "compatibility": [
@@ -343,6 +344,10 @@
           "targets": [
             {
               "version": "4.46.0_tv",
+              "experimental": false
+            },
+            {
+              "version": "4.47.2_tv",
               "experimental": false
             }
           ]
@@ -551,7 +556,8 @@
       "dependencies": [],
       "compatiblePackages": {
         "com.univision.prendetv": [
-          "4.46.0_tv"
+          "4.46.0_tv",
+          "4.47.2_tv"
         ]
       },
       "compatibility": [
@@ -563,6 +569,10 @@
           "targets": [
             {
               "version": "4.46.0_tv",
+              "experimental": false
+            },
+            {
+              "version": "4.47.2_tv",
               "experimental": false
             }
           ]

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/vix/ads/Fingerprints.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/vix/ads/Fingerprints.kt
@@ -27,29 +27,28 @@ import com.android.tools.smali.dexlib2.AccessFlags
 
 // ─────────────────────────────────────────────────────────────────────────────
 // InnovidHelper — ad overlay mount entry point
-// classes10.dex / com/univision/descarga/videoplayer/utilities/innovid/
+// com/univision/descarga/videoplayer/utilities/innovid/InnovidHelper
 //
 // Method `h(boolean, WebView, VideoModel, Flow)` is the call that mounts the
-// Innovid SSAI ad WebView overlay. Confirmed via the "innovidAd" parameter
-// string in the body and its sole call site in videoplayer/z.smali, which
-// dispatches it from the player's ad-event switch. Returning void at index 0
-// stops the overlay before any WebView is attached or network request fires.
+// Innovid SSAI ad WebView overlay. Its sole call site in the player's ad-event
+// switch dispatches it; returning void at index 0 stops the overlay before any
+// WebView is attached or network request fires.
 //
-// The method name (`h`) is R8-obfuscated and intentionally NOT matched on —
-// InnovidHelper exposes four void methods that share [PUBLIC, FINAL]
-// (the synthetic accessors a/b, the teardown c(DisposeReason), and h), so the
-// previous name-less, parameter-less fingerprint could bind the wrong one
-// (e.g. teardown). The full parameter signature uniquely identifies the mount
-// method and survives method renaming across minor builds.
+// Anchored on the "innovidAd" string constant, which appears only inside this
+// mount method within InnovidHelper — so definingClass + that string uniquely
+// identify it. The method name (`h`) is R8-obfuscated and NOT matched on.
+//
+// Version note (4.46.0_tv → 4.47.2_tv): the earlier fingerprint pinned the
+// full parameter list, but R8 renamed the obfuscated VideoModel param type
+// (…/models/video/v → …/models/video/t) between builds, which broke the exact
+// match. The string anchor is immune to that obfuscation drift and matches
+// both builds, so it replaces the parameter list. returnType + [PUBLIC, FINAL]
+// are kept as cheap extra constraints (the other public-final-void methods —
+// the a/b accessors and c(DisposeReason) teardown — don't carry this string).
 // ─────────────────────────────────────────────────────────────────────────────
 object InnovidStartAdFingerprint : Fingerprint(
     definingClass = "Lcom/univision/descarga/videoplayer/utilities/innovid/InnovidHelper;",
-    parameters = listOf(
-        "Z",
-        "Landroid/webkit/WebView;",
-        "Lcom/univision/descarga/presentation/models/video/v;",
-        "Lkotlinx/coroutines/flow/i;"
-    ),
+    strings = listOf("innovidAd"),
     returnType = "V",
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL)
 )

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/vix/shared/Constants.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/vix/shared/Constants.kt
@@ -8,6 +8,6 @@ object Constants {
         name = "ViX Android TV",
         packageName = "com.univision.prendetv",
         appIconColor = 0x00A0E9,
-        targets = listOf(AppTarget("4.46.0_tv"))
+        targets = listOf(AppTarget("4.46.0_tv"), AppTarget("4.47.2_tv"))
     )
 }


### PR DESCRIPTION
## Summary

Adds ViX **4.47.2_tv** as a supported target and fixes the one hook that broke between builds.

Compared the new `4.47.2_tv` dex set against the current `4.46.0_tv` patch:

| Hook | Status on 4.47.2_tv |
|---|---|
| `LuraAdBreakSchedulerFingerprint` (linear/VOD ad-break scheduler) | ✅ Transfers unchanged — still resolves uniquely to `analyzers/a.c(LuraEventData$TimeUpdate)V`; anchored in Lura's un-obfuscated `api` package. |
| `InnovidStartAdFingerprint` (Innovid overlay mount) | ❌ Broke — R8 renamed the obfuscated VideoModel param type (`…/models/video/v` → `…/models/video/t`), so the hardcoded parameter list matched no method and the patch would fail to apply. |

## Fix

Re-anchor `InnovidStartAdFingerprint` on the `"innovidAd"` string constant, which occurs only inside the mount method within `InnovidHelper` (verified via disassembly). This is immune to the obfuscation drift and matches **both** `4.46.0_tv` and `4.47.2_tv`. `returnType` + `[PUBLIC, FINAL]` are kept as cheap extra constraints.

## Changes
- `vix/ads/Fingerprints.kt` — Innovid fingerprint re-anchored on `strings = listOf("innovidAd")`.
- `vix/shared/Constants.kt` — added `AppTarget("4.47.2_tv")`.
- `patches-list.json` — added `4.47.2_tv` to both ViX entries (Skip ads + Override certificate pinning).

## Verification status
⚠️ **Static/fingerprint-verified only** — confirmed by baksmali disassembly (fingerprints resolve uniquely) and by mirroring the repo's own `strings`-anchor convention. Not compiled or on-device tested in the authoring environment; on-device confirmation on 4.47.2_tv is pending. README Status table left at the last device-tested build (`4.46.0_tv`) intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013M7paaSzJv1TsKhXQbbTou)_