### PR TITLE
docs(hbomax): bump to 7.7.0.78 and warn about com.wbd.stream package confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ I'm just like you — I enjoy watching TV and movies without being bored and ann
 |-----|---------|--------|---------------|------|
 | 🟢 Disney+ | `com.disney.disneyplus` | Working | `26.9.2+rc1-2026.06.12` | 6/17/26 |
 | 🟡 Prime Video | `com.amazon.amazonvideo.livingroom` | Partial/Testing — [DNS filters](dns/README.md) required; native prerolls may still appear | `6.23.23+v15.5.0.70-armv7a` | 6/26/26 |
-| 🟢 HBO Max | `com.wbd.hbomax` | Working | `v7.5.0.73` | 6/22/26 |
+| 🟢 HBO Max | `com.wbd.hbomax` | Working | `v7.7.0.78` | 7/18/26 |
 | 🟢 Peacock | `com.peacocktv.peacockandroid` | Working — no DNS required | `v7.6.100` | 7/16/26 |
 | 🟢 Tubi | `com.tubitv` | Working | `v10.20.5000` | 5/20/26 |
 | 🟢 ViX | `com.univision.prendetv` | Working | `v4.47.2_tv` | 7/11/26 |
@@ -59,7 +59,8 @@ All patches follow the same general workflow using **Morphe Manager**:
 
 ### 🎭 HBO Max
 
-1. Open the **[HBO Max (Android TV) listing on APKMirror](https://www.apkmirror.com/apk/warnermedia-direct-llc/max-stream-hbo-tv-movies-android-tv/)** and select version **`7.5.0.73`** (or the fallback `7.2.0.41`)
+1. Open the **[HBO Max (Android TV) listing on APKMirror](https://www.apkmirror.com/apk/warnermedia-direct-llc/max-stream-hbo-tv-movies-android-tv/)** and select version **`7.7.0.78`** (or the fallback `7.5.0.73`)
+   > ⚠️ **Get the right package.** These patches target **`com.wbd.hbomax`** (the "Max: Stream HBO, TV & Movies — Android TV" listing linked above). A Google search may surface a different **`com.wbd.stream`** build — that is a *separate* app variant and the patches will **not** apply to it. Confirm the download shows package `com.wbd.hbomax` before patching.
 2. Download the `.apkm` file
 3. Select it in Morphe Manager
 4. Apply the patch


### PR DESCRIPTION
## What

- Bumps the HBO Max **Tested Version** to `v7.7.0.78` (dated 7/18/26) in the status table and download step — matching the patch support shipped in **v1.12.3** (#63).
- Adds a warning callout in the HBO Max download steps about package confusion.

## Why the warning

A Google search for the HBO Max Android TV APK can surface a **`com.wbd.stream`** build, which is a *separate app variant*. Our patches target **`com.wbd.hbomax`**, so the `stream` package won't patch and silently confuses users. The callout tells them to confirm the package before downloading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
