### PR TITLE
feat(twitch): live ad-reduction for Android TV (embed playerType + GrandDads + stitched-metadata)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -15,4 +15,27 @@ Modifications:
 - Converted to ParameterizedFingerprint system
 - Integrated into modular patch framework
 
+- Purple TV (nyanarchive/purpletv)
+  GrandDads ad-eligibility short-circuit technique for Twitch
+  The approach of blocking GrandDadsApiImpl.shouldDeclineAds to return
+  AdContextUnavailable was discovered by reverse-engineering Purple TV's
+  AdBlocker class from PurpleTV_2.4.apk.
+  Source: https://github.com/AdrianLxM/PurpleTV
+
+- TwitchAdSolutions (pixeltris/TwitchAdSolutions)
+  playerType spoofing concept for Twitch ad suppression
+  The idea of substituting the stream access token's playerType to reduce
+  server-side ad fill originates from TwitchAdSolutions' proxy/playlist
+  rewriting techniques.
+  Source: https://github.com/pixeltris/TwitchAdSolutions
+
+- Xtra for Twitch (crackededed/Xtra)
+  Referenced as prior art for Android-side Twitch ad mitigation
+  Source: https://github.com/crackededed/Xtra
+
+Modifications:
+- Twitch techniques independently re-derived via dex disassembly of the
+  official Twitch Android APK v30.2.2, not copied from source code
+- Adapted to morphe-androidtv-patches Fingerprint/bytecodePatch framework
+
 All original authors retain credit for their contributions.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ I'm just like you — I enjoy watching TV and movies without being bored and ann
 | 🟢 ViX | `com.univision.prendetv` | Working | `v4.47.2_tv` | 7/11/26 |
 | 🟢 Pluto TV | `tv.pluto.android` | Working — VOD ad breaks removed (video, markers, beacons); LIVE TV ads are broadcast time and remain | `5.66.0-leanback` | 7/3/26 |
 | 🟡 Paramount+ | `com.cbs.ott` | ✅ Use `v16.8.0` — newer versions (`v16.12`) still in development | `v16.8.0` | 7/19/26 |
+| 🔴 Twitch | `tv.twitch.android.app` | Under Development — untested | `30.2.2` | — |
 | 🔴 Fox One | **Under Development** | — |
 | 🔴 MLB TV | **Under Development** | — |
 
