### PR TITLE
feat(tubi): bump target to 10.28.5000

### DIFF
--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/tubi/ads/Fingerprints.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/tubi/ads/Fingerprints.kt
@@ -65,13 +65,18 @@ object FoxImaLiveStreamRequestFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC)
 )
 
-// Hook 7 — xo/C$c.shouldInterceptRequest(WebView, WebResourceRequest)
+// Hook 7 — Po/C$c.shouldInterceptRequest(WebView, WebResourceRequest)
 //
 // Intercepts WebView XHR/fetch requests and blocks ad domains. Cannot
 // intercept media element (<video> src) requests — those are blocked at
 // DNS layer via AGH rules.
+//
+// Class is the TvWebFragment.kt WebViewClient (source-confirmed). R8 renames
+// its outer prefix each release: xo (10.20) → yo (10.21) → Po (10.28). NOTE a
+// second class (Ml/w1$c, WebViewFragment.kt) also has this exact signature, so
+// a pure signature match would be ambiguous — keep the class pinned.
 object TubiWebClientInterceptFingerprint : Fingerprint(
-    definingClass = "Lxo/C\$c;",
+    definingClass = "LPo/C\$c;",
     name = "shouldInterceptRequest",
     parameters = listOf(
         "Landroid/webkit/WebView;",
@@ -81,7 +86,7 @@ object TubiWebClientInterceptFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC)
 )
 
-// Hook 8 — xo/C$c.onPageFinished(WebView, String)
+// Hook 8 — Po/C$c.onPageFinished(WebView, String)
 //
 // JavaScript fetch override injection. Fires after the SPA at
 // ott-androidtv.tubitv.com has fully loaded, before the user selects
