### PR TITLE
feat(disney): cover new DMP SGAI/SSAI VOD ad insertion pipeline

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/disney/DisneyPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/disney/DisneyPatch.kt
@@ -39,6 +39,12 @@ val disneyPatch = bytecodePatch(
         // Emptying it prevents live interstitial gating from admitting any
         // ad range and stops serialisation from writing range data.
         //
+        // Two parallel insertion containers must be emptied:
+        //   - com.dss.sdk.internal.media.Insertion       (legacy BAM-SDK)
+        //   - com.disney.dmp.internal.pbo.Insertion      (new Disney Media
+        //     Platform pipeline, v26.9.2+ — the SGAI/SSAI VOD ads the legacy
+        //     patch missed rode through here). See Fingerprints.kt.
+        //
         // Both methods are simple iget-object / return-object pairs, so
         // prepending a fresh ArrayList return at offset 0 is safe — the
         // original iget is never reached and the field is never read.
@@ -46,6 +52,8 @@ val disneyPatch = bytecodePatch(
         arrayOf(
             InsertionGetPointsFingerprint,
             InsertionGetRangesFingerprint,
+            DmpInsertionGetPointsFingerprint,
+            DmpInsertionGetRangesFingerprint,
         ).forEach { fingerprint ->
             fingerprint.method.addInstructions(
                 0,

--- a/patches/src/main/kotlin/app/morphe/patches/disney/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/disney/Fingerprints.kt
@@ -43,6 +43,34 @@ internal object InsertionGetRangesFingerprint : Fingerprint(
 )
 
 // ---------------------------------------------------------------------------
+// NEW pipeline (v26.9.2+): Disney Media Platform ("dmp") PlayBack-Orchestration
+// ("pbo") insertion container. The player migrated off the legacy DSS-SDK
+// Insertion (above) to com.disney.dmp.internal.pbo.Insertion — a @Keep Moshi
+// data class with the same getPoints()/getRanges() shape (mode = SGAI/SSAI).
+// The ad-break builder iterates getPoints(), casts each to InsertionPoint and
+// branches on `instanceof Sgai/SsaiVodInsertionPoint`; emptying getPoints()/
+// getRanges() here yields zero ad cues → no SGAI/SSAI VOD ads (pre- and mid-roll),
+// with no DNS dependency. Verified on Onn 4K TV (v26.9.2+rc1). This is why the
+// legacy-only patch still applied yet SGAI ads leaked through.
+// ---------------------------------------------------------------------------
+
+internal object DmpInsertionGetPointsFingerprint : Fingerprint(
+    returnType = "Ljava/util/List",
+    custom = { method, _ ->
+        method.name == "getPoints" &&
+            method.definingClass == "Lcom/disney/dmp/internal/pbo/Insertion;"
+    },
+)
+
+internal object DmpInsertionGetRangesFingerprint : Fingerprint(
+    returnType = "Ljava/util/List",
+    custom = { method, _ ->
+        method.name == "getRanges" &&
+            method.definingClass == "Lcom/disney/dmp/internal/pbo/Insertion;"
+    },
+)
+
+// ---------------------------------------------------------------------------
 // Pause ad fingerprint — MediaXPauseSession.started()
 //
 // Network analysis (PCAPdroid) confirmed the pause ad image is fetched from


### PR DESCRIPTION
## What

Disney+ Android TV **v26.9.2+** migrated the player to the **Disney Media Platform** (`com.disney.dmp`) stack. Its PlayBack-Orchestration (`pbo`) layer carries its own insertion container — `com.disney.dmp.internal.pbo.Insertion` — a twin of the legacy `com.dss.sdk.internal.media.Insertion` the patch already empties.

SGAI/SSAI VOD ads (pre- and mid-roll) now ride through the **new** container, so the legacy-only patch still applied but ads leaked through.

## Fix

Empty `getPoints()`/`getRanges()` on the DMP `Insertion` too, using the same proven empty-`ArrayList` prepend. The ad-break builder (`fr0/q0`, which iterates `getPoints()` and branches on `instanceof Sgai/SsaiVodInsertionPoint`) sees zero cues → schedules no breaks. No DNS dependency.

## Verification (Onn 4K Plus, v26.9.2+rc1, AGH DNS off)

- Pre-roll ads: **gone** — content plays straight through.
- Mid-roll ads: **gone**.
- No crash / VerifyError / ClassCast; app launches and plays normally.
- Confirmed the root cause via PCAPdroid (ad-pod fetch `*.ads.digital.disneyadvertising.com` is native) and dex tracing (the ad *timeline* is parsed in Java via the DMP `Insertion`, which is the reachable seam).

## Scope

Two files, additive only — extends the existing insertion loop with two fingerprints. Legacy DSS path and pause-ad patch unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