@@ -164,6 +165,13 @@ All patches follow the same general workflow using **Morphe Manager**:
 ## 🙏 Credits
 
 This patch template is based on the prior work of [ReVanced](https://github.com/ReVanced/revanced-patches-template). All modifications made by Morphe, along with their dates, can be found in the Git history.
+
+**Twitch ad-suppression techniques** are informed by:
+- [Purple TV](https://github.com/AdrianLxM/PurpleTV) (nyanarchive/purpletv) — GrandDads ad-eligibility short-circuit approach
+- [TwitchAdSolutions](https://github.com/pixeltris/TwitchAdSolutions) (pixeltris) — playerType spoofing concept
+- [Xtra for Twitch](https://github.com/crackededed/Xtra) (crackededed) — Android-side Twitch ad mitigation prior art
+
+All Twitch techniques were independently re-derived via dex disassembly and are not copied from these projects' source code. See [NOTICE](NOTICE) for full attribution details.
 
 ---
 

--- a/docs/PARESH_APK_ANALYSIS_METHODOLOGY.md
+++ b/docs/PARESH_APK_ANALYSIS_METHODOLOGY.md
@@ -1,0 +1,179 @@
+# APK Analysis Methodology (source: Paresh Maheshwari's `morphe-ai`)
+
+**Source:** [Paresh-Maheshwari/morphe-ai](https://github.com/Paresh-Maheshwari/morphe-ai),
+`.kiro/skills/apk-analysis/SKILL.md` (+ companion `.kiro/agents/apk-recon.json` /
+`.kiro/prompts/apk-recon.md`). Fetched read-only via shallow clone on 2026-07-30. Licensed GPLv3
+(same as this repo), reproduced/adapted here for internal reference.
+
+Context: this is one of the "learn from inspiring devs" study subjects — see
+`docs/DAILY_STUDY_LOG.md` and the `morphe-ai-paresh-study` memory for the broader framework
+(6-agent pipeline: RECON → DECOMPILE → HUNT → WRITE → BUILD+DEPLOY) this workflow is step 1 of.
+
+> **When to use:** starting analysis of a new app for patching. Follow the steps in order:
+> setup folder → identify APK → decompile → extract smali → search targets → document findings.
+> Always verify targets in smali before writing fingerprints — never trust jadx's decompiled names,
+> jadx invents deobfuscated names that don't exist in the actual bytecode.
+
+## Step 1: Setup Analysis Folder
+
+```bash
+APP="appname"
+mkdir -p analysis/$APP/notes
+# Move + rename APK: <app>_<version>.<ext>
+mv /path/to/downloaded.apk analysis/$APP/${APP}_<version>.<ext>
+cd analysis/$APP
+```
+
+## Step 2: Identify the APK
+
+```bash
+aapt dump badging ${APP}_*.apk* | head -5       # Package, version, SDK
+uvx apkid ${APP}_*.apk*                          # Protections/obfuscators
+```
+
+APKiD tells you: compiler (dx/d8/r8), obfuscator (ProGuard/R8/DexGuard), packer.
+
+## Step 3: Check APK Type
+
+```bash
+aapt dump xmltree ${APP}_*.apk* AndroidManifest.xml | rg -i "split|requiredSplit"
+unzip -l ${APP}_*.apk* | rg "\.dex"
+unzip -l ${APP}_*.apk* | rg "index.android.bundle|libflutter|libapp"
+```
+
+| What you see | ApkFileType |
+|-------------|-------------|
+| No requiredSplitTypes | `APK` |
+| requiredSplitTypes in manifest | `XAPK` |
+| APKM format | `APKM` |
+| index.android.bundle | React Native (JS, not Java) |
+| libflutter.so | Flutter (logic in libapp.so) |
+
+## Step 4: Decompile
+
+```bash
+# Remote decompile on Kaggle (4 cores, 28GB RAM) — his primary method for large APKs
+.kiro/jadx-decompile "<apk-download-url>" analysis/$APP/
+
+# Unzip the output
+cd analysis/$APP && unzip *_decompiled.zip -d decompiled/
+```
+
+For quick local decompile of small APKs only:
+```bash
+jadx -d decompiled ${APP}_*.apk --deobf --show-bad-code -m restructure --no-res
+```
+
+> We are **not** adopting the Kaggle step (ships the APK to a third-party cloud, needs a public
+> direct-download URL our APKMirror links don't reliably give us) — see `morphe-ai-paresh-study`
+> memory. Worth keeping his local jadx flag set though:
+> `--deobf --show-bad-code -Pkotlin-metadata.*=yes --use-source-name-as-class-name-alias always --use-kotlin-methods-for-var-names apply-and-hide`
+
+## Step 5: Extract Smali (CRITICAL)
+
+The patcher works on smali, not Java. Always extract:
+
+```bash
+for dex in $(unzip -l ${APP}_*.apk* | rg "\.dex" | awk '{print $4}'); do
+    name=$(basename $dex .dex)
+    unzip -o ${APP}_*.apk* $dex -d /tmp/dex_extract
+    baksmali d /tmp/dex_extract/$dex -o smali/$name
+done
+```
+
+## Step 6: Search for Targets
+
+```bash
+# Step 6a: Identify billing SDK
+rg "revenuecat|adapty|qonversion|superwall|BillingClient|LicenseChecker" decompiled/ -g "*.java" -l
+
+# Step 6b: Find subscription checks (by SDK found above)
+rg "CustomerInfo|EntitlementInfos|getActive|getEntitlements" decompiled/ -g "*.java" -l
+rg "isPro|isPremium|isSubscribed|hasPremium" decompiled/ -g "*.java" -l
+
+# Step 6c: Find ads
+rg "showAd|loadAd|interstitial|AdMob|adView|MobileAds" decompiled/ -g "*.java" -l
+
+# Step 6d: Read target method with context
+rg "public static boolean.*CustomerInfo" decompiled/ -g "*.java" -A 10
+```
+
+For our SSAI/ad-timeline targets specifically, the client-side `loadAd → returnEarly` pattern above
+is the ReVanced-lineage shallow layer — see `ssai-portable-knowledge` /
+`java-ad-timeline-hook-methodology` memories for the deeper "empty the ad-cue accessor before
+RETURN_OBJECT" technique this repo already uses beyond his material.
+
+## Step 7: Verify in Smali
+
+```bash
+# Find target class in smali
+find smali/ -name "TargetClass.smali" | head
+
+# Read target method
+rg -A 30 "\.method public static" smali/classes5/yz/u.smali
+```
+
+From smali, note: method signature, access flags, register count, invoke-virtual calls and their
+order.
+
+## Step 8: Document Findings
+
+Save in separate files per target type in `notes/`:
+
+`notes/recon.md` — APK identification:
+```markdown
+# <App> Recon
+- Package: com.example.app
+- Version: 1.0.0
+- APK Type: XAPK
+- Obfuscator: R8
+- DEX count: 5
+- Framework: Native Java/Kotlin
+```
+
+`notes/premium-bypass.md` — subscription targets:
+```markdown
+# <App> — Premium Bypass
+
+## Target 1: Entitlement check
+- Class: yz/u (obfuscated)
+- Method: public static boolean e(CustomerInfo)
+- DEX: classes5.dex
+- Purpose: Returns true if user has active entitlements
+- Fingerprint strategy:
+  - returnType: Z
+  - accessFlags: PUBLIC, STATIC
+  - parameters: CustomerInfo
+  - filters: getEntitlements() → getActive()
+```
+
+Other files: `ad-removal.md`, `signature-bypass.md`, `feature-gates.md`
+
+## Final Folder Structure
+
+```
+analysis/<app>/
+├── <app>_<version>.<ext>              # Original APK (renamed)
+├── <app>_<version>_decompiled.zip     # JADX output zip
+├── decompiled/                        # Extracted Java sources
+├── smali/                             # baksmali output (all DEX files)
+│   ├── classes/
+│   ├── classes2/
+│   └── ...
+└── notes/
+    ├── recon.md                       # APK identification
+    ├── premium-bypass.md              # Subscription/entitlement targets
+    ├── ad-removal.md                  # Ad-related targets
+    ├── signature-bypass.md            # Signature check targets
+    └── feature-gates.md               # Feature flag targets
+```
+
+## Durable principles behind the steps (from the broader study)
+
+- **Never trust jadx — verify every finding against smali** (access flags, param descriptors,
+  instruction order, which DEX). jadx invents deobfuscated names not present in the actual
+  bytecode.
+- **Fingerprint only on what survives R8:** return type, params, access flags, SDK class/method
+  names, string constants, opcodes, call order. Never fingerprint on app-owned obfuscated names;
+  use `"L"` (opaque reference type) for obfuscated parameter types.
+- **Fewer stable filters beat many fragile ones**, and filter order must match smali order.

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/twitch/ads/Fingerprints.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/twitch/ads/Fingerprints.kt
@@ -1,0 +1,104 @@
+/*
+ * Attribution:
+ *
+ * The ad-suppression strategy used in this patch is informed by techniques
+ * from several open-source projects. Specific credit:
+ *
+ * - Purple TV (nyanarchive/purpletv, https://github.com/AdrianLxM/PurpleTV)
+ *   The GrandDads ad-eligibility short-circuit approach was discovered by
+ *   reverse-engineering Purple TV's AdBlocker class (decompiled from
+ *   PurpleTV_2.4.apk). Purple TV's shipped technique short-circuits
+ *   GrandDadsApiImpl.shouldDeclineAds to return AdContextUnavailable
+ *   before any network call, gated by a DISABLE_AD_ELIGIBILITY flag.
+ *   Credit to the Purple TV developers for identifying this as the
+ *   decisive ad-eligibility choke point.
+ *
+ * - TwitchAdSolutions (pixeltris/TwitchAdSolutions,
+ *   https://github.com/pixeltris/TwitchAdSolutions)
+ *   The playerType spoofing concept — substituting the default
+ *   mobile_player token type with an alternative that receives fewer
+ *   or no ads — originates from TwitchAdSolutions' proxy/playlist
+ *   rewriting techniques. The specific playerType values and their
+ *   ad-reduction effects were first documented by that project.
+ *
+ * - Xtra for Twitch (crackededed/Xtra, https://github.com/crackededed/Xtra)
+ *   Referenced as prior art for Android-side Twitch ad mitigation
+ *   approaches and playerType enumeration.
+ *
+ * All techniques were independently re-derived against the official
+ * Twitch Android APK v30.2.2 (versionCode 3002026) via dex disassembly,
+ * not copied from any project's source code. The fingerprints and smali
+ * patches below are original work targeting obfuscated class/method names
+ * specific to this build.
+ */
+package ajstrick81.morphe.patches.twitch.ads
+
+import app.morphe.patcher.Fingerprint
+
+// ===========================================================================
+// Twitch Android — ad architecture (confirmed by dex disassembly of v30.2.2)
+//
+// Twitch uses Amazon IVS Player for live playback. Ad decisioning is NOT
+// reactive to player events (AdBreak/AdCue callbacks are no-ops). Instead,
+// two mechanisms control ad delivery:
+//
+// 1. StreamAccessTokenQuery (GQL) — requests a playback access token from
+//    Twitch's API. The token carries a `playerType` field (enum Lr440 in
+//    this build) that influences server-side ad-fill decisions. Values
+//    include mobile_player (default for live), background_audio, autoplay,
+//    prime_video_player, etc.
+//
+// 2. GrandDads GQL query — a per-session ad-eligibility/decisioning call
+//    that determines dynamic ad rotation. Call chain:
+//      VideoAdManager → AdEligibilityFetcher/ClientAdEligibilityFetcher
+//        → GrandDadsFetcher → GrandDadsApiImpl.shouldDeclineAds
+//        → GrandDadsQuery
+//    Short-circuiting shouldDeclineAds to return AdContextUnavailable
+//    before the network call prevents the app from ever requesting ads.
+//
+// Patching both layers provides defense-in-depth: playerType spoofing
+// reduces server-side ad fill, while the GrandDads block prevents the
+// client from requesting ad eligibility at all.
+// ===========================================================================
+
+// Layer 1 — playerType spoofing on StreamAccessTokenQuery
+//
+// The PlaybackAccessTokenParams class is constructed with a playerType
+// value from enum Lr440. Its toString() includes the literal string
+// "PlaybackAccessTokenParams" which survives R8 minification (it's a
+// data-class generated toString, not a debug string). We anchor on that
+// toString() in a sibling method to locate the constructor, then patch
+// the playerType argument.
+//
+// This fingerprint targets the toString() method to locate the class,
+// not the constructor directly — the constructor's signature is generic
+// enough that it could false-match without the string anchor.
+object PlaybackAccessTokenParamsToStringFingerprint : Fingerprint(
+    strings = listOf("PlaybackAccessTokenParams(playerType=")
+)
+
+// Layer 2 — GrandDads ad-eligibility query document
+//
+// Apollo-codegen embeds the full GQL document string as a static field
+// in the generated query class. This string is stable across builds
+// because it's derived from the GraphQL schema, not from R8 renaming.
+// We use it to locate the GrandDads query class reliably.
+object GrandDadsQueryDocumentFingerprint : Fingerprint(
+    strings = listOf("query GrandDads")
+)
+
+// Layer 3 — GrandDadsApiImpl.shouldDeclineAds (version-pinned)
+//
+// This is the method Purple TV's AdBlocker short-circuits. In v30.2.2,
+// it lives at Lhs9; method f (obfuscated). Because the Morphe framework's
+// Fingerprint.method requires an execute{} context for dynamic resolution,
+// and cross-fingerprint references don't compile outside that context, this
+// fingerprint is version-pinned to the exact obfuscated names.
+//
+// When the app updates and class/method names change, this fingerprint
+// will need to be re-derived from a fresh decompilation.
+object DeclineAdsRequestFingerprint : Fingerprint(
+    definingClass = "Lhs9;",
+    name = "f",
+    returnType = "Lio/reactivex/rxjava3/core/Single;"
+)

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/twitch/ads/Fingerprints.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/twitch/ads/Fingerprints.kt
@@ -74,7 +74,7 @@ import app.morphe.patcher.Fingerprint
 // not the constructor directly — the constructor's signature is generic
 // enough that it could false-match without the string anchor.
 object PlaybackAccessTokenParamsToStringFingerprint : Fingerprint(
-    strings = listOf("PlaybackAccessTokenParams(playerType=")
+    strings = listOf("PlaybackAccessTokenParams(disableHTTPS=")
 )
 
 // Layer 2 — GrandDads ad-eligibility query document
@@ -87,18 +87,19 @@ object GrandDadsQueryDocumentFingerprint : Fingerprint(
     strings = listOf("query GrandDads")
 )
 
-// Layer 3 — GrandDadsApiImpl.shouldDeclineAds (version-pinned)
+// Layer 3 — GrandDadsApiImpl.shouldDeclineAds — NOT YET FOUND.
 //
-// This is the method Purple TV's AdBlocker short-circuits. In v30.2.2,
-// it lives at Lhs9; method f (obfuscated). Because the Morphe framework's
-// Fingerprint.method requires an execute{} context for dynamic resolution,
-// and cross-fingerprint references don't compile outside that context, this
-// fingerprint is version-pinned to the exact obfuscated names.
+// Purple TV's AdBlocker short-circuits this method. The `Lhs9;` / method `f`
+// pin previously here was verified WRONG on 2026-07-28 against v30.2.2 smali:
+// `Lhs9;` is a shared SAM-lambda dispatch class (implements `Lt5h;`, methods
+// a/b/c/e/f/i/l/m... selected by a numeric tag field at construction), and
+// method `f` in this build is an unrelated method building playback/ad-context
+// objects that returns an RxJava2 `Observable`, not `Single`. This app is also
+// RxJava2-only (`io.reactivex.*`, itself R8-renamed) — there is no
+// `io.reactivex.rxjava3` anywhere in the dex, so any fingerprint/injection
+// targeting that package is wrong regardless of which method is pinned.
 //
-// When the app updates and class/method names change, this fingerprint
-// will need to be re-derived from a fresh decompilation.
-object DeclineAdsRequestFingerprint : Fingerprint(
-    definingClass = "Lhs9;",
-    name = "f",
-    returnType = "Lio/reactivex/rxjava3/core/Single;"
-)
+// The `GrandDadsQueryDocumentFingerprint` above (anchored on the "query
+// GrandDads" GQL document string) still reliably locates the query class —
+// the real next step is tracing ITS actual callers (not guessing a lambda
+// dispatch letter) to find the true shouldDeclineAds call site.

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/twitch/ads/Fingerprints.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/twitch/ads/Fingerprints.kt
@@ -34,6 +34,7 @@
 package ajstrick81.morphe.patches.twitch.ads
 
 import app.morphe.patcher.Fingerprint
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 
 // ===========================================================================
 // Twitch Android — ad architecture (confirmed by dex disassembly of v30.2.2)
@@ -87,19 +88,76 @@ object GrandDadsQueryDocumentFingerprint : Fingerprint(
     strings = listOf("query GrandDads")
 )
 
-// Layer 3 — GrandDadsApiImpl.shouldDeclineAds — NOT YET FOUND.
+// Layer 2 (real) — GrandDads ad-eligibility RESPONSE MAPPER.
 //
-// Purple TV's AdBlocker short-circuits this method. The `Lhs9;` / method `f`
-// pin previously here was verified WRONG on 2026-07-28 against v30.2.2 smali:
-// `Lhs9;` is a shared SAM-lambda dispatch class (implements `Lt5h;`, methods
-// a/b/c/e/f/i/l/m... selected by a numeric tag field at construction), and
-// method `f` in this build is an unrelated method building playback/ad-context
-// objects that returns an RxJava2 `Observable`, not `Single`. This app is also
-// RxJava2-only (`io.reactivex.*`, itself R8-renamed) — there is no
-// `io.reactivex.rxjava3` anywhere in the dex, so any fingerprint/injection
-// targeting that package is wrong regardless of which method is pinned.
+// The decisive ad-eligibility choke point. Traced 2026-07-30 from the only
+// R8-stable anchor, the "query GrandDads" document string:
+//   "query GrandDads" ── document() of Li0i (GrandDadsQuery)
+//   Li0i is constructed in exactly ONE place: Lhs9;->f (the query builder;
+//     runs when the shared Lhs9 dispatch class is invoked with tag a=0x18).
+//   Lhs9;->f calls the gql service Ld2i;->l(query, mapper, …) passing the
+//     response mapper `new Lwyh(0x4)` (a Lt5h; functor).
+//   That mapper is Lwyh;->invoke, tag-4 branch: it casts the gql response to
+//     Lg0i (GrandDadsQuery.Data) and returns a GrandDadsResponse (sealed base
+//     Lp0i): if the decision node Lg0i;->a is null → Ln0i (AdContextUnavailable
+//     singleton, INSTANCE = Ln0i;->a:Ln0i;), else Lo0i (ads-available).
 //
-// The `GrandDadsQueryDocumentFingerprint` above (anchored on the "query
-// GrandDads" GQL document string) still reliably locates the query class —
-// the real next step is tracing ITS actual callers (not guessing a lambda
-// dispatch letter) to find the true shouldDeclineAds call site.
+// SkipAdsPatch forces this mapper to ALWAYS return the AdContextUnavailable
+// sentinel Ln0i;->a — the obfuscated analog of Purple TV's
+// shouldDeclineAds → GrandDadsResponse.AdContextUnavailable.INSTANCE.
+//
+// Scope safety: the tag-4 branch begins `check-cast p1, Lg0i;`, so any
+// non-GrandDads tag-4 use of Lwyh would already ClassCastException — proving
+// tag-4 is GrandDads-exclusive and the guard is correctly scoped.
+//
+// This is a v30.2.2 obfuscated pin (Lwyh/Ln0i/tag names change per app
+// version). The `custom` predicate self-verifies the match by requiring the
+// method to reference the Ln0i sentinel, so a drifted pin fails to match
+// (patch skipped) rather than mis-applying. Re-derive via the chain above.
+object GrandDadsResponseMapperFingerprint : Fingerprint(
+    definingClass = "Lwyh;",
+    name = "invoke",
+    parameters = listOf("Ljava/lang/Object;"),
+    returnType = "Ljava/lang/Object;",
+    custom = { method, _ ->
+        method.implementation?.instructions?.any { insn ->
+            (insn as? ReferenceInstruction)?.reference?.toString()?.contains("Ln0i;") == true
+        } == true
+    }
+)
+
+// Layer 3 (real SSAI kill) — ExoPlayer stitched-ad metadata parser.
+//
+// The decisive on-device seam. Twitch live playback on Android TV runs on
+// ExoPlayer2 (NOT sealed native IVS): the player core
+// `tv.twitch.android.shared.player.core.b` (unobfuscated package) receives
+// timed HLS metadata via its onMetadata callback (method obfuscated to `G`,
+// param `com.google.android.exoplayer2.metadata.Metadata`). That method walks
+// each `#EXT-X-DATERANGE` tag, reads the tag's `CLASS` attribute, and does
+// `"twitch-stitched-ad".equals(class)` → a boolean. When true it enters ad
+// handling (parses the X-TV-TWITCH-AD-* metadata, dispatches an ad event to
+// the ad manager, fires quartile beacons); when false it takes the player's
+// own built-in "no ads" path.
+//
+// SkipAdsPatch forces that boolean false so onMetadata always takes the no-ad
+// path — the client-side analog of the TwitchAdSolutions stitched-ad strip.
+//
+// Fingerprint is version-durable: the class name is unobfuscated and the two
+// strings are HLS/Twitch protocol constants that don't change with R8. The
+// injection point (the equals→move-result) is located dynamically in the
+// patch, not by a fixed offset, so register/instruction drift doesn't break it.
+object StitchedAdMetadataFingerprint : Fingerprint(
+    definingClass = "Ltv/twitch/android/shared/player/core/b;",
+    strings = listOf("#EXT-X-DATERANGE", "twitch-stitched-ad"),
+)
+
+// NOTE (Path B / join pre-roll — investigated, not shippable): a fourth layer
+// that strips ad segments from the live HLS media playlist was prototyped
+// against ExoPlayer's HlsPlaylistParser (R8-renamed `Lxsi;`). On-device it was
+// proven INEFFECTIVE: a hook injected at that parser's parse() entry never
+// fired during live playback (0 calls across a full join with an ad), so Twitch
+// live does NOT route through ExoPlayer's stock HLS parser — it feeds ExoPlayer
+// via a custom/native IVS media source whose playlist parsing bytecode cannot
+// reach. The residual ~15s pre-roll therefore can't be stripped at the Java
+// playlist layer. See the twitch-ad-suppression handoff memory for the full
+// trace before re-attempting.

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/twitch/ads/SkipAdsPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/twitch/ads/SkipAdsPatch.kt
@@ -1,0 +1,81 @@
+/*
+ * Attribution:
+ *
+ * See Fingerprints.kt in this package for full credit to Purple TV,
+ * TwitchAdSolutions, and Xtra for Twitch — the projects whose published
+ * techniques informed this patch's ad-suppression strategy.
+ */
+package ajstrick81.morphe.patches.twitch.ads
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import ajstrick81.morphe.patches.twitch.shared.Constants
+
+@Suppress("unused")
+val skipAdsPatch = bytecodePatch(
+    name = "Skip ads",
+    description = "Suppresses Twitch ads via two layers: spoofs the playerType on the " +
+        "stream access token request to reduce server-side ad fill, and blocks the " +
+        "GrandDads ad-eligibility query to prevent client-side ad decisioning. " +
+        "UNTESTED — requires on-device validation.",
+) {
+    compatibleWith(Constants.COMPATIBILITY)
+
+    execute {
+
+        // Layer 1 — playerType spoofing
+        //
+        // Locate PlaybackAccessTokenParams via its toString() string anchor,
+        // then find the constructor in the same class. The constructor takes
+        // the playerType as a String parameter. We prepend instructions that
+        // overwrite the playerType register with "background_audio" before
+        // the original constructor body runs.
+        //
+        // Why "background_audio": this playerType is used by Twitch's own
+        // background playback mode and historically receives no ad fill.
+        // If this value doesn't work, candidates to try (from enum Lr440):
+        //   - "autoplay"
+        //   - "prime_video_on_twitch_mobile" (shared Amazon infra)
+        //   - "embed" (web embed context)
+        //
+        // Technique credit: TwitchAdSolutions (playerType spoofing concept)
+        val toStringMethod = PlaybackAccessTokenParamsToStringFingerprint.method
+        val paramsClass = toStringMethod.definingClass
+
+        val constructor = toStringMethod.classDef.methods.first { it.name == "<init>" }
+
+        // The constructor's first String parameter is playerType. In Kotlin
+        // data classes, constructor parameters map to registers p1, p2, ...
+        // after p0 (this). We overwrite the playerType register with our
+        // spoofed value. The exact register depends on parameter order —
+        // playerType is first in the data class, so it's p1.
+        constructor.addInstructions(
+            0,
+            """
+                const-string p1, "background_audio"
+            """,
+        )
+
+        // Layer 2 — GrandDads ad-eligibility block
+        //
+        // Short-circuits the shouldDeclineAds method to return
+        // Single.error(...) immediately, preventing the GrandDads GQL
+        // query from ever executing. Downstream callers handle Single
+        // errors gracefully (the ad system treats eligibility failures as
+        // "no ads" — same behavior Purple TV achieves by returning
+        // AdContextUnavailable).
+        //
+        // Technique credit: Purple TV (GrandDads short-circuit approach)
+        DeclineAdsRequestFingerprint.method.addInstructions(
+            0,
+            """
+                new-instance v0, Ljava/lang/Exception;
+                const-string v1, "ads blocked"
+                invoke-direct {v0, v1}, Ljava/lang/Exception;-><init>(Ljava/lang/String;)V
+                invoke-static {v0}, Lio/reactivex/rxjava3/core/Single;->error(Ljava/lang/Throwable;)Lio/reactivex/rxjava3/core/Single;
+                move-result-object v0
+                return-object v0
+            """,
+        )
+    }
+}

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/twitch/ads/SkipAdsPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/twitch/ads/SkipAdsPatch.kt
@@ -10,42 +10,56 @@ package ajstrick81.morphe.patches.twitch.ads
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.bytecodePatch
 import ajstrick81.morphe.patches.twitch.shared.Constants
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.StringReference
 
 @Suppress("unused")
 val skipAdsPatch = bytecodePatch(
     name = "Skip ads",
-    description = "Suppresses Twitch ads by spoofing the playerType on the stream access " +
-        "token request to reduce server-side ad fill. " +
-        "UNTESTED — requires on-device validation.",
+    description = "Reduces Twitch live ads: spoofs the stream access-token playerType to " +
+        "\"embed\" (usher serves an ad-free stream for that context — kills the long SSAI " +
+        "mid-rolls), forces the GrandDads ad-eligibility response to AdContextUnavailable, and " +
+        "forces the ExoPlayer stitched-ad (SSAI) metadata parser to treat every segment as " +
+        "non-ad (suppresses ad tracking/beacons). On-device (v30.2.2, Onn 4K): the long " +
+        "mid-roll ads are gone and the join pre-roll drops to ~15s; a residual short pre-roll " +
+        "remains because it is server-stitched in the native IVS path, which bytecode cannot reach.",
 ) {
     compatibleWith(Constants.COMPATIBILITY)
 
     execute {
 
-        // Layer 1 — playerType spoofing
+        // Layer 1 — playerType spoofing (access-token / clean-stream route)
         //
         // Locate PlaybackAccessTokenParams via its toString() string anchor,
         // then find the constructor in the same class. The constructor takes
-        // the playerType as a String parameter. We prepend instructions that
-        // overwrite the playerType register with "background_audio" before
-        // the original constructor body runs.
+        // the playerType as a String parameter (field `d`, register p1). We
+        // overwrite it before the constructor body runs.
         //
-        // Why "background_audio": this playerType is used by Twitch's own
-        // background playback mode and historically receives no ad fill.
-        // If this value doesn't work, candidates to try (from enum Lr440):
-        //   - "autoplay"
-        //   - "prime_video_on_twitch_mobile" (shared Amazon infra)
-        //   - "embed" (web embed context)
+        // Why "embed": the playerType is baked into the signed streamPlayback
+        // access token, and usher (usher.ttvnw.net) serves an AD-FREE stream
+        // for the "backup" web player contexts. TwitchAdSolutions' `vaft`
+        // treats `embed`/`popout`/`autoplay` as the ad-free player types
+        // (embed = Source quality) and uses `popout` as its forced
+        // access-token type. "embed" is tried first: best quality, and unlike
+        // the vaft web script — which must fight Twitch client-integrity to
+        // spoof the type on the logged-in session and therefore also swaps the
+        // m3u8 — we rewrite the token request at the bytecode source, so the
+        // returned token genuinely encodes `embed` and usher should hand us the
+        // ad-free stream directly. (Prior value "background_audio" did NOT stop
+        // ads on-device 2026-07-31; if "embed" also fails try "popout", then
+        // "autoplay" (360p), then escalate to a backup-stream m3u8 swap.)
         //
-        // Technique credit: TwitchAdSolutions (playerType spoofing concept)
+        // Technique credit: TwitchAdSolutions / vaft (pixeltris) — ad-free
+        // player-type + clean-stream approach.
         //
         // Verified 2026-07-28 against v30.2.2 smali (class `Ls1r;`): the
         // toString() field order in this build is
         // disableHTTPS,hasAdblock,playerBackend,playerType,maid,notificationID
         // — playerType is field `d` (String, non-Optional/required), and the
         // single physical constructor is `<init>(Ljava/lang/String;Lu1q;I)V`
-        // where p1 is iput directly into `d`. So p1 IS playerType here,
-        // confirming the register choice below is correct for this build.
+        // where p1 is iput directly into `d`. So p1 IS playerType here.
         val toStringMethod = PlaybackAccessTokenParamsToStringFingerprint.method
         val paramsClass = toStringMethod.definingClass
 
@@ -54,29 +68,83 @@ val skipAdsPatch = bytecodePatch(
         constructor.addInstructions(
             0,
             """
-                const-string p1, "background_audio"
+                const-string p1, "embed"
             """,
         )
 
-        // Layer 2 — GrandDads ad-eligibility block — REMOVED 2026-07-28.
+        // Layer 2 — force GrandDads ad-eligibility to "AdContextUnavailable"
         //
-        // The DeclineAdsRequestFingerprint pin (Lhs9;->f) was verified WRONG
-        // against v30.2.2 smali: Lhs9; is a shared SAM-lambda dispatch class
-        // (implements Lt5h;, dispatches on a numeric tag field to methods
-        // a/b/c/e/f/i/l/m...), and method `f` in this build is an unrelated
-        // ~700-instruction method that builds playback/ad-context objects and
-        // returns an RxJava2 `io.reactivex.internal.operators.observable.j1`
-        // (Observable), not a Single. It is not shouldDeclineAds.
+        // The decisive choke point. The GrandDads GQL response mapper
+        // (Lwyh;->invoke, tag-4 branch) turns the query result into a
+        // GrandDadsResponse (sealed base Lp0i): a null decision node yields the
+        // AdContextUnavailable singleton Ln0i (INSTANCE = Ln0i;->a:Ln0i;),
+        // otherwise the ads-available variant Lo0i. We short-circuit the mapper
+        // to ALWAYS return the AdContextUnavailable sentinel, so the ad system
+        // never receives a usable ad context — the obfuscated analog of Purple
+        // TV's shouldDeclineAds → GrandDadsResponse.AdContextUnavailable.INSTANCE.
         //
-        // The injected smali also referenced `Lio/reactivex/rxjava3/core/
-        // Single;`, which does not exist anywhere in this app — this build is
-        // RxJava2-only (`io.reactivex.*`, itself R8-renamed to single-letter
-        // classes like `Lio/reactivex/v;`, not "Single"/"Observable" by name).
-        // That reference would have failed to resolve at runtime even if the
-        // method pin had been right.
+        // The guard only fires for tag 4 (the GrandDads mapping). That branch
+        // begins `check-cast p1, Lg0i;` (GrandDadsQuery.Data), so any
+        // non-GrandDads tag-4 use of the shared Lwyh dispatch class would
+        // already ClassCastException — proving tag-4 is GrandDads-exclusive and
+        // this is correctly scoped. Registers v0/v1 are re-initialized by the
+        // original method body (which starts by re-reading the tag), so
+        // clobbering them at entry is safe (.locals 12).
         //
-        // Re-deriving the real GrandDads/shouldDeclineAds call site (finding
-        // it via the "query GrandDads" document string's actual caller chain,
-        // not a guessed lambda-class letter) is follow-up work, not done here.
+        // See Fingerprints.kt for the full "query GrandDads" → Li0i → Lhs9;->f
+        // → Lwyh(0x4) → Ln0i derivation. Version-pinned obfuscated names.
+        //
+        // Technique credit: Purple TV (GrandDads short-circuit →
+        // AdContextUnavailable). Re-derived independently against v30.2.2.
+        GrandDadsResponseMapperFingerprint.method.addInstructions(
+            0,
+            """
+                iget v0, p0, Lwyh;->a:I
+                const/16 v1, 0x4
+                if-ne v0, v1, :not_granddads
+                sget-object v0, Ln0i;->a:Ln0i;
+                return-object v0
+                :not_granddads
+                nop
+            """,
+        )
+
+        // Layer 3 — ExoPlayer stitched-ad metadata suppression (the real SSAI kill)
+        //
+        // tv.twitch.android.shared.player.core.b's onMetadata handler parses each
+        // #EXT-X-DATERANGE tag from the live HLS stream and tests its CLASS
+        // attribute with `"twitch-stitched-ad".equals(class)`. A true result puts
+        // the player into ad handling. We locate that equals→move-result pair and
+        // overwrite the result register with 0, so onMetadata always concludes the
+        // segment is NOT a stitched ad and takes the player's built-in no-ad path.
+        //
+        // The injection index and the result register are resolved dynamically
+        // (not a fixed offset) so register-allocation / instruction drift across
+        // versions doesn't silently move the target — same resilience rationale as
+        // the repo's Peacock dynamic injectors.
+        //
+        // Technique credit: TwitchAdSolutions (client-side stitched-ad strip).
+        StitchedAdMetadataFingerprint.method.apply {
+            val insns = implementation!!.instructions.toList()
+            // First "twitch-stitched-ad" literal = the CLASS-equality check
+            // (a later identical literal is only the ad-event name, not a check).
+            val checkStrIndex = insns.indexOfFirst { insn ->
+                insn.opcode == Opcode.CONST_STRING &&
+                    ((insn as ReferenceInstruction).reference as? StringReference)?.string ==
+                    "twitch-stitched-ad"
+            }
+            // The boolean result of the equals() lands in the next move-result.
+            val moveResultIndex = (checkStrIndex until insns.size).first { i ->
+                insns[i].opcode == Opcode.MOVE_RESULT
+            }
+            val resultRegister = (insns[moveResultIndex] as OneRegisterInstruction).registerA
+            // const/4 covers v0..v15 (register is 4-bit); use const/16 above that.
+            val zeroInsn = if (resultRegister <= 15) {
+                "const/4 v$resultRegister, 0x0"
+            } else {
+                "const/16 v$resultRegister, 0x0"
+            }
+            addInstructions(moveResultIndex + 1, zeroInsn)
+        }
     }
 }

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/twitch/ads/SkipAdsPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/twitch/ads/SkipAdsPatch.kt
@@ -14,9 +14,8 @@ import ajstrick81.morphe.patches.twitch.shared.Constants
 @Suppress("unused")
 val skipAdsPatch = bytecodePatch(
     name = "Skip ads",
-    description = "Suppresses Twitch ads via two layers: spoofs the playerType on the " +
-        "stream access token request to reduce server-side ad fill, and blocks the " +
-        "GrandDads ad-eligibility query to prevent client-side ad decisioning. " +
+    description = "Suppresses Twitch ads by spoofing the playerType on the stream access " +
+        "token request to reduce server-side ad fill. " +
         "UNTESTED — requires on-device validation.",
 ) {
     compatibleWith(Constants.COMPATIBILITY)
@@ -39,16 +38,19 @@ val skipAdsPatch = bytecodePatch(
         //   - "embed" (web embed context)
         //
         // Technique credit: TwitchAdSolutions (playerType spoofing concept)
+        //
+        // Verified 2026-07-28 against v30.2.2 smali (class `Ls1r;`): the
+        // toString() field order in this build is
+        // disableHTTPS,hasAdblock,playerBackend,playerType,maid,notificationID
+        // — playerType is field `d` (String, non-Optional/required), and the
+        // single physical constructor is `<init>(Ljava/lang/String;Lu1q;I)V`
+        // where p1 is iput directly into `d`. So p1 IS playerType here,
+        // confirming the register choice below is correct for this build.
         val toStringMethod = PlaybackAccessTokenParamsToStringFingerprint.method
         val paramsClass = toStringMethod.definingClass
 
-        val constructor = toStringMethod.classDef.methods.first { it.name == "<init>" }
+        val constructor = mutableClassDefBy(paramsClass).methods.first { it.name == "<init>" }
 
-        // The constructor's first String parameter is playerType. In Kotlin
-        // data classes, constructor parameters map to registers p1, p2, ...
-        // after p0 (this). We overwrite the playerType register with our
-        // spoofed value. The exact register depends on parameter order —
-        // playerType is first in the data class, so it's p1.
         constructor.addInstructions(
             0,
             """
@@ -56,26 +58,25 @@ val skipAdsPatch = bytecodePatch(
             """,
         )
 
-        // Layer 2 — GrandDads ad-eligibility block
+        // Layer 2 — GrandDads ad-eligibility block — REMOVED 2026-07-28.
         //
-        // Short-circuits the shouldDeclineAds method to return
-        // Single.error(...) immediately, preventing the GrandDads GQL
-        // query from ever executing. Downstream callers handle Single
-        // errors gracefully (the ad system treats eligibility failures as
-        // "no ads" — same behavior Purple TV achieves by returning
-        // AdContextUnavailable).
+        // The DeclineAdsRequestFingerprint pin (Lhs9;->f) was verified WRONG
+        // against v30.2.2 smali: Lhs9; is a shared SAM-lambda dispatch class
+        // (implements Lt5h;, dispatches on a numeric tag field to methods
+        // a/b/c/e/f/i/l/m...), and method `f` in this build is an unrelated
+        // ~700-instruction method that builds playback/ad-context objects and
+        // returns an RxJava2 `io.reactivex.internal.operators.observable.j1`
+        // (Observable), not a Single. It is not shouldDeclineAds.
         //
-        // Technique credit: Purple TV (GrandDads short-circuit approach)
-        DeclineAdsRequestFingerprint.method.addInstructions(
-            0,
-            """
-                new-instance v0, Ljava/lang/Exception;
-                const-string v1, "ads blocked"
-                invoke-direct {v0, v1}, Ljava/lang/Exception;-><init>(Ljava/lang/String;)V
-                invoke-static {v0}, Lio/reactivex/rxjava3/core/Single;->error(Ljava/lang/Throwable;)Lio/reactivex/rxjava3/core/Single;
-                move-result-object v0
-                return-object v0
-            """,
-        )
+        // The injected smali also referenced `Lio/reactivex/rxjava3/core/
+        // Single;`, which does not exist anywhere in this app — this build is
+        // RxJava2-only (`io.reactivex.*`, itself R8-renamed to single-letter
+        // classes like `Lio/reactivex/v;`, not "Single"/"Observable" by name).
+        // That reference would have failed to resolve at runtime even if the
+        // method pin had been right.
+        //
+        // Re-deriving the real GrandDads/shouldDeclineAds call site (finding
+        // it via the "query GrandDads" document string's actual caller chain,
+        // not a guessed lambda-class letter) is follow-up work, not done here.
     }
 }

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/twitch/shared/Constants.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/twitch/shared/Constants.kt
@@ -1,0 +1,13 @@
+package ajstrick81.morphe.patches.twitch.shared
+
+import app.morphe.patcher.patch.AppTarget
+import app.morphe.patcher.patch.Compatibility
+
+object Constants {
+    val COMPATIBILITY = Compatibility(
+        name = "Twitch",
+        packageName = "tv.twitch.android.app",
+        appIconColor = 0x9146FF,
+        targets = listOf(AppTarget("30.2.2"))
+    )
+}

--- a/testing/config/apps.conf
+++ b/testing/config/apps.conf
@@ -9,3 +9,4 @@ tubi|com.tubitv|Tubi
 vix|com.univision.prendetv|ViX
 paramount|com.cbs.ott|Paramount+
 pluto|tv.pluto.android|Pluto TV
+twitch|tv.twitch.android.app|Twitch


### PR DESCRIPTION
## Summary

Adds a **Twitch live ad-reduction** patch for the official Android TV app (`tv.twitch.android.app`, v30.2.2), addressing #75.

Three crash-free, on-device-validated layers (Onn 4K Plus, GTV):

| Layer | Mechanism | Effect |
|-------|-----------|--------|
| 1 (the win) | Spoof the stream access-token `playerType` → `"embed"` | usher serves an ad-free stream for that web-player context — the long SSAI **mid-rolls are gone** |
| 2 | Force GrandDads ad-eligibility → `AdContextUnavailable` | Client eligibility block (PurpleTV-style, defense-in-depth) |
| 3 | Force the ExoPlayer stitched-ad metadata check `false` | Suppresses ad tracking / beacons / UI |

## Result

- ✅ Long SSAI **mid-roll ads eliminated**
- ✅ Join **pre-roll cut to ~15s** (from 45s+), lower frequency
- ⚠️ A short residual pre-roll **remains** — it is server-stitched in Twitch's **native IVS** playback path, which bytecode cannot reach

## What was tried and ruled out

A fourth layer — stripping ad segments from the live HLS media playlist (à la TwitchAdSolutions) — was prototyped against ExoPlayer's `HlsPlaylistParser` and **proven ineffective on-device**: a hook at the parser's `parse()` entry never fired during live playback (0 calls across a full join with an ad). Twitch live does **not** route through ExoPlayer's stock HLS parser; it feeds ExoPlayer via a custom/native IVS media source. That layer is therefore **not shipped** (diagnostic scaffolding removed).

## Testing

- Built `.mpp` → merged `.apkm` → Morphe CLI patch (`Applied: Skip ads`) → in-place install on Onn 4K
- Launches crash-free (no VerifyError/NoClassDefFound/ClassCast); only the benign Play Core `ERROR_API_NOT_AVAILABLE` non-fatal, present in stock too
- Ad behavior confirmed on repeated cold channel joins: mid-rolls gone, ~15s pre-roll

## Attribution

Techniques independently re-derived against v30.2.2 dex; credit to TwitchAdSolutions/vaft (playerType), PurpleTV (GrandDads), and Xtra (see file headers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