@@ -95,7 +100,7 @@ object TubiWebClientInterceptFingerprint : Fingerprint(
 // Uses window.__tubiAdBlockInstalled guard to ensure idempotency if
 // onPageFinished fires multiple times in a session.
 object TubiWebClientPageFinishedFingerprint : Fingerprint(
-    definingClass = "Lxo/C\$c;",
+    definingClass = "LPo/C\$c;",
     name = "onPageFinished",
     parameters = listOf(
         "Landroid/webkit/WebView;",
@@ -105,16 +110,18 @@ object TubiWebClientPageFinishedFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC)
 )
 
-// Hook 9 — qf/c.suspendGetAdBreaks(String, String, String, Map, Continuation)
+// Hook 9 — sf/c.suspendGetAdBreaks(String, String, String, Map, Continuation)
 //
-// Rainmaker ad-break fetch coroutine. Confirmed via classes7.dex analysis:
-// returns Lwm/d; (sealed result wrapper) — Lwm/d$e for success, Lwm/d$b
-// subtypes (Lwm/d$c / Lwm/d$d) for error. The caller (Lpf/a;->c) branches
-// on instance-of Lwm/d$e vs Lwm/d$b and converges afterward either way,
-// so a synchronously-returned error result is sufficient — no suspension
-// needed.
+// Rainmaker ad-break fetch coroutine (RainmakerAdsFetcher.kt). Returns
+// LMm/d; (sealed result wrapper, NetworkResponse.kt) — LMm/d$e for success,
+// LMm/d$b subtypes (LMm/d$c / LMm/d$d) for error. The caller (Lrf/a;)
+// branches on instance-of LMm/d$e vs LMm/d$b and converges afterward either
+// way, so a synchronously-returned error result is sufficient — no
+// suspension needed.
+//
+// R8 renames per release: class qf/c → sf/c; wrapper wm/d → Mm/d (10.28).
 object QfcSuspendGetAdBreaksFingerprint : Fingerprint(
-    definingClass = "Lqf/c;",
+    definingClass = "Lsf/c;",
     name = "suspendGetAdBreaks",
     parameters = listOf(
         "Ljava/lang/String;",

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/tubi/ads/SkipAdsPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/tubi/ads/SkipAdsPatch.kt
@@ -123,9 +123,9 @@ val skipAdsPatch = bytecodePatch(
 
         // Hook 9 — qf/c.suspendGetAdBreaks(String, String, String, Map, Continuation)
         //
-        // Rainmaker ad-break fetch coroutine. Returns Lwm/d; (sealed result),
-        // with the caller (Lpf/a;->c) branching on instance-of Lwm/d$e
-        // (success) vs Lwm/d$b (error) and converging afterward either way.
+        // Rainmaker ad-break fetch coroutine. Returns LMm/d; (sealed result),
+        // with the caller (Lrf/a;) branching on instance-of LMm/d$e
+        // (success) vs LMm/d$b (error) and converging afterward either way.
         //
         // Previous attempt returned COROUTINE_SUSPENDED directly to fake a
         // no-op, which broke the suspend-function contract: nothing ever
@@ -134,7 +134,7 @@ val skipAdsPatch = bytecodePatch(
         // at TubiNewPlayerImpl.kt:102), hanging the entire content pipeline.
         //
         // Fix: skip the network call and the continuation machinery entirely,
-        // returning a real, immediate Lwm/d$d (generic error) result. The
+        // returning a real, immediate LMm/d$d (generic error) result. The
         // caller takes its existing error branch — the same one a genuine
         // network failure already triggers gracefully — and the coroutine
         // completes normally, with no DNS-layer workaround required.
@@ -144,8 +144,8 @@ val skipAdsPatch = bytecodePatch(
                 new-instance v0, Ljava/io/IOException;
                 const-string v1, "ads_blocked"
                 invoke-direct {v0, v1}, Ljava/io/IOException;-><init>(Ljava/lang/String;)V
-                new-instance v2, Lwm/d${"$"}d;
-                invoke-direct {v2, v0}, Lwm/d${"$"}d;-><init>(Ljava/lang/Throwable;)V
+                new-instance v2, LMm/d${"$"}d;
+                invoke-direct {v2, v0}, LMm/d${"$"}d;-><init>(Ljava/lang/Throwable;)V
                 return-object v2
             """
         )

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/tubi/shared/Constants.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/tubi/shared/Constants.kt
@@ -8,6 +8,6 @@ object Constants {
         name = "Tubi Android TV",
         packageName = "com.tubitv",
         appIconColor = 0xE9181C,
-        targets = listOf(AppTarget("10.20.5000"))
+        targets = listOf(AppTarget("10.28.5000"))
     )
 }


### PR DESCRIPTION
## What

Bumps the Tubi Android TV patch target from **10.20.5000 → 10.28.5000**.

R8 re-obfuscated class names again on this release. Only the three name-dependent hooks needed re-pinning; Hooks 1–6 (Fox IMA/DAI SDK + Tubi) are byte-for-byte unchanged — they match on stable SDK names + string anchors and the lambda numbers were identical.

## Rename map (10.20 → 10.28)

| Hook | Target | Old | New |
|------|--------|-----|-----|
| 7 & 8 | TvWebFragment WebViewClient | `Lxo/C$c;` | `LPo/C$c;` |
| 9 | `RainmakerAdsFetcher.suspendGetAdBreaks` | `Lqf/c;` | `Lsf/c;` |
| 9 return | NetworkResponse sealed error subtype | `Lwm/d$d;` | `LMm/d$d;` |

## Verification (Onn 4K Plus)

- `list-patches` shows **Skip ads** enabled/compatible for 10.28.5000
- Patch applies cleanly — all 9 fingerprints resolve (a single failure errors the whole patch)
- Differential dex-string check: injected literals (`dai_blocked`, `__tubiAdBlockInstalled`, `ads_blocked`) present in patched dex, absent from original
- App launches with **no** `NoClassDefFound` / `VerifyError` / `ClassCastException` (confirms the new `LMm/d$d;` and renamed refs resolve at load)
- **Movie playback is ad-free** — no pre-rolls, no long buffering

## Note for future bumps

Two classes share the `shouldInterceptRequest`+`onPageFinished` signature (`Po/C$c` = TvWebFragment, `Ml/w1$c` = generic WebViewFragment), so Hooks 7/8 must stay **class-pinned** — a pure signature match would be ambiguous and could hook the wrong WebView.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
