### PR TITLE
fix(dns): correct malformed modifier separators and add a rule linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,21 @@ on:
       - main
 
 jobs:
+  lint-dns:
+    name: Lint DNS filter lists
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Lint dns/*.txt
+        run: node tools/lint-dns-rules.mjs
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/dns/prime-video.txt
+++ b/dns/prime-video.txt
@@ -1,9 +1,32 @@
 ! Prime Video — DNS Ad-Suppression Filter List
-! Version: 4.6  (2026-06-30)
+! Version: 4.7  (2026-07-14)
 ! AdGuard Home syntax. Safe-harbor allows first, then blocks.
 !
 ! Two Ad Pipelines: (1) Java/media3 ad-groups -> bytecode PATCH; (2) native SGAI ->
 ! separate ad manifests on a dedicated ad host -> THIS list. Run both together.
+!
+! ⚠️ 2026-07-14 CORRECTION: pipeline (1) is INERT on the ATV app. On-device proof
+! (static call-graph + native JNI-string scan + live logcat across 5 titles/3 prerolls)
+! showed the media3 `setAdPlaybackStates` hook NEVER fires — PV ATV routes ads through
+! the native MPB, not media3. So THIS DNS list is effectively the ONLY lever for the
+! native ATV client. (The media3 patch still matters for other apps; harmless here.)
+!
+! 2026-07-14 LIVE HOST MAP (PCAPdroid VPN capture, no root; SNI + DNS, ads-vs-noads diff):
+!   ters-sgai1.us-east-2.aiv-delivery.net  = CURRENT SGAI stitcher (was draper1/s0s7)
+!   api.us-east-1.aiv-delivery.net         = ad delivery API
+!   regolith.prime-video.amazon.dev        = PAUSE-screen ad endpoint — CONFIRMED reached
+!     (user saw a pause-ad overlay; host present in capture). Already blocked at line 56.
+!   ab8mt4dd97et.na.api.amazonvideo.com    = GetPlaybackResources (dual-use, DO NOT block)
+!   *.ta.(pop-)vod-dash.main.amazon.pv-cdn.net = video + SSAI-stitched ad segments (dual-use)
+!
+! ⚠️ DUAL-USE CAUTION (line 35, aiv-delivery.net): tonight's diff showed ters-sgai1 is
+!   contacted for EVERY title, ads or not — so it is the SGAI session host, not an
+!   ad-only host. The line-50 note claims a prior on-device test found "blocking cuts
+!   ads, content intact" (i.e. PV falls back to a clean manifest). These are in tension.
+!   Blocking MAY fall-back-clean (good) OR stall playback (bad + a loud anti-adblock tell).
+!   UNRESOLVED — needs a fresh on-device A/B before trusting line 35. Prerolls are baked
+!   server-side (mediatailor-ssai-model), so DNS is expected to be partial for prerolls;
+!   the phone app remains the preroll-free path. regolith (pause ads) is the clean win.
 !
 ! KEY DISTINCTION (confirmed by a with-ad HAR: content on pv-cdn.net + akamaized,
 ! ads on avoddashs3ww-a.akamaihd.net, zero host overlap):

--- a/dns/prime-video.txt
+++ b/dns/prime-video.txt
@@ -1,5 +1,5 @@
 ! Prime Video — DNS Ad-Suppression Filter List
-! Version: 4.7  (2026-07-14)
+! Version: 4.8  (2026-07-15)
 ! AdGuard Home syntax. Safe-harbor allows first, then blocks.
 !
 ! Two Ad Pipelines: (1) Java/media3 ad-groups -> bytecode PATCH; (2) native SGAI ->
@@ -59,7 +59,6 @@
 ! SGAI ad-media host (Akamai HD) — ads only, distinct from akamaized content
 ||*avoddashs3ww-a.akamaihd.net^$dnsrewrite=0.0.0.0
 ||*aivottevtad-a.akamaihd.net^$dnsrewrite=0.0.0.0
-||*vod-dash-pv-ta-amazon.akamaized.net^$dnsrewrite=0.0.0.0
 /^a\d+avod.*\.akamaihd\.net$/$dnsrewrite=0.0.0.0
 /^a\d+.*evtad.*\.akamaihd\.net$/$dnsrewrite=0.0.0.0
 /^a\d+.*vottevtad.*\.akamaihd\.net$/$dnsrewrite=0.0.0.0
@@ -74,8 +73,8 @@
 ! intact. Revert to @@||s0s7.api.amazonvideo.com^$important if playback stalls.
 ||s0s7.api.amazonvideo.com^$dnsrewrite=0.0.0.0
 ! Weblab ad triggers ($important beats the weblab allow above)
-||zoar.triggers-v1.prod.mobile.weblab.a2z.com^$important$dnsrewrite=0.0.0.0
-||hercule.triggers-v1.prod.mobile.weblab.a2z.com^$important$dnsrewrite=0.0.0.0
+||zoar.triggers-v1.prod.mobile.weblab.a2z.com^$important,dnsrewrite=0.0.0.0
+||hercule.triggers-v1.prod.mobile.weblab.a2z.com^$important,dnsrewrite=0.0.0.0
 ||regolith.prime-video.amazon.dev^$dnsrewrite=0.0.0.0
 
 ! ── TELEMETRY / TRACKERS (privacy; no ad-delivery impact) ─────────────────────

--- a/docs/ADGUARD_DNS_SYNTAX.md
+++ b/docs/ADGUARD_DNS_SYNTAX.md
@@ -1,0 +1,70 @@
+# AdGuard DNS rule syntax — house reference
+
+Reference for maintaining the filter lists in [`dns/`](../dns/). Validated by
+[`tools/lint-dns-rules.mjs`](../tools/lint-dns-rules.mjs) on every PR (`npm run lint:dns`).
+
+Upstream: <https://adguard-dns.io/kb/general/dns-filtering-syntax/>
+
+## The one that bites: two different engines
+
+"AdGuard" is three products with overlapping-but-unequal rule syntax:
+
+| | What it is | Our use |
+|---|---|---|
+| **AdGuard Home** | Self-hosted resolver | **This is what `dns/*.txt` targets** |
+| **AdGuard DNS** | Hosted service, rules in their Dashboard | Not used by this repo |
+| **AdGuard (browser ext.)** | Content blocker | Irrelevant — different syntax |
+
+The docs interleave all three, so **always check which engine a modifier belongs to
+before using it.** The linter enforces this.
+
+## Modifier table
+
+Rule structure: `["@@"] pattern [ "$" modifiers ]`. Per the docs, *"Modifiers must be
+located at the end of the rule after the `$` character and be separated by commas."*
+
+| Modifier | Engine | Notes |
+|---|---|---|
+| `client` | Home + DNS | IPs, CIDRs, or client names |
+| `denyallow` | both | `*$denyallow=com\|net` |
+| `dnstype` | both | `$dnstype=A\|AAAA`, `~` to exclude. Don't mix inclusion and exclusion |
+| `dnsrewrite` | both | Higher priority than other rules. In *hosted* DNS, custom rules only |
+| `important` | both | Beats exception rules; only another `$important` overrides |
+| `badfilter` | both | Does **not** work with `/etc/hosts`-style rules |
+| `ctag` | **Home only** | `device_tv`, `os_android`, `user_child`, … |
+| `respgeo` | **DNS only** | ⚠️ **Silently useless in our lists.** Country (ISO 3166-1 alpha-2), ASN (`AS15169`), `--` = unknown |
+
+`@@` = exception. `/regexp/` = regex pattern — note the regex body may itself contain
+`$`, so modifier parsing must start after the closing `/`.
+
+### Precedence
+
+`$important` allow beats a plain block. So a safe-harbor line like
+`@@||main.amazon.pv-cdn.net^$important` will override a later block rule — which is why
+a contradictory block can sit in a list looking active while doing nothing.
+
+## Gotchas we have actually hit
+
+- **`$important$dnsrewrite=…` is wrong** — modifiers separate with a **comma**, not a
+  second `$`. AdGuard Home drops malformed rules at load time *without reporting them*,
+  so the failure mode is a silently unenforced block. This is the bug the linter exists
+  to catch.
+- **Don't use `$respgeo`.** It's evaluated server-side by the hosted service. AdGuard
+  Home has no equivalent. It also can't see through a CDN — anything fronted by
+  Cloudflare/Akamai geolocates to the edge node, not the operator — and it does nothing
+  against SSAI ads baked into the content stream (i.e. Prime Video's native pipeline).
+- **Don't reach for AGLint.** `@adguard/aglint` cannot validate these lists: its
+  compatibility tables contain no AdGuard Home/DNS platform, so it flags every
+  `$dnsrewrite` as a non-existent modifier (25 false positives on `dns/prime-video.txt`)
+  while missing the comma bug entirely. Tested and rejected 2026-07-15.
+- **akamai`zed` vs akamai`hd`** (Prime Video): `akamaized.net` = content, **allow**;
+  `akamaihd.net` = ads, **block**. One character apart.
+
+## Adding a rule
+
+1. Confirm the host is ad-only, not dual-use — a dual-use block stalls playback and is a
+   loud anti-adblock tell. Capture evidence first (PCAPdroid, ads-vs-noads diff).
+2. Add it with a comment saying what it is and how you confirmed it.
+3. `npm run lint:dns`.
+4. Verify **on-device** that ads stop and content still plays — not just that the rule
+   loads. The AdGuard Home rules log shows which rule actually matched.

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "lint:dns": "node tools/lint-dns-rules.mjs"
+  },
   "devDependencies": {
     "@cleyrop-org/semantic-release-backmerge": "^5.2.4",
     "@MorpheApp/changelog": "git+https://github.com/MorpheApp/changelog.git#bundle",

--- a/tools/lint-dns-rules.mjs
+++ b/tools/lint-dns-rules.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+// Validates the AdGuard Home filter lists in dns/.
+//
+// AdGuard Home drops malformed rules at load time without reporting them, so a
+// typo silently disables a block rather than failing loudly. This checks the
+// grammar documented at
+// https://adguard-dns.io/kb/general/dns-filtering-syntax/
+//
+// Deliberately dependency-free: @adguard/aglint cannot be used here, as its
+// compatibility tables have no AdGuard Home/DNS platform and flag every
+// `$dnsrewrite` as a non-existent modifier. See docs/ADGUARD_DNS_SYNTAX.md.
+//
+// Usage: node tools/lint-dns-rules.mjs [files...]   (defaults to dns/*.txt)
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Modifier -> which engine implements it. Our lists target AdGuard Home.
+const MODIFIERS = {
+  client: 'both',
+  denyallow: 'both',
+  dnstype: 'both',
+  dnsrewrite: 'both',
+  important: 'both',
+  badfilter: 'both',
+  ctag: 'home', // AdGuard Home only
+  respgeo: 'dns', // AdGuard DNS (hosted) only — NOT valid in our lists
+};
+
+const IPV4 = /^\d{1,3}(\.\d{1,3}){3}$/;
+const IPV6 = /^[0-9a-f:]+:[0-9a-f:]*$/i;
+
+/** Split a rule into its pattern and raw modifier string. */
+function splitRule(rule) {
+  const body = rule.startsWith('@@') ? rule.slice(2) : rule;
+
+  // Regex rules: /regexp/$modifiers — the regexp itself may contain '$'.
+  if (body.startsWith('/')) {
+    const m = body.match(/^\/(.*)\/(?:\$(.*))?$/);
+    if (!m) return { error: 'unterminated regex rule (expected /regexp/)' };
+    return { regex: m[1], mods: m[2] ?? '' };
+  }
+
+  const i = body.indexOf('$');
+  return i === -1
+    ? { pattern: body, mods: '' }
+    : { pattern: body.slice(0, i), mods: body.slice(i + 1) };
+}
+
+function lintLine(rule) {
+  const problems = [];
+  const { regex, mods, error } = splitRule(rule);
+
+  if (error) return [error];
+
+  if (regex !== undefined) {
+    try {
+      new RegExp(regex);
+    } catch (e) {
+      problems.push(`invalid regex: ${e.message}`);
+    }
+  }
+
+  if (!mods) return problems;
+
+  // The docs: "Modifiers must be located at the end of the rule after the `$`
+  // character and be separated by commas." A '$' here means someone wrote
+  // `$important$dnsrewrite=...` instead of `$important,dnsrewrite=...`.
+  if (mods.includes('$')) {
+    problems.push(
+      `modifiers must be separated by commas, not '$' — found "$${mods}"`,
+    );
+    return problems;
+  }
+
+  for (const part of mods.split(',')) {
+    const raw = part.trim();
+    if (!raw) {
+      problems.push('empty modifier (stray comma)');
+      continue;
+    }
+    const name = raw.replace(/^~/, '').split('=')[0];
+    const engine = MODIFIERS[name];
+
+    if (!engine) {
+      problems.push(`unknown modifier: '${name}'`);
+    } else if (engine === 'dns') {
+      problems.push(
+        `'${name}' is AdGuard DNS (hosted) only and is not supported by ` +
+          `AdGuard Home — it will be ignored in this list`,
+      );
+    }
+  }
+  return problems;
+}
+
+function lintFile(path) {
+  const found = [];
+  const lines = readFileSync(path, 'utf8').split(/\r?\n/);
+
+  lines.forEach((line, idx) => {
+    const text = line.trim();
+    if (!text || text.startsWith('!') || text.startsWith('#')) return;
+
+    // /etc/hosts-style: "IP hostname [aliases]" — no modifier grammar.
+    const [first] = text.split(/\s+/);
+    if (/\s/.test(text) && (IPV4.test(first) || IPV6.test(first))) return;
+
+    for (const problem of lintLine(text)) {
+      found.push({ line: idx + 1, problem, text });
+    }
+  });
+  return found;
+}
+
+const files = process.argv.slice(2).length
+  ? process.argv.slice(2)
+  : readdirSync('dns')
+      .filter((f) => f.endsWith('.txt'))
+      .map((f) => join('dns', f));
+
+let total = 0;
+for (const file of files) {
+  const problems = lintFile(file);
+  if (!problems.length) continue;
+  total += problems.length;
+  console.error(`\n${file}`);
+  for (const { line, problem, text } of problems) {
+    console.error(`  ${String(line).padStart(4)}:  ${problem}`);
+    console.error(`        ${text}`);
+  }
+}
+
+if (total) {
+  console.error(`\n✗ ${total} problem(s) in ${files.length} file(s).`);
+  process.exit(1);
+}
+console.log(`✓ ${files.length} file(s) OK.`);


### PR DESCRIPTION
Started as a study of the [AdGuard DNS v2.23 release](https://adguard-dns.io/en/blog/adguard-dns-v2-23.html) and turned up two real bugs in `dns/prime-video.txt`, plus a gap worth closing mechanically.

## The bugs

**Malformed modifier separators.** The zoar/hercule weblab rules joined their modifiers with a second `$`:

```
||zoar.triggers-v1.prod.mobile.weblab.a2z.com^$important$dnsrewrite=0.0.0.0
```

The [syntax reference](https://adguard-dns.io/kb/general/dns-filtering-syntax/) is explicit: *"Modifiers must be located at the end of the rule after the `$` character and be separated by commas."* Corrected to `$important,dnsrewrite=0.0.0.0`.

This matters because AdGuard Home **drops malformed rules at load time without reporting them** — the failure mode is a silently unenforced block, not an error. If these were being dropped, the blanket `@@||*.weblab.a2z.com^` exception above them has been letting the ad triggers through.

⚠️ **Still unverified:** whether AGH was in fact dropping them. The comma form is correct regardless, but this needs a look at the AGH rules log (filter for `zoar.triggers-v1`) to confirm. Not a blocker for the fix; it does change what we believe about the list's past behaviour.

**A self-contradicting rule.** `||*vod-dash-pv-ta-amazon.akamaized.net^` was blocking a host the list's own header designates as content (`akamaiZED.net = CONTENT -> ALLOW`), directly contradicting the `$important` safe-harbor above it. The safe-harbor already won, so removing it is behaviour-neutral — it was a trap for the next reader.

## The linter

`tools/lint-dns-rules.mjs` — ~130 lines, **zero dependencies**, wired into CI as a `lint-dns` job and available as `npm run lint:dns`. It validates comma separation, known modifier names, stray commas, and regex rule syntax, and correctly handles the awkward forms already in our list (regex bodies containing `$`, `@@` exceptions, hosts-style lines).

The check I didn't anticipate: **it rejects `$respgeo`**, the new v2.23 country/ASN modifier. That modifier is hosted-AdGuard-DNS only — dropping it into our AdGuard **Home** lists would be silently ignored. `$ctag` is flagged the other way (Home-only). The docs interleave all three AdGuard products, so this engine split is easy to get wrong; now it's enforced.

Verified in both directions: passes the corrected list, and catches all five bad forms on a probe (including the exact bug above) while passing all eight valid forms.

## Why not AGLint

Evaluated `@adguard/aglint` 3.0.2 first and **rejected** it. Its compatibility tables (`@adguard/agtree`) contain **no AdGuard Home or AdGuard DNS platform** — no `dnsrewrite`, `dnstype`, `client`, `ctag`, or `respgeo` in its modifier table:

- with `invalid-modifiers` on → **25 false errors** on our list, every one `Non-existent modifier: 'dnsrewrite'`
- with it off → `No problems found`; its other rules are CSS/scriptlet checks we have none of
- and it **never flagged the comma bug** it was proposed to catch

A linter that either fails every PR for bad reasons or passes every PR for no reason. Documented in `docs/ADGUARD_DNS_SYNTAX.md` so it isn't retried.

## Commits

- `docs(dns)` — carries over the prior session's uncommitted 2026-07-14 ATV findings (notes only, no rule changes), separated out so today's fix reviews cleanly.
- `fix(dns)` — the syntax fix, the linter, CI wiring, and the house syntax reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)