### PR TITLE
docs(disney): bump tested version to 26.12.1+rc1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ I'm just like you — I enjoy watching TV and movies without being bored and ann
 
 | App | Package | Status | Tested Version | Date |
 |-----|---------|--------|---------------|------|
-| 🟢 Disney+ | `com.disney.disneyplus` | Working | `26.9.2+rc1-2026.06.12` | 6/17/26 |
+| 🟢 Disney+ | `com.disney.disneyplus` | Working | `26.12.1+rc1-2026.07.15` | 7/21/26 |
 | 🟡 Prime Video | `com.amazon.amazonvideo.livingroom` | Partial/Testing — [DNS filters](dns/README.md) required; native prerolls may still appear | `6.23.23+v15.5.0.70-armv7a` | 6/26/26 |
 | 🟢 HBO Max | `com.wbd.hbomax` | Working | `v7.7.0.78` | 7/18/26 |
 | 🟢 Peacock | `com.peacocktv.peacockandroid` | Working — no DNS required | `v7.6.100` | 7/16/26 |
@@ -50,7 +50,7 @@ All patches follow the same general workflow using **Morphe Manager**:
 
 ### 🎬 Disney+
 
-1. Open the **[Disney+ (Android TV) listing on APKMirror](https://www.apkmirror.com/apk/disney/disney-android-tv/)** and select version **`26.9.2+rc1-2026.06.12`**
+1. Open the **[Disney+ (Android TV) listing on APKMirror](https://www.apkmirror.com/apk/disney/disney-android-tv/)** and select version **`26.12.1+rc1-2026.07.15`**
 2. Download the `.apkm` file
 3. Select it in Morphe Manager
 4. Apply the patch

--- a/patches/src/main/kotlin/app/morphe/patches/disney/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/disney/Fingerprints.kt
@@ -3,10 +3,15 @@
  * https://gitlab.com/ReVanced/revanced-patches/-/blob/main/patches/src/main/kotlin/app/revanced/patches/disneyplus/ads/Fingerprints.kt
  * ALL CREDIT GOES TO RookieEnough FOR THE ORIGINAL CODE
  *
- * Updated for Disney+ Android TV v26.8.0+rc6 (versionCode 1779314460)
- * - InsertionGetPointsFingerprint:  VALIDATED ✅  (class + method unchanged)
- * - InsertionGetRangesFingerprint:  VALIDATED ✅  (class + method unchanged)
- * - PauseAdStartedFingerprint:      NEW ✅  targets MediaXPauseSession.started()
+ * Verified on Disney+ Android TV v26.12.1+rc1-2026.07.15 (versionCode 1784077450)
+ * — all fingerprints resolve unchanged; on-device pre- and mid-roll ads gone for
+ * both movies and TV (AGH off). Previously validated on v26.8.0+rc6 (1779314460)
+ * and the DMP-pipeline fix landed on v26.9.2+rc1 (1781224190).
+ * - InsertionGetPointsFingerprint:     VALIDATED ✅  (legacy DSS-SDK Insertion)
+ * - InsertionGetRangesFingerprint:     VALIDATED ✅  (legacy DSS-SDK Insertion)
+ * - DmpInsertionGetPointsFingerprint:  VALIDATED ✅  (new com.disney.dmp Insertion)
+ * - DmpInsertionGetRangesFingerprint:  VALIDATED ✅  (new com.disney.dmp Insertion)
+ * - PauseAdStartedFingerprint:         VALIDATED ✅  MediaXPauseSession.started()
  *
  * Pause ad patch history:
  *   v1 — targeted onPauseScheduled() → no match (wrong method)
@@ -22,8 +27,8 @@ package app.morphe.patches.disney
 import app.morphe.patcher.Fingerprint
 
 // ---------------------------------------------------------------------------
-// Existing fingerprints — validated present and structurally unchanged in
-// com.dss.sdk.internal.media.Insertion as of v26.8.0+rc6-2026.05.20
+// Legacy pipeline — validated present and structurally unchanged in
+// com.dss.sdk.internal.media.Insertion through v26.12.1+rc1-2026.07.15
 // ---------------------------------------------------------------------------
 
 internal object InsertionGetPointsFingerprint : Fingerprint(


### PR DESCRIPTION
## What

Bumps the documented **Disney+** tested version to **`26.12.1+rc1-2026.07.15`** (versionCode 1784077450).

The shipped **v1.12.0** patch — legacy DSS-SDK `Insertion` + new `com.disney.dmp` `Insertion` (both `getPoints`/`getRanges`) + the `MediaXPauseSession.started()` pause-ad hook — applies to 26.12.1 with **no code change**; all five fingerprints still resolve.

## Verification (Onn 4K Plus, 26.12.1+rc1, AGH DNS off)

- Patched in place over 26.9.2 (same keystore, login intact), launches clean, no crash.
- **Movies + TV shows**: no pre-roll, no mid-roll ads — content plays straight through.

## Changes

- `README.md` — Disney+ status-table row + install-step version.
- `Fingerprints.kt` — validation comment updated to record 26.12.1 verification (comment-only, no logic change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
