### PR TITLE
feat(mlbtv): HLS manifest ad-segment stripping + overlay driven by manifest markers

### DIFF
--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/mlbtv/ads/AdBreakOverlayHelper.kt
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/mlbtv/ads/AdBreakOverlayHelper.kt
@@ -13,21 +13,42 @@ import android.widget.TextView
 
 /**
  * Shows/hides a full-screen "Commercial Break in Progress" overlay over the
- * IMA SSAI ad-view-group, driven by the VideoStreamPlayer ad-break lifecycle
- * callbacks (Lb6/h$i;.onAdBreakStarted()/onAdBreakEnded() — see AtBatPatch.kt
- * Patch 5). This shields viewers from gambling ad content during live game
- * commercial breaks without touching any playback/DAI request plumbing,
- * so it carries none of the live-stream risk that blocking the SSAI session
- * outright (Patches 2/3/4) would.
+ * IMA SSAI ad-view-group during live commercial breaks, shielding viewers from
+ * gambling ad content without touching any playback/DAI request plumbing.
+ *
+ * Triggering: the PRIMARY, IMA-independent trigger is [signalAdBreak], called
+ * by [MlbManifestRewriter] whenever it sees ad markers in a live media
+ * playlist — the ground-truth signal that a break is on air. The IMA
+ * onAdBreakStarted()/onAdBreakEnded() hooks ([showOverlay]/[hideOverlay],
+ * AtBatPatch Patch 5b/5c) are kept as a secondary trigger; they were never
+ * observed firing in field tests, most likely because Patches 2/3/4 suppress
+ * the IMA machinery that emits them, which is exactly why the manifest path
+ * now drives the overlay.
  */
 object AdBreakOverlayHelper {
 
     private const val TAG = "MORPHE-MLB-ADBREAK"
 
+    /**
+     * How long after the most recent ad-break signal to auto-hide the overlay.
+     *
+     * During a live break the media playlist is re-fetched roughly every
+     * target-duration (typically 2-6s) and every fetch that still carries ad
+     * markers re-arms this timer, so the overlay stays up for the whole break
+     * and clears ~this long after manifests stop carrying ad markers (i.e.
+     * content has resumed). Sized comfortably above the playlist refresh
+     * interval so a single briefly-clean refresh mid-break can't cause flicker.
+     * This timer also protects against IMA firing onAdBreakStarted() without a
+     * matching onAdBreakEnded() — the overlay self-heals instead of sticking.
+     */
+    private const val AD_BREAK_HIDE_DELAY_MS = 10_000L
+
     private val mainHandler = Handler(Looper.getMainLooper())
 
     private var adViewGroup: ViewGroup? = null
     private var overlayView: FrameLayout? = null
+
+    private val hideRunnable = Runnable { hideOverlayNow() }
 
     @JvmStatic
     fun registerAdViewGroup(viewGroup: ViewGroup) {
@@ -35,24 +56,59 @@ object AdBreakOverlayHelper {
         Log.d(TAG, "registerAdViewGroup() — ad view group registered")
     }
 
+    /**
+     * Primary, IMA-independent ad-break trigger. Called from
+     * [MlbManifestRewriter] each time a media playlist carrying ad markers is
+     * observed. Shows the overlay (if not already shown) and (re)arms the
+     * auto-hide timer. Safe to call from any thread.
+     */
     @JvmStatic
-    fun showOverlay() {
+    fun signalAdBreak() {
         mainHandler.post {
-            val container = adViewGroup ?: return@post
-            val overlay = overlayView ?: buildOverlay(container).also { overlayView = it }
-            if (overlay.parent == null) container.addView(overlay)
-            overlay.visibility = View.VISIBLE
-            overlay.bringToFront()
-            Log.d(TAG, "showOverlay() — commercial break overlay shown")
+            showOverlayNow()
+            mainHandler.removeCallbacks(hideRunnable)
+            mainHandler.postDelayed(hideRunnable, AD_BREAK_HIDE_DELAY_MS)
         }
     }
 
+    /**
+     * Secondary trigger for IMA's onAdBreakStarted() hook (AtBatPatch Patch
+     * 5b). Routed through the same timer-armed path as [signalAdBreak] so a
+     * missing onAdBreakEnded() can't leave the overlay stuck on screen.
+     */
+    @JvmStatic
+    fun showOverlay() = signalAdBreak()
+
+    /**
+     * IMA's onAdBreakEnded() hook (AtBatPatch Patch 5c). Cancels the auto-hide
+     * timer and hides immediately.
+     */
     @JvmStatic
     fun hideOverlay() {
         mainHandler.post {
-            overlayView?.visibility = View.GONE
-            Log.d(TAG, "hideOverlay() — commercial break overlay hidden")
+            mainHandler.removeCallbacks(hideRunnable)
+            hideOverlayNow()
         }
+    }
+
+    private fun showOverlayNow() {
+        val container = adViewGroup
+        if (container == null) {
+            // If this fires during a known break, the IMA display-container
+            // path (Patch 5a) never ran — the overlay has nothing to attach to.
+            Log.w(TAG, "ad break signaled but no ad view group registered — overlay cannot be shown")
+            return
+        }
+        val overlay = overlayView ?: buildOverlay(container).also { overlayView = it }
+        if (overlay.parent == null) container.addView(overlay)
+        overlay.visibility = View.VISIBLE
+        overlay.bringToFront()
+        Log.d(TAG, "overlay shown — commercial break in progress")
+    }
+
+    private fun hideOverlayNow() {
+        overlayView?.visibility = View.GONE
+        Log.d(TAG, "overlay hidden — commercial break ended")
     }
 
     private fun buildOverlay(container: ViewGroup): FrameLayout {

--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/mlbtv/ads/MlbManifestRewriter.kt
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/mlbtv/ads/MlbManifestRewriter.kt
@@ -1,0 +1,99 @@
+package ajstrick81.morphe.extension.mlbtv.ads
+
+import android.net.Uri
+import android.util.Log
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+
+/**
+ * Rewrites HLS playlists fetched by Media3's OkHttpDataSource (Lr5/a; in the
+ * obfuscated MLB At Bat dex) to strip live SSAI/DAI ad segments before
+ * ExoPlayer ever parses them.
+ *
+ * Why this exists: blocking the IMA SDK's own DAI/SSAI Java methods
+ * (AtBatPatch.kt Patches 2/3/4) does NOT stop dclk_video_ads segments from
+ * being fetched during live games — confirmed via logcat against v1.5.1.
+ * The ad segments are stitched directly into the HLS manifest server-side,
+ * so the player just sequentially requests whatever the manifest lists,
+ * with no client-side "ad request" call to intercept. The only place left
+ * to act is the manifest text itself, before ExoPlayer's HLS parser reads it.
+ *
+ * [wrap] is called from injected smali at the exact point where the data
+ * source assigns the raw response InputStream to its `k` field — right
+ * after the network read, before anything parses it. The `dataSpec`
+ * parameter is passed through as `Any` (its real type, Lq5/i;, is obfuscated
+ * and unavailable to this module at compile time); its Uri is pulled out via
+ * reflection rather than by adding a smali register to extract it first,
+ * which avoids any register-liveness risk in the injected call site.
+ */
+object MlbManifestRewriter {
+
+    private const val TAG = "MORPHE-MLB-MANIFEST"
+
+    private val AD_MARKERS = listOf(
+        "dclk_video_ads",
+        "doubleclick.net",
+        "googlesyndication.com",
+    )
+
+    @JvmStatic
+    fun wrap(dataSpec: Any, stream: InputStream): InputStream {
+        val uri = extractUri(dataSpec) ?: return stream
+        val path = uri.toString()
+        if (!path.contains(".m3u8")) return stream
+
+        val bytes = stream.readBytes()
+        val text = bytes.toString(Charsets.UTF_8)
+        if (AD_MARKERS.none { text.contains(it) }) {
+            return ByteArrayInputStream(bytes)
+        }
+
+        val rewritten = stripAdSegments(text)
+        Log.d(TAG, "stripped ad segments from manifest: $path")
+        return ByteArrayInputStream(rewritten.toByteArray(Charsets.UTF_8))
+    }
+
+    private fun extractUri(dataSpec: Any): Uri? = try {
+        dataSpec.javaClass.fields
+            .firstOrNull { it.type == Uri::class.java }
+            ?.apply { isAccessible = true }
+            ?.get(dataSpec) as? Uri
+    } catch (t: Throwable) {
+        Log.w(TAG, "failed to read DataSpec uri via reflection", t)
+        null
+    }
+
+    /**
+     * Drops any #EXTINF segment line (and its preceding tags, up to the
+     * previous segment or the start of the playlist) whose URI matches a
+     * known ad marker. Anything that isn't an ad segment — including
+     * #EXT-X-DISCONTINUITY/#EXT-X-KEY/etc tags attached to real segments —
+     * is left untouched, since removing unrelated tags could desync the
+     * player's segment timeline.
+     */
+    private fun stripAdSegments(playlist: String): String {
+        val lines = playlist.split("\n")
+        val output = ArrayList<String>(lines.size)
+        var pendingTags = ArrayList<String>()
+
+        for (line in lines) {
+            val trimmed = line.trim()
+            when {
+                trimmed.isEmpty() || trimmed.startsWith("#") -> {
+                    pendingTags.add(line)
+                }
+                AD_MARKERS.any { trimmed.contains(it) } -> {
+                    // Ad segment URI — discard it and every tag queued for it.
+                    pendingTags = ArrayList()
+                }
+                else -> {
+                    output.addAll(pendingTags)
+                    output.add(line)
+                    pendingTags = ArrayList()
+                }
+            }
+        }
+        output.addAll(pendingTags)
+        return output.joinToString("\n")
+    }
+}

--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/mlbtv/ads/MlbManifestRewriter.kt
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/mlbtv/ads/MlbManifestRewriter.kt
@@ -30,11 +30,25 @@ object MlbManifestRewriter {
 
     private const val TAG = "MORPHE-MLB-MANIFEST"
 
-    private val AD_MARKERS = listOf(
+    /**
+     * Ad-segment URI substrings. Segments whose URI contains one of these are
+     * physically removed from the playlist by [stripAdSegments]. Confirmed
+     * present in MLB's live manifests via logcat (dclk_video_ads).
+     */
+    private val SEGMENT_AD_MARKERS = listOf(
         "dclk_video_ads",
         "doubleclick.net",
         "googlesyndication.com",
     )
+
+    /**
+     * Vendor-neutral HLS / SCTE-35 ad-break signaling tag matching a DATERANGE
+     * row flagged as an ad. Used only to DETECT an active break (to drive the
+     * overlay), not to strip — removing a DATERANGE without the segments it
+     * brackets could desync the player timeline.
+     */
+    private val DATERANGE_AD_REGEX =
+        Regex("#EXT-X-DATERANGE:[^\\n]*CLASS=\"ad", RegexOption.IGNORE_CASE)
 
     @JvmStatic
     fun wrap(dataSpec: Any, stream: InputStream): InputStream {
@@ -44,13 +58,34 @@ object MlbManifestRewriter {
 
         val bytes = stream.readBytes()
         val text = bytes.toString(Charsets.UTF_8)
-        if (AD_MARKERS.none { text.contains(it) }) {
+        if (!containsAdBreakMarkers(text)) {
             return ByteArrayInputStream(bytes)
         }
 
+        // Ground-truth ad-break signal. A live media playlist actually carrying
+        // ad markers is the most reliable indication a commercial break is on
+        // air — far more dependable than IMA's onAdBreakStarted() callback,
+        // which was never observed firing. Drive the "Commercial Break in
+        // Progress" overlay straight off it so it appears mid-inning even when
+        // the IMA callback path is dead. See AdBreakOverlayHelper.
+        AdBreakOverlayHelper.signalAdBreak()
+
         val rewritten = stripAdSegments(text)
-        Log.d(TAG, "stripped ad segments from manifest: $path")
+        Log.d(TAG, "ad break detected; stripped ad segments from manifest: $path")
         return ByteArrayInputStream(rewritten.toByteArray(Charsets.UTF_8))
+    }
+
+    /**
+     * True if this playlist looks like it carries an active ad break. Covers
+     * both MLB's concrete ad-segment URIs and the standard HLS/SCTE-35 markers
+     * a break is delimited with, so the overlay still triggers if the segment
+     * domains ever change. #EXT-X-CUE-OUT also matches #EXT-X-CUE-OUT-CONT; the
+     * bare #EXT-X-CUE-IN (break END) is intentionally not treated as active.
+     */
+    private fun containsAdBreakMarkers(text: String): Boolean {
+        if (SEGMENT_AD_MARKERS.any { text.contains(it) }) return true
+        if (text.contains("#EXT-X-CUE-OUT")) return true
+        return DATERANGE_AD_REGEX.containsMatchIn(text)
     }
 
     private fun extractUri(dataSpec: Any): Uri? = try {
@@ -82,7 +117,7 @@ object MlbManifestRewriter {
                 trimmed.isEmpty() || trimmed.startsWith("#") -> {
                     pendingTags.add(line)
                 }
-                AD_MARKERS.any { trimmed.contains(it) } -> {
+                SEGMENT_AD_MARKERS.any { trimmed.contains(it) } -> {
                     // Ad segment URI — discard it and every tag queued for it.
                     pendingTags = ArrayList()
                 }

--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/mlbtv/ads/MlbManifestRewriter.kt
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/mlbtv/ads/MlbManifestRewriter.kt
@@ -31,6 +31,17 @@ object MlbManifestRewriter {
     private const val TAG = "MORPHE-MLB-MANIFEST"
 
     /**
+     * Info-gathering switch. When true, [wrap] logs a one-line census of the
+     * ad-signaling markers found in each media playlist (see [logMarkerCensus]).
+     * This is how we replace guesswork about MLB's manifest with fact: a single
+     * `adb logcat -s $TAG` during a live break tells us exactly which of
+     * CUE-OUT / DISCONTINUITY / DATERANGE / dclk MLB's DAI actually emits — the
+     * open question the SCTE-35 / producer-side research left unanswered. Flip
+     * to false to silence it; it changes no playback behavior either way.
+     */
+    private const val LOG_MARKER_CENSUS = true
+
+    /**
      * Ad-segment URI substrings. Segments whose URI contains one of these are
      * physically removed from the playlist by [stripAdSegments]. Confirmed
      * present in MLB's live manifests via logcat (dclk_video_ads).
@@ -50,6 +61,8 @@ object MlbManifestRewriter {
     private val DATERANGE_AD_REGEX =
         Regex("#EXT-X-DATERANGE:[^\\n]*CLASS=\"ad", RegexOption.IGNORE_CASE)
 
+    private const val TAG_DISCONTINUITY = "#EXT-X-DISCONTINUITY"
+
     @JvmStatic
     fun wrap(dataSpec: Any, stream: InputStream): InputStream {
         val uri = extractUri(dataSpec) ?: return stream
@@ -58,6 +71,9 @@ object MlbManifestRewriter {
 
         val bytes = stream.readBytes()
         val text = bytes.toString(Charsets.UTF_8)
+
+        if (LOG_MARKER_CENSUS) logMarkerCensus(path, text)
+
         if (!containsAdBreakMarkers(text)) {
             return ByteArrayInputStream(bytes)
         }
@@ -71,7 +87,6 @@ object MlbManifestRewriter {
         AdBreakOverlayHelper.signalAdBreak()
 
         val rewritten = stripAdSegments(text)
-        Log.d(TAG, "ad break detected; stripped ad segments from manifest: $path")
         return ByteArrayInputStream(rewritten.toByteArray(Charsets.UTF_8))
     }
 
@@ -81,6 +96,11 @@ object MlbManifestRewriter {
      * a break is delimited with, so the overlay still triggers if the segment
      * domains ever change. #EXT-X-CUE-OUT also matches #EXT-X-CUE-OUT-CONT; the
      * bare #EXT-X-CUE-IN (break END) is intentionally not treated as active.
+     *
+     * Note: a bare #EXT-X-DISCONTINUITY is deliberately NOT a trigger here — it
+     * marks any timeline break (codec/PID/timestamp change), not specifically an
+     * ad, so it would false-fire the overlay. Discontinuity is used only for the
+     * census and for cleaning up the strip (see [stripAdSegments]).
      */
     private fun containsAdBreakMarkers(text: String): Boolean {
         if (SEGMENT_AD_MARKERS.any { text.contains(it) }) return true
@@ -99,17 +119,67 @@ object MlbManifestRewriter {
     }
 
     /**
+     * Emits a one-line census of ad-signaling markers for a media playlist, so
+     * a field-test logcat reveals exactly what MLB's DAI puts in the manifest.
+     * Skips the master playlist and pure-content media playlists (nothing
+     * informative to report) to keep the log readable.
+     */
+    private fun logMarkerCensus(path: String, text: String) {
+        var segments = 0
+        var adSegments = 0
+        var discontinuity = 0
+        var discontinuitySeq = 0
+        var cueOut = 0
+        var cueIn = 0
+
+        for (raw in text.split("\n")) {
+            val line = raw.trim()
+            when {
+                line.startsWith("#EXTINF") -> segments++
+                line.startsWith("#EXT-X-DISCONTINUITY-SEQUENCE") -> discontinuitySeq++
+                line == TAG_DISCONTINUITY -> discontinuity++
+                line.startsWith("#EXT-X-CUE-OUT") -> cueOut++
+                line.startsWith("#EXT-X-CUE-IN") -> cueIn++
+                line.isNotEmpty() && !line.startsWith("#") &&
+                    SEGMENT_AD_MARKERS.any { line.contains(it) } -> adSegments++
+            }
+        }
+        val dateRangeAd = DATERANGE_AD_REGEX.findAll(text).count()
+
+        // Only log playlists that carry at least one signal worth studying.
+        if (adSegments == 0 && discontinuity == 0 && cueOut == 0 && cueIn == 0 && dateRangeAd == 0) {
+            return
+        }
+        Log.d(
+            TAG,
+            "manifest census: segments=$segments adSegments=$adSegments " +
+                "discontinuity=$discontinuity discontinuitySeq=$discontinuitySeq " +
+                "cueOut=$cueOut cueIn=$cueIn dateRangeAd=$dateRangeAd :: $path",
+        )
+    }
+
+    /**
      * Drops any #EXTINF segment line (and its preceding tags, up to the
      * previous segment or the start of the playlist) whose URI matches a
      * known ad marker. Anything that isn't an ad segment — including
-     * #EXT-X-DISCONTINUITY/#EXT-X-KEY/etc tags attached to real segments —
-     * is left untouched, since removing unrelated tags could desync the
-     * player's segment timeline.
+     * #EXT-X-KEY/etc tags attached to real segments — is left untouched, since
+     * removing unrelated tags could desync the player's segment timeline.
+     *
+     * DISCONTINUITY handling: an ad break is normally bracketed by a
+     * #EXT-X-DISCONTINUITY on each side (content→ad, ad→content). Removing the
+     * ad segments already drops the opening bracket (it rides in the ad
+     * segment's pending tags); the closing bracket is kept, so one discontinuity
+     * remains where the break was. That is deliberately conservative — a spare
+     * discontinuity costs at most a decoder reset, whereas a missing one that
+     * was actually needed causes a hard timeline desync. As a safety net,
+     * [collapseAdjacentDiscontinuities] removes any *consecutive* duplicates
+     * that back-to-back break removal could leave behind.
      */
     private fun stripAdSegments(playlist: String): String {
         val lines = playlist.split("\n")
         val output = ArrayList<String>(lines.size)
         var pendingTags = ArrayList<String>()
+        var removedSegments = 0
 
         for (line in lines) {
             val trimmed = line.trim()
@@ -120,6 +190,7 @@ object MlbManifestRewriter {
                 SEGMENT_AD_MARKERS.any { trimmed.contains(it) } -> {
                     // Ad segment URI — discard it and every tag queued for it.
                     pendingTags = ArrayList()
+                    removedSegments++
                 }
                 else -> {
                     output.addAll(pendingTags)
@@ -129,6 +200,31 @@ object MlbManifestRewriter {
             }
         }
         output.addAll(pendingTags)
-        return output.joinToString("\n")
+
+        val collapsed = collapseAdjacentDiscontinuities(output)
+        Log.d(TAG, "stripped $removedSegments ad segment(s) from manifest")
+        return collapsed.joinToString("\n")
+    }
+
+    /**
+     * Removes a #EXT-X-DISCONTINUITY line whenever the previous non-blank line
+     * is also a #EXT-X-DISCONTINUITY, so ad removal can never leave two
+     * discontinuities in a row (which the player would read as two timeline
+     * breaks and could over-reset the decoder on).
+     */
+    private fun collapseAdjacentDiscontinuities(lines: List<String>): List<String> {
+        val result = ArrayList<String>(lines.size)
+        var lastNonBlankWasDiscontinuity = false
+        for (line in lines) {
+            val trimmed = line.trim()
+            if (trimmed == TAG_DISCONTINUITY && lastNonBlankWasDiscontinuity) {
+                continue
+            }
+            result.add(line)
+            if (trimmed.isNotEmpty()) {
+                lastNonBlankWasDiscontinuity = trimmed == TAG_DISCONTINUITY
+            }
+        }
+        return result
     }
 }

--- a/extensions/proguard-rules.pro
+++ b/extensions/proguard-rules.pro
@@ -60,3 +60,10 @@
     public static void showOverlay();
     public static void hideOverlay();
 }
+
+# MLB At Bat — Patch 6: HLS manifest ad-segment stripper. Called directly
+# from injected smali via invoke-static {} in Lr5/a;.f(Lq5/i;)J, right after
+# the network response InputStream is obtained.
+-keep class ajstrick81.morphe.extension.mlbtv.ads.MlbManifestRewriter {
+    public static java.io.InputStream wrap(java.lang.Object, java.io.InputStream);
+}

--- a/patches/src/main/kotlin/app/morphe/patches/mlbtv/AtBatFingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/mlbtv/AtBatFingerprints.kt
@@ -44,7 +44,10 @@
 package app.morphe.patches.mlbtv
 
 import app.morphe.patcher.Fingerprint
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.iface.reference.StringReference
 
 // ---------------------------------------------------------------------------
 // Patch 1a: VOD SSAI — createVodStreamRequest (3-arg)
@@ -203,5 +206,45 @@ internal object AdBreakEndedFingerprint : Fingerprint(
         method.name == "onAdBreakEnded" &&
             method.parameterTypes.isEmpty() &&
             method.implementation != null
+    },
+)
+
+// ---------------------------------------------------------------------------
+// Patch 6: HLS Manifest Ad-Segment Stripping — Lr5/a;.f(Lq5/i;)J
+//
+// VERIFIED via androguard dex analysis of this build: Lr5/a; is Media3's
+// OkHttpDataSource — its <clinit> calls Ll5/r;.a("media3.datasource.okhttp"),
+// a literal androidx.media3 telemetry tag string that ships unobfuscated
+// with the library and is stable across app rebuilds, unlike the renamed
+// class/method names around it.
+//
+// f(Lq5/i;)J is OkHttpDataSource.open(DataSpec): it issues the network
+// request and stores the resulting InputStream into the data source's
+// `k` field. This is the actual fetch path for both the HLS manifest and
+// every media segment (live and VOD) — confirmed empirically that the
+// IMA SDK method-blocks in Patches 2/3/4 do NOT stop dclk_video_ads
+// segments from being fetched here, because they're stitched into the
+// manifest server-side rather than requested via a separate client-side
+// "ad request" call.
+//
+// Matched by: method name "f", single parameter (the DataSpec), and the
+// class-level "media3.datasource.okhttp" <clinit> string, rather than any
+// obfuscated name — keeping this fingerprint stable across rebuilds even
+// though Lr5/a;'s own member names are renamed per-build by R8.
+// ---------------------------------------------------------------------------
+
+internal object OkHttpDataSourceOpenFingerprint : Fingerprint(
+    returnType = "J",
+    custom = { method, classDef ->
+        method.name == "f" &&
+            method.parameterTypes.size == 1 &&
+            classDef.methods.any { candidate ->
+                candidate.name == "<clinit>" &&
+                    candidate.implementation?.instructions?.any { instruction ->
+                        instruction.opcode == Opcode.CONST_STRING &&
+                            ((instruction as ReferenceInstruction).reference as? StringReference)
+                                ?.string == "media3.datasource.okhttp"
+                    } == true
+            }
     },
 )

--- a/patches/src/main/kotlin/app/morphe/patches/mlbtv/AtBatPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/mlbtv/AtBatPatch.kt
@@ -8,35 +8,41 @@
  * Coverage:
  *   ✅ VOD ads              — createVodStreamRequest() empty zzdm →
  *                             IMA SDK throws → fallback to pre-cached CDN URL
- *   ✅ SSAI media source    — Lb6/h;.b0() blocked → no SSAI startup →
- *                             requestStream() never called → no DAI manifest URL
- *   ✅ DAI StreamManager    — Lb6/h;.m0() blocked → no ad segment scheduling
- *   ✅ TXXX dispatch        — Lu70/i;.onMetadata() blocked → no MLB EVI/IMA cues
+ *   🧪 SSAI media source    — Lb6/h;.b0() blocked (no confirmed effect on
+ *                             live ad segments — see status note)
+ *   🧪 DAI StreamManager    — Lb6/h;.m0() blocked (same caveat as above)
+ *   🧪 TXXX dispatch        — Lu70/i;.onMetadata() blocked (same caveat)
  *   🧪 Commercial-break overlay — hooks onAdBreakStarted()/onAdBreakEnded()
  *                             to show/hide a full-screen overlay (Patch 5).
- *                             RE-ENABLED ALONGSIDE Patches 2/3/4 for field
- *                             testing — see note below.
+ *                             Never observed firing in two field tests so far.
+ *   🧪 HLS manifest ad-segment stripping (Patch 6) — rewrites the .m3u8
+ *                             playlist itself to drop dclk_video_ads
+ *                             segments before ExoPlayer parses them.
+ *                             Not yet field-tested.
  *
  * STATUS NOTE (this revision):
  *
- *   A prior revision disabled Patches 2/3/4 (blocking the SSAI session,
- *   DAI StreamManager, and TXXX metadata dispatch outright) in favor of
- *   Patch 5's overlay, reasoning that blocking SSAI was unconfirmed-safe
- *   for live games. A logcat capture was taken to validate this — but it
- *   was mistakenly captured against v1.4.107, a build that predates Patch
- *   5 entirely, so it only confirmed v1.4.107's pre-existing behavior
- *   (Patches 2/3/4 active, no overlay code present) and proved nothing
- *   about whether Patch 5 actually works.
+ *   Two logcat captures against builds with Patches 2/3/4 active (most
+ *   recently v1.5.1, confirmed against app v26.8.1.1) both showed
+ *   dclk_video_ads segments STILL being fetched during live ad breaks —
+ *   36 occurrences in the second capture — and the Patch 5 overlay never
+ *   firing, with no crashes either time. This falsifies the original theory
+ *   that blocking Lb6/h;.b0()/m0() would prevent requestStream() and thus
+ *   prevent ad segment fetching: live SSAI/DAI ad segments are stitched
+ *   directly into the HLS manifest server-side, so the player just
+ *   sequentially requests whatever the manifest lists — there's no
+ *   client-side "ad request" call gating segment fetches for IMA SDK
+ *   method-blocking to intercept.
  *
- *   Patches 2/3/4 are re-enabled here and Patch 5 is left active as well,
- *   so the next field test (logcat against THIS build) can determine:
- *     - whether Patches 2/3/4 cause any live-playback regressions, and
- *     - whether onAdBreakStarted()/onAdBreakEnded() ever fire once the
- *       SSAI session itself is blocked (they may not — Patch 2/3 prevent
- *       Lb6/h$g; construction, which is plausibly upstream of however
- *       those callbacks get invoked — but this needs to be confirmed by
- *       logcat rather than assumed).
- *   Update this note once results come back.
+ *   Patch 6 is the pivot: rather than blocking IMA SDK methods, it rewrites
+ *   the manifest text itself at the data-source level (Lr5/a;.f(), Media3's
+ *   OkHttpDataSource.open()) — see AtBatFingerprints.kt and
+ *   MlbManifestRewriter.kt for the full mechanism. Patches 2/3/4/5 are left
+ *   in place as belt-and-suspenders (Patch 1a/1b's VOD path and any
+ *   tracking/cue suppression they still provide), but Patch 6 is the one
+ *   actually expected to stop live ad segments. Needs a field test (logcat
+ *   against a build containing Patch 6) before that expectation is
+ *   confirmed — update this note once results come back.
  */
 
 package app.morphe.patches.mlbtv
@@ -47,6 +53,8 @@ import app.morphe.patches.shared.compat.AppCompatibilities
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 @Suppress("unused")
@@ -198,5 +206,50 @@ val atbatPatch = bytecodePatch(
                 invoke-static {}, Lajstrick81/morphe/extension/mlbtv/ads/AdBreakOverlayHelper;->hideOverlay()V
             """.trimIndent(),
         )
+
+        // ------------------------------------------------------------------
+        // Patch 6: HLS Manifest Ad-Segment Stripping — Lr5/a;.f(Lq5/i;)J
+        //
+        // Patches 2/3/4 block the IMA SDK's own DAI/SSAI Java methods, but
+        // logcat against v1.5.1 confirmed dclk_video_ads segments are STILL
+        // fetched during live games regardless — they're stitched into the
+        // HLS manifest server-side, so there's no client-side "ad request"
+        // call left to intercept. The only remaining point of control is the
+        // manifest text itself, before ExoPlayer's HLS parser reads it.
+        //
+        // f(Lq5/i;)J is OkHttpDataSource.open(): it stores the raw response
+        // InputStream into the data source's only Ljava/io/InputStream;
+        // field right after the network read. We splice
+        // MlbManifestRewriter.wrap() in at that exact point — it passes
+        // through non-manifest fetches (segments, etc.) untouched and only
+        // rewrites .m3u8 responses that actually contain ad markers.
+        //
+        // Register safety: this reuses the InputStream register already
+        // live at the iput-object site (no new register is introduced for
+        // it) and passes the DataSpec parameter via its own untouched `p1`
+        // register — f() takes exactly one declared parameter, so `p1` is
+        // guaranteed to hold it for the lifetime of the method regardless of
+        // any internal `move-object` the method does with its own locals.
+        // The extension method itself uses reflection to pull the Uri out of
+        // the DataSpec rather than requiring its obfuscated type at the
+        // smali call site.
+        // ------------------------------------------------------------------
+        OkHttpDataSourceOpenFingerprint.method.apply {
+            val instructions = implementation!!.instructions
+            val iputStreamIndex = instructions.indexOfFirst { instruction ->
+                instruction.opcode == Opcode.IPUT_OBJECT &&
+                    ((instruction as ReferenceInstruction).reference as? FieldReference)?.type ==
+                        "Ljava/io/InputStream;"
+            }
+            val streamRegister = "v${(instructions[iputStreamIndex] as TwoRegisterInstruction).registerA}"
+
+            addInstructions(
+                iputStreamIndex,
+                """
+                    invoke-static {p1, $streamRegister}, Lajstrick81/morphe/extension/mlbtv/ads/MlbManifestRewriter;->wrap(Ljava/lang/Object;Ljava/io/InputStream;)Ljava/io/InputStream;
+                    move-result-object $streamRegister
+                """.trimIndent(),
+            )
+        }
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/mlbtv/AtBatPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/mlbtv/AtBatPatch.kt
@@ -12,9 +12,13 @@
  *                             live ad segments — see status note)
  *   🧪 DAI StreamManager    — Lb6/h;.m0() blocked (same caveat as above)
  *   🧪 TXXX dispatch        — Lu70/i;.onMetadata() blocked (same caveat)
- *   🧪 Commercial-break overlay — hooks onAdBreakStarted()/onAdBreakEnded()
- *                             to show/hide a full-screen overlay (Patch 5).
- *                             Never observed firing in two field tests so far.
+ *   🧪 Commercial-break overlay (Patch 5) — shows a full-screen overlay
+ *                             during ad breaks. Primary trigger is now the
+ *                             manifest rewriter (Patch 6), which signals an ad
+ *                             break whenever it sees ad markers in a media
+ *                             playlist; the IMA onAdBreakStarted()/
+ *                             onAdBreakEnded() hooks are kept as a backup
+ *                             (never observed firing in field tests).
  *   🧪 HLS manifest ad-segment stripping (Patch 6) — rewrites the .m3u8
  *                             playlist itself to drop dclk_video_ads
  *                             segments before ExoPlayer parses them.
@@ -169,6 +173,13 @@ val atbatPatch = bytecodePatch(
                     ((instruction as ReferenceInstruction).reference as? MethodReference)?.name ==
                         "getAdViewGroup"
             }
+            // Fail loud at patch time: a -1 here would silently make
+            // moveResultIndex 0 and register a garbage view group, leaving the
+            // overlay with nothing valid to attach to (it would never show).
+            check(getAdViewGroupIndex != -1) {
+                "SsaiDisplayContainerFingerprint matched but no getAdViewGroup() call was found — " +
+                    "the overlay's ad view group cannot be registered"
+            }
             val moveResultIndex = getAdViewGroupIndex + 1
             val adViewGroupRegister =
                 (instructions[moveResultIndex] as OneRegisterInstruction).registerA
@@ -190,9 +201,13 @@ val atbatPatch = bytecodePatch(
         }
 
         // 5b/5c — wire the no-op ad-break lifecycle callbacks to show/hide
-        // the overlay. Both bodies are a single return-void (1 register,
-        // `this`), so prepending at index 0 is unconditionally safe — no
-        // registers are live yet for the verifier to conflict over.
+        // the overlay. These are now a BACKUP trigger: the primary trigger is
+        // MlbManifestRewriter.signalAdBreak() (Patch 6), which fires off the
+        // actual manifest content and does not depend on these callbacks ever
+        // running (they never were observed firing in field tests). Both
+        // bodies are a single return-void (1 register, `this`), so prepending
+        // at index 0 is unconditionally safe — no registers are live yet for
+        // the verifier to conflict over.
         AdBreakStartedFingerprint.method.addInstructions(
             0,
             """
@@ -240,6 +255,13 @@ val atbatPatch = bytecodePatch(
                 instruction.opcode == Opcode.IPUT_OBJECT &&
                     ((instruction as ReferenceInstruction).reference as? FieldReference)?.type ==
                         "Ljava/io/InputStream;"
+            }
+            // Fail loud at patch time: a -1 here would index instructions[-1]
+            // and throw an opaque IndexOutOfBounds; surface the real cause
+            // (the manifest rewriter could not be spliced in) instead.
+            check(iputStreamIndex != -1) {
+                "OkHttpDataSourceOpenFingerprint matched but no InputStream iput-object was found — " +
+                    "the manifest rewriter cannot be spliced in"
             }
             val streamRegister = "v${(instructions[iputStreamIndex] as TwoRegisterInstruction).registerA}"
 


### PR DESCRIPTION
Cherry-picked from the stale, never-PR'd \`claude/upbeat-heisenberg-noys1i\` (dug up in the 2026-07-16 night review). Only the 3 commits genuinely new relative to current \`main\` — the rest of that branch's history is either already merged or superseded, so this is a clean pick rather than a raw branch PR.

## What it does

1. **Add MLB At Bat Patch 6: HLS manifest ad-segment stripping** — new \`MlbManifestRewriter\` that strips ad segments directly from the HLS media playlist.
2. **Drive commercial-break overlay from the manifest rewriter** — fixes a real bug: the "Commercial Break in Progress" overlay (merged earlier via #20/#21) was wired to IMA's \`onAdBreakStarted()/onAdBreakEnded()\` callbacks, but those callbacks were never observed firing in field tests once the SSAI/DAI/TXXX blocking patches were re-enabled (see 4cfcf7c) — blocking suppresses the very machinery that emits them. This commit makes the manifest rewriter (which has ground-truth evidence of ad markers) signal the overlay directly instead, with a keep-alive auto-hide timer, and broadens marker detection to vendor-neutral HLS/SCTE-35 tags (\`#EXT-X-CUE-OUT\`, \`#EXT-X-DATERANGE CLASS="ad"\`) so it keeps working if MLB's domains change.
3. **Manifest marker census + DISCONTINUITY-safe strip** — hardening pass on top.

All 3 commits applied with zero conflicts against current main (verified via a dry-run cherry-pick in an isolated worktree before pushing).

## Deliberately left out of this PR

The same source branch also had 2 HBO Max commits and 4 Peacock Layer 7 commits. Checked each individually:
- **HBO Max 7.5.0.73 compat (2 commits)** — confirmed fully redundant (zero-diff dry-run cherry-pick), already shipped via #21.
- **Peacock Layer 7 constructor-resilience commits (4 commits)** — all 4 produce real content conflicts against current main's Peacock code, which has since evolved independently (v7.6.100 support, Layer 9 restore, Layer 1-8 rollback all landed separately). Needs manual reconciliation, not a mechanical pick — left for a follow-up if still wanted.

Not device-verified — needs the usual patch/install/logcat pass before shipping per [docs/AGENT_PATCH_WORKFLOW.md](https://github.com/ajstrick81/morphe-androidtv-patches/blob/main/docs/AGENT_PATCH_WORKFLOW.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)