### PR TITLE
fix(dns): stop blocking aiv-delivery.net — it breaks playback (#58)

### DIFF
--- a/dns/prime-video.txt
+++ b/dns/prime-video.txt
@@ -78,9 +78,14 @@
 ! s0s7: fires every ad cycle; on-device test showed blocking cuts ads, content
 ! intact. Revert to @@||s0s7.api.amazonvideo.com^$important if playback stalls.
 ||s0s7.api.amazonvideo.com^$dnsrewrite=0.0.0.0
-! Weblab ad triggers ($important beats the weblab allow above)
-||zoar.triggers-v1.prod.mobile.weblab.a2z.com^$important,dnsrewrite=0.0.0.0
-||hercule.triggers-v1.prod.mobile.weblab.a2z.com^$important,dnsrewrite=0.0.0.0
+! Weblab ad triggers (zoar / hercule) — DELIBERATELY NOT BLOCKED, pending proof.
+! These were written as `$important$dnsrewrite=...` (a `$` where a comma belongs).
+! AdGuard Home drops malformed rules silently, so they may never have been live.
+! v1.12.1 "fixed" the syntax, which would have switched two $important blocks on
+! for the first time — an untested behaviour change shipped as a cleanup.
+! Left off until an AGH query log proves (a) whether they were ever enforced and
+! (b) that enforcing them does not disturb playback. The weblab allow above covers
+! them meanwhile. Re-enable as: ||zoar…^$important,dnsrewrite=0.0.0.0
 ||regolith.prime-video.amazon.dev^$dnsrewrite=0.0.0.0
 
 ! ── TELEMETRY / TRACKERS (privacy; no ad-delivery impact) ─────────────────────

--- a/dns/prime-video.txt
+++ b/dns/prime-video.txt
@@ -1,5 +1,5 @@
 ! Prime Video — DNS Ad-Suppression Filter List
-! Version: 4.8  (2026-07-15)
+! Version: 4.9  (2026-07-15)
 ! AdGuard Home syntax. Safe-harbor allows first, then blocks.
 !
 ! Two Ad Pipelines: (1) Java/media3 ad-groups -> bytecode PATCH; (2) native SGAI ->
@@ -19,14 +19,16 @@
 !   ab8mt4dd97et.na.api.amazonvideo.com    = GetPlaybackResources (dual-use, DO NOT block)
 !   *.ta.(pop-)vod-dash.main.amazon.pv-cdn.net = video + SSAI-stitched ad segments (dual-use)
 !
-! ⚠️ DUAL-USE CAUTION (line 35, aiv-delivery.net): tonight's diff showed ters-sgai1 is
-!   contacted for EVERY title, ads or not — so it is the SGAI session host, not an
-!   ad-only host. The line-50 note claims a prior on-device test found "blocking cuts
-!   ads, content intact" (i.e. PV falls back to a clean manifest). These are in tension.
-!   Blocking MAY fall-back-clean (good) OR stall playback (bad + a loud anti-adblock tell).
-!   UNRESOLVED — needs a fresh on-device A/B before trusting line 35. Prerolls are baked
-!   server-side (mediatailor-ssai-model), so DNS is expected to be partial for prerolls;
-!   the phone app remains the preroll-free path. regolith (pause ads) is the clean win.
+! ⚠️ RESOLVED 2026-07-15 (issue #58) — aiv-delivery.net: DO NOT BLOCK.
+!   The 2026-07-14 note flagged this as UNRESOLVED: ters-sgai1 is contacted for EVERY
+!   title, ads or not, so it is the SGAI *session* host, not an ad-only host. Blocking
+!   it "MAY fall-back-clean OR stall playback" — a user report settled it: playback
+!   stalls, movies do not start at all. It is now safe-harboured below.
+!   The older "blocking cuts ads, content intact" note was wrong (or was true only for
+!   one title/region on one build). Do not re-block it on the strength of that note.
+!   Prerolls are baked server-side (mediatailor-ssai-model), so DNS is expected to be
+!   partial for prerolls; the phone app remains the preroll-free path. regolith
+!   (pause ads) is the clean win.
 !
 ! KEY DISTINCTION (confirmed by a with-ad HAR: content on pv-cdn.net + akamaized,
 ! ads on avoddashs3ww-a.akamaihd.net, zero host overlap):
@@ -39,6 +41,10 @@
 @@||qgmg.api.amazonvideo.com^$important
 @@||p7kg.api.amazonvideo.com^$important
 @@||abxc3apcastp.na-f.api.amazonvideo.com^$important
+! SGAI SESSION host — contacted for EVERY title, ads or not. Blocking it stops
+! playback entirely (issue #58). Stitcher prefixes rotate (draper1 -> s0s7 ->
+! ters-sgai1), so allow the whole domain: a narrow allow re-breaks on rotation.
+@@||aiv-delivery.net^$important
 ! Content CDNs — caught serving the movie; never block.
 @@||main.amazon.pv-cdn.net^$important
 @@/^[a-z0-9]*vod-dash-pv-ta-amazon\.akamaized\.net$/$important
@@ -54,8 +60,8 @@
 ! ── AD HOSTS (block; dnsrewrite=0.0.0.0 = fast connection-refused) ────────────
 ! Amazon ad platform (exchange / decisioning / aax)
 ||amazon-adsystem.com^$dnsrewrite=0.0.0.0
-! SGAI ad decisioning + stitchers (api / ters-sgai1 / ters-draper1 .aiv-delivery)
-||aiv-delivery.net^$dnsrewrite=0.0.0.0
+! (aiv-delivery.net is NOT blocked — it is the SGAI *session* host. See the
+!  safe harbor above and the REGRESSION note in the header.)
 ! SGAI ad-media host (Akamai HD) — ads only, distinct from akamaized content
 ||*avoddashs3ww-a.akamaihd.net^$dnsrewrite=0.0.0.0
 ||*aivottevtad-a.akamaihd.net^$dnsrewrite=0.0.0.0


### PR DESCRIPTION
Fixes the playback regression reported in #58 ("Prevents movies playing. Do not start at all.").

## Cause

`||aiv-delivery.net^$dnsrewrite=0.0.0.0` — **`ters-sgai1` is the SGAI *session* host, not an ad-only host.** The 2026-07-14 PCAPdroid capture found it is contacted for **every title, ads or not**, so blocking it kills playback session setup rather than just ads.

This was a known, documented risk. The header note added on 2026-07-14 called it out and left it explicitly UNRESOLVED:

> Blocking MAY fall-back-clean (good) OR stall playback (bad + a loud anti-adblock tell). UNRESOLVED — needs a fresh on-device A/B.

The user report is that A/B. It stalls. The older, conflicting "blocking cuts ads, content intact" note is now believed wrong — or true only for one title/region/build. The header records that so it doesn't get re-blocked on the strength of it.

Safe-harboured rather than deleted, and at the **domain** level rather than the `ters-sgai1` hostname, because the stitcher prefix rotates (`draper1` → `s0s7` → `ters-sgai1`) — a narrow allow would silently re-break on the next rotation.

This costs us whatever suppression that host provided. A stalled player is worse than an ad, and it's also a loud anti-adblock tell.

## Second commit: zoar/hercule left off

v1.12.1 corrected these from `$important$dnsrewrite=…` to `$important,dnsrewrite=…`. The syntax fix was right; **shipping it was not.** AdGuard Home drops malformed rules silently, so if it had been dropping these, that "cleanup" quietly switched two `$important` blocks on for the first time. A syntax fix that activates a dead rule is a behaviour change, and this one went out with its effect explicitly flagged as unverified.

They stay off until an AGH query log shows (a) whether they were ever enforced and (b) that enforcing them doesn't disturb playback. `@@||*.weblab.a2z.com^` covers them meanwhile. This restores the list's *effective* pre-v1.12.1 behaviour without reintroducing malformed syntax (which the linter now rejects).

Not believed to be the cause of #58 — blocking two A/B-experiment triggers is a weak mechanism for "won't start at all" — but a playback regression is not the moment to leave a second unvalidated restriction in the list.

## Safety property

Rule-level diff against **v1.12.0** (the last release before this list was touched) is *only removed blocks plus one added allow*:

```
+@@||aiv-delivery.net^$important
-||aiv-delivery.net^$dnsrewrite=0.0.0.0
-||*vod-dash-pv-ta-amazon.akamaized.net^$dnsrewrite=0.0.0.0
-||zoar.triggers-v1...^$important$dnsrewrite=0.0.0.0
-||hercule.triggers-v1...^$important$dnsrewrite=0.0.0.0
```

Strictly more permissive than v1.12.0, so it cannot play worse than the last known-good release.

## Still unverified

Not confirmed on-device — no device was attached. The decisive evidence remains the AGH query log at the moment of a failed play, which names the blocking rule. Worth asking the reporter whether this was a fresh install of the list or an upgrade from a working version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)