### PR TITLE
feat(disney): add 26.12.1+rc1 to compatible targets

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
@@ -20,9 +20,10 @@ object AppCompatibilities {
         packageName = "com.disney.disneyplus",
         appIconColor = 0x113CCF,
         targets = listOf(AppTarget("26.6.0+rc5-2026.04.21"),
-                         AppTarget("26.8.0+rc6-2026.05.20"), 
+                         AppTarget("26.8.0+rc6-2026.05.20"),
                          AppTarget("26.9.2+rc1-2026.06.12"),
-        ),                 
+                         AppTarget("26.12.1+rc1-2026.07.15"),
+        ),
     )
 
     val HBO_TV = Compatibility(


### PR DESCRIPTION
## What

Adds **`26.12.1+rc1-2026.07.15`** (versionCode 1784077450) to `AppCompatibilities.DISNEY_PLUS_TV.targets`.

The shipped v1.12.0 patch applies to 26.12.1 with no code change (all fingerprints resolve; verified on-device — pre/mid-roll ads gone for movies + TV, no crash). Without this entry the Manager would refuse the version unless forced. Complements the docs bump in #70.

## Change

One-line target addition (+ trailing-whitespace tidy on the two adjacent lines). `:patches:compileKotlin` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
