### PR TITLE
fix(dns): stop telling users to block aiv-delivery.net (#58)

### DIFF
--- a/dns/README.md
+++ b/dns/README.md
@@ -83,11 +83,21 @@ Pi-hole does not parse `$dnsrewrite`/`$important`. Two options:
 - **Adlist (ABP mode):** enable Pi-hole's ABP-style adlist support, then the
   plain `||host^` rules are honored; strip the `$...` modifiers.
 - **Regex/exact:** translate the key rules manually, e.g.
-  - Block: `amazon-adsystem.com`, `aiv-delivery.net`,
-    `zoar.triggers-v1.prod.mobile.weblab.a2z.com`
-  - Allowlist (critical): `atv-ps.amazon.com`, `vod-dash.main.amazon.pv-cdn.net`,
-    `vod-dash-pv-ta-amazon.akamaized.net`, `aux.pv-cdn.net` (subtitles +
-    trickplay), `aiv-cdn.net`, `images-na.ssl-images-amazon.com`, `m.media-amazon.com`
+  - Block: `amazon-adsystem.com` and the Akamai **HD** ad hosts
+    (`avoddashs3ww-a.akamaihd.net`, `aivottevtad-a.akamaihd.net`, `*evtad*.akamaihd.net`).
+  - Allowlist (critical): **`aiv-delivery.net` — all regions** (this is the SGAI
+    *session* host, contacted for every title; blocking any region, e.g.
+    `api.eu-west-1.aiv-delivery.net` for EU or `api.us-east-1.aiv-delivery.net` for
+    NA, **stops playback entirely** — issue #58). Also: `atv-ps.amazon.com`,
+    `vod-dash.main.amazon.pv-cdn.net`, `vod-dash-pv-ta-amazon.akamaized.net`,
+    `aux.pv-cdn.net` (subtitles + trickplay), `aiv-cdn.net`,
+    `images-na.ssl-images-amazon.com`, `m.media-amazon.com`
+
+> ⚠️ **Do not block `aiv-delivery.net`.** Earlier versions of this guide (and the
+> v3.6 list) listed it under *Block* — that is what breaks playback. It is now a
+> permanent allow. If ads still play after allowing it, they are SSAI-baked
+> (server-stitched); DNS cannot remove those — use the bytecode patch or the
+> phone-app route.
 
 > The `threeplr*`/`nit*` prefix rules need wildcard/regex support; in Pi-hole use
 > a regex blacklist: `^(threeplr|nit)[a-z0-9.-]*\.api\.amazonvideo\.com$`.
@@ -95,10 +105,19 @@ Pi-hole does not parse `$dnsrewrite`/`$important`. Two options:
 ## Verifying it works
 
 - **DNS side:** watch your resolver log during playback. You want
-  `aiv-delivery.net` / `amazon-adsystem.com` **blocked**, and `amazonvideo.com` /
-  `*.pv-cdn.net` content hosts **allowed**.
-- **If a title stalls / black-screens:** you are likely on a native-road SGAI
-  title and the stitcher block is too aggressive — narrow `||aiv-delivery.net^`
-  to `||api.us-east-1.aiv-delivery.net^` (see the inline note in the list).
+  `amazon-adsystem.com` and the `*evtad*.akamaihd.net` ad hosts **blocked**, and the
+  content/session hosts **allowed** — `amazonvideo.com`, `*.pv-cdn.net`, and
+  crucially **`aiv-delivery.net` (all regions)**. `aiv-delivery.net` is the SGAI
+  *session* host contacted for every title: if it shows **blocked**, playback will
+  not start (issue #58).
+- **If a title stalls / black-screens and `aiv-delivery.net` (e.g.
+  `api.eu-west-1.aiv-delivery.net`) shows blocked** even though this list allows it:
+  a rule from **another subscribed blocklist is overriding the allow**. Fix the
+  precedence — put the safe-harbor allows in **User Rules**, which outrank every
+  subscribed list:
+  - **AdGuard Home:** *Filters → Custom filtering rules*, paste
+    `@@||aiv-delivery.net^$important` (and the other `@@…$important` lines).
+  - **Pi-hole:** add `aiv-delivery.net` (and the other critical hosts above) to the
+    **Allowlist**, which always wins over adlists.
 - **Patch side:** with DNS blocking **off**, `logcat | grep -i skipads` during an
   ad title tells you whether the Java-road hooks are firing.

--- a/dns/prime-video.txt
+++ b/dns/prime-video.txt
@@ -1,5 +1,7 @@
 ! Prime Video — DNS Ad-Suppression Filter List
-! Version: 4.9  (2026-07-15)
+! Version: 4.10 (2026-07-19)  — doc/regional clarity: aiv-delivery.net allow is
+!   domain-wide (covers api.eu-west-1 EU + all regions); README no longer tells
+!   users to block it (issue #58 follow-up).
 ! AdGuard Home syntax. Safe-harbor allows first, then blocks.
 !
 ! Two Ad Pipelines: (1) Java/media3 ad-groups -> bytecode PATCH; (2) native SGAI ->
@@ -13,7 +15,10 @@
 !
 ! 2026-07-14 LIVE HOST MAP (PCAPdroid VPN capture, no root; SNI + DNS, ads-vs-noads diff):
 !   ters-sgai1.us-east-2.aiv-delivery.net  = CURRENT SGAI stitcher (was draper1/s0s7)
-!   api.us-east-1.aiv-delivery.net         = ad delivery API
+!   api.us-east-1.aiv-delivery.net         = ad delivery API (NA)
+!   api.eu-west-1.aiv-delivery.net         = same, EU region (issue #58 reporter). The
+!     safe-harbor allow below is domain-wide (@@||aiv-delivery.net^) so it covers EVERY
+!     region — never narrow it to one region or you break playback elsewhere.
 !   regolith.prime-video.amazon.dev        = PAUSE-screen ad endpoint — CONFIRMED reached
 !     (user saw a pause-ad overlay; host present in capture). Already blocked at line 56.
 !   ab8mt4dd97et.na.api.amazonvideo.com    = GetPlaybackResources (dual-use, DO NOT block)


### PR DESCRIPTION
## Problem

Issue #58 reporter (EU) applied the list with the `aiv-delivery.net` allow but **playback still won't start**, and `api.eu-west-1.aiv-delivery.net` shows **blocked** in their stats.

Root cause is in `dns/README.md`, not the list. The list correctly safe-harbors `aiv-delivery.net` (`@@||aiv-delivery.net^$important`) — it's the SGAI **session** host contacted for every title, so blocking any region stops playback. But the README was never updated after the #58 fix and still tells users to **block** it:

- **Pi-hole translation:** listed `aiv-delivery.net` under *Block*.
- **"Verifying it works":** "You want `aiv-delivery.net` … **blocked**", and advised narrowing the allow to `api.us-east-1` — which breaks EU users (`api.eu-west-1`).

Anyone following the README kills playback.

## Fix (docs only, behaviour-safe — no new blocks)

- Move `aiv-delivery.net` from **Block** → **Allowlist (all regions)**; flip the verification note; drop the region-narrowing advice; add an explicit "do not block" callout.
- Add **User-Rules precedence** guidance: an `$important` allow can still lose to another subscribed blocklist (e.g. HaGeZi). Putting the safe-harbor allows in AdGuard Home *Custom filtering rules* / Pi-hole *Allowlist* makes them win — the likely reason the reporter still saw it blocked.
- Document `api.eu-west-1` (EU) in the list host map; note the allow is domain-wide across all regions; bump to v4.10.

The other hosts the reporter listed (`app-measurement.com`, `unagi-*`, `global.telemetry.insights…`, `minerva…`) are telemetry-only and safe to leave blocked — not the cause.

Closes #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)