### PR TITLE
chore: gitignore decompiled/ app sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,9 @@ gradle-app.setting
 # Potentially copyrighted test APK
 *.apk
 
+# Decompiled app sources (copyrighted; huge; breaks GitHub compare/diff)
+decompiled/
+
 # Ignore vscode config
 .vscode/
 


### PR DESCRIPTION
Cherry-picked from the stale, never-PR'd \`claude/fork-analysis-java-94e5dn\` (dug up in the 2026-07-16 night review). That branch's only unique content over current \`main\` was this one commit — the rest of its diff was just staleness (missing infra main has gained since). Applied with zero conflicts.

Adds a \`.gitignore\` entry so decompiled/unpacked app sources (from apktool etc.) don't get accidentally tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)