### PR TITLE
fix(pluto): skip DASH period strip on live (dynamic) manifests

### DIFF
--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/pluto/ads/PlutoDashManifestProbe.java
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/pluto/ads/PlutoDashManifestProbe.java
@@ -75,6 +75,23 @@ public final class PlutoDashManifestProbe {
     public static DashManifest stripAdPeriods(DashManifest manifest) {
         try {
             if (manifest == null) return null;
+
+            // LIVE TV guard. Only VOD is in scope: on-demand titles are STATIC DASH
+            // (manifest.dynamic == false, a fixed set of periods with a known total
+            // duration). Live/linear channels are DYNAMIC DASH — the manifest is
+            // continuously re-issued with a moving live edge and a wall-clock
+            // timeline, and re-basing period startMs there corrupts that timeline:
+            // the player can't advance past a period boundary and loops/rebuffers on
+            // the same few seconds (reported on Nvidia Shield, v1.17.0). Live ads are
+            // real broadcast time and were never removable anyway, so leave dynamic
+            // manifests completely untouched. (VOD briefly serves a dynamic startup
+            // manifest too; passing it through is harmless — the ad periods live in
+            // the static full manifest that follows.)
+            if (manifest.dynamic) {
+                Log.i(TAG, "dynamic (live) manifest -> untouched, periods=" + manifest.getPeriodCount());
+                return manifest;
+            }
+
             int n = manifest.getPeriodCount();
             List<Period> kept = new ArrayList<>();
             long cursor = 0;


### PR DESCRIPTION
## The bug

v1.17.0's `Skip ads` Hook 5 (DASH period strip) broke **Live TV** on Pluto: channels load a few seconds, buffer ~10–15s, replay the same few seconds, and loop. Reported on Nvidia Shield; downgrading to v1.16.0 restored Live TV. VOD was unaffected.

## Cause

`stripAdPeriods` ran on **every** `DashManifestParser.parse` — including live/linear channels. Live TV is **dynamic DASH** (a continuously re-issued manifest with a moving live edge and a wall-clock timeline). Re-basing period `startMs` to a contiguous VOD-style timeline corrupts that, so the player can't advance past a period boundary and loops/rebuffers on the same window.

## Fix

Guard `stripAdPeriods` to return the manifest **untouched when `manifest.dynamic` is true**. Only VOD (static DASH) is in scope, and live ads were never removable anyway (real broadcast time). VOD's brief dynamic startup manifest is also passed through harmlessly — the ad periods live in the static full manifest that follows.

## Verified on-device (Onn 4K, 5.66.0-leanback)

- **Live channels stream normally** — log: `dynamic (live) manifest -> untouched`.
- **VOD still fully stripped** — log: `STRIPPED 47 ad periods, kept 18 content`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)