### PR TITLE
docs: add repo-root CLAUDE.md (growth-mindset philosophy)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# Project Philosophy
+
+This project runs on a **growth mindset**. What started as basic patches that
+just passed checks has grown into a sophisticated APK patching resource
+because of a deliberate approach:
+
+- **Stay curious.** Treat unfamiliar app internals, obfuscation, and manifest
+  quirks as things to investigate, not blockers to route around.
+- **Accept the hard problems.** Prefer tackling the real ad-injection or
+  DRM/anti-tamper mechanism over a shallow workaround, even when it takes
+  longer.
+- **Walls are usually not walls.** When something looks architecturally
+  impossible (a "can't be done" limitation), dig one level deeper before
+  accepting that conclusion — most limitations turn out to be assumptions,
+  not hard constraints.
+- **Expect adversity and keep going.** Apps update, obfuscation changes,
+  detection improves — setbacks are the normal cost of this work, not a
+  signal to stop.
+
+When picking up new patching challenges (new apps, broken patches after an
+app update, anti-tamper/detection countermeasures, etc.), default to this
+mindset: explore first, question assumed limitations, and iterate rather
+than settling for the first workaround.


### PR DESCRIPTION
Adds a repo-root `CLAUDE.md` recording the project's growth-mindset philosophy so it loads as persistent project context for every session on this repo (not just one feature branch):

- **Stay curious** — investigate app internals/obfuscation rather than route around them.
- **Accept the hard problems** — go at the real ad-injection / anti-tamper mechanism over a shallow workaround.
- **Walls are usually not walls** — treat "architecturally impossible" as an assumption to test, not a hard constraint.
- **Expect adversity and keep going** — app updates and detection changes are the normal cost of the work.

Doc-only change (single new file), branched cleanly off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)