### PR TITLE
fix(hbomax): support 7.7.0.78 and derive Patch 2 register dynamically

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/hbomax/HBOAdsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/hbomax/HBOAdsPatch.kt
@@ -4,6 +4,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.shared.compat.AppCompatibilities
 import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 @Suppress("unused")
 val hboAdsPatch = bytecodePatch(
@@ -31,23 +32,37 @@ val hboAdsPatch = bytecodePatch(
 
         // ─────────────────────────────────────────────────────────────────────
         // Patch 2: BoltDynamicAdFetcher$fetchNonLinearAds$1.invokeSuspend()
-        // Insert const/4 v8, 0x0 immediately after move-result-object v8
-        // following the fetchNonLinearAds call. Discards the real ad list
-        // before it reaches the coroutine collector — null != COROUTINE_SUSPENDED
-        // so if-ne branch is taken, Result.success(null) returned, no ads
-        // scheduled, no crash.
+        // Null the ad-list result immediately after move-result-object following
+        // the fetchNonLinearAds call. null != COROUTINE_SUSPENDED so the if-ne
+        // branch is taken, Result.success(null) is returned, no ads scheduled,
+        // no crash.
+        //
+        // The destination register of that move-result-object is NOT stable
+        // across builds: it was v8 on 7.5.0.73, but landed in p0/v7 on 7.7.0.78
+        // (and hard-coding v8 there would have nulled the COROUTINE_SUSPENDED
+        // sentinel instead — corrupting the suspend check). So read the actual
+        // destination register from the instruction and null THAT register,
+        // rather than hard-coding one. const/4 covers v0–v15; fall back to
+        // const/16 for the (unlikely) wider register.
         // ─────────────────────────────────────────────────────────────────────
         BoltDynamicAdFetcherInvokeSuspendFingerprint.method.apply {
-            val instructions = implementation!!.instructions
+            val instructions = implementation!!.instructions.toList()
             val moveResultIndex = instructions.indexOfFirst { instruction ->
                 val idx = instructions.indexOf(instruction)
                 instruction.opcode == Opcode.MOVE_RESULT_OBJECT &&
                     idx > 0 &&
                     instructions[idx - 1].opcode == Opcode.INVOKE_VIRTUAL_RANGE
             }
+            val resultRegister =
+                (instructions[moveResultIndex] as OneRegisterInstruction).registerA
+            val nullInstruction = if (resultRegister <= 0xF) {
+                "const/4 v$resultRegister, 0x0"
+            } else {
+                "const/16 v$resultRegister, 0x0"
+            }
             addInstructions(
                 moveResultIndex + 1,
-                "const/4 v8, 0x0",
+                nullInstruction,
             )
         }
 

--- a/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
@@ -30,6 +30,7 @@ object AppCompatibilities {
     packageName = "com.wbd.hbomax",
     appIconColor = 0xFFFFFF,
     targets = listOf(
+        AppTarget("7.7.0.78"),
         AppTarget("7.5.0.73"),
         AppTarget("7.2.0.41"),
     ),


### PR DESCRIPTION
## What

Adds HBO Max **7.7.0.78** support to the `HBO Max - Disable Ads` patch and hardens Patch 2 against per-build register reshuffling.

## Why

7.7.0.78 recompiled `BoltDynamicAdFetcher$fetchNonLinearAds$1.invokeSuspend()` so the `fetchNonLinearAds` result now lands in **`p0` (v7)** instead of **v8** (as on 7.5.0.73). The old hard-coded `const/4 v8, 0x0`:

- targets a register that doesn't exist in the now-8-register method, and
- where v8 *does* map (the param slot), it's the `COROUTINE_SUSPENDED` sentinel — nulling it corrupts the suspend check rather than the ad list.

## Fix

Read the destination register from the anchoring `move-result-object` and null **that** register (`const/4` for v0–v15, `const/16` fallback). Version-proof against future register shuffles.

## Verification

- Static: patched dex confirmed `const/4 p0, 0x0` nulls the ad-list result register.
- On-device (Onn 4K Plus, `com.wbd.hbomax` 7.7.0.78): `Applied: HBO Max - Disable Ads` with no verify error; app launches clean (no crash/VerifyError); playback stable.

Patches 1, 3, 4, 5 and Nowtilus port unchanged (P1 `write$Self` prefix-match holds; P4 accessor absent → try/catch skips, as designed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
