### PR TITLE
feat(paramount): support v16.17.0 via shouldPlayAd gate; recommend v16.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ I'm just like you — I enjoy watching TV and movies without being bored and ann
 | 🟢 Tubi | `com.tubitv` | Working | `v10.28.5000` | 7/20/26 |
 | 🟢 ViX | `com.univision.prendetv` | Working | `v4.47.2_tv` | 7/11/26 |
 | 🟢 Pluto TV | `tv.pluto.android` | Working — VOD ad breaks removed (video, markers, beacons); LIVE TV ads are broadcast time and remain | `5.66.0-leanback` | 7/3/26 |
-| 🟡 Paramount+ | `com.cbs.ott` | ✅ Use `v16.8.0` — newer versions (`v16.12`) still in development | `v16.8.0` | 7/19/26 |
+| 🟢 Paramount+ | `com.cbs.ott` | Working — VOD ads removed (movies + TV shows, pre-roll + mid-roll); pause ads removed; live TV preserved | `v16.17.0` | 8/4/26 |
 | 🔴 Twitch | `tv.twitch.android.app` | Under Development — untested | `30.2.2` | — |
 | 🔴 Fox One | **Under Development** | — |
 | 🔴 MLB TV | **Under Development** | — |
@@ -89,11 +89,14 @@ All patches follow the same general workflow using **Morphe Manager**:
 
 ### 📡 Paramount+
 
-> ✅ **Recommended version: `v16.8.0`.** This is the version to patch and install right now — it works.
+> 🟢 **Recommended version: `v16.17.0`.** VOD ads (movies **and** TV shows,
+> pre-roll and mid-roll) and pause ads are removed, while **live TV is
+> preserved**. This is the version to patch and install right now.
 >
-> 🔴 Newer versions (`v16.12` and up) are **not yet supported**: they introduced a playback-breaking issue that is still being debugged. Stay on `v16.8.0` until this notice is updated.
+> 🟡 **Stable fallback: `v16.8.0`.** The previous recommended build. Use it only
+> if you can't get `v16.17.0`.
 
-1. Open the **[Paramount+ (Android TV) listing on APKMirror](https://www.apkmirror.com/apk/cbs-interactive-inc/paramount-2/)** and select version **`16.8.0`**
+1. Open the **[Paramount+ (Android TV) listing on APKMirror](https://www.apkmirror.com/apk/cbs-interactive-inc/paramount-2/)** and select version **`16.17.0`** (fallback: `16.8.0`)
 2. ⚠️ This listing is published by **CBS Interactive, Inc.** — the correct publisher. Do **not** use the separate Viacom-published build.
 3. Download the `.apkm` file
 4. Select it in Morphe Manager

--- a/patches/src/main/kotlin/app/morphe/patches/paramount/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/paramount/Fingerprints.kt
@@ -1,28 +1,8 @@
 /*
  * Paramount+ Android TV — Ad Patch Fingerprints
  *
- * Validated against:
- *   v16.8.0  (versionCode 520000464) — com.cbs.ott
- *   v16.12.0 (versionCode 520000571) — com.cbs.ott
- *
- * AD SUPPRESSION MECHANISM (confirmed via APK analysis of v16.8.0 and v16.12.0):
- *
- *   g1.c() builds the player media source (nm0.c) from ek0.s (content URI)
- *   BEFORE DAI initialization begins. This runs for all resource config types.
- *
- *   For VOD:      content URL is non-null → fallback media source is valid.
- *   For live TV:  no pre-DAI content URL exists → fallback media source is null.
- *
- *   STRATEGY: return an empty (but non-null) zzcx StreamRequest from
- *   createVodStreamRequest(). The bundled IMA SDK's zzah.requestStream()
- *   never throws synchronously on an empty/invalid StreamRequest in either
- *   version — it reports the failure later via the registered
- *   AdErrorListener (Luk0; in v16.8.0 / Lcl0; in v16.12.0). That listener's
- *   onAdError(AdErrorEvent) only forwards to the AVIA fallback path
- *   (Ln1;->t0(Boolean, Lml0)) when AdError.getErrorType() is LOAD or PLAY —
- *   but the SDK's own async failure path (zzq.zza(Throwable)) always
- *   classifies this failure as AdErrorType.LOAD, so the unmodified filter
- *   already forwards it. No changes to onAdError() are needed.
+ * Validated against v16.17.0 (versionCode 520000758) — com.cbs.ott.
+ * See ParamountPatch.kt for the mechanism write-up.
  */
 
 package app.morphe.patches.paramount
@@ -30,45 +10,26 @@ package app.morphe.patches.paramount
 import app.morphe.patcher.Fingerprint
 
 // ---------------------------------------------------------------------------
-// Patch 1a: VOD SSAI — createVodStreamRequest (3-arg)
-// Unchanged from v16.8.0 — fingerprint still matches in v16.12.0.
-// ---------------------------------------------------------------------------
-
-internal object VodStreamRequest3ArgFingerprint : Fingerprint(
-    returnType = "Lcom/google/ads/interactivemedia/v3/api/StreamRequest;",
-    custom = { method, _ ->
-        method.name == "createVodStreamRequest" &&
-            method.definingClass ==
-                "Lcom/google/ads/interactivemedia/v3/api/ImaSdkFactory;" &&
-            method.parameterTypes.size == 3 &&
-            method.parameterTypes.all { it == "Ljava/lang/String;" }
-    },
-)
-
-// ---------------------------------------------------------------------------
-// Patch 1b: VOD SSAI — createVodStreamRequest (4-arg)
-// Unchanged from v16.8.0 — fingerprint still matches in v16.12.0.
+// Patch 1: VOD ad gate — AviaDAIResourceProvider.shouldPlayAd(AviaAdPod)
 //
-// NOTE: v16.12.0's IMA SDK also adds a 5-arg overload taking a
-// StreamRequest$StreamTrackingMode parameter, but it is not called anywhere
-// in Paramount's app code (confirmed: the only real VOD call site,
-// Lyk0;->run(), still calls the 3-arg overload). No fingerprint needed for it.
+// The AVIA DAI provider gates each ad pod through shouldPlayAd(); its position
+// monitor (AviaDAIResourceProvider$3) skips the pod natively when this returns
+// false. Forcing false removes VOD pre-roll ads while the DAI stream keeps
+// playing. Private direct method, matched by name + defining class.
 // ---------------------------------------------------------------------------
 
-internal object VodStreamRequest4ArgFingerprint : Fingerprint(
-    returnType = "Lcom/google/ads/interactivemedia/v3/api/StreamRequest;",
+internal object ShouldPlayAdFingerprint : Fingerprint(
+    returnType = "Z",
     custom = { method, _ ->
-        method.name == "createVodStreamRequest" &&
-            method.definingClass ==
-                "Lcom/google/ads/interactivemedia/v3/api/ImaSdkFactory;" &&
-            method.parameterTypes.size == 4 &&
-            method.parameterTypes.all { it == "Ljava/lang/String;" }
+        method.name == "shouldPlayAd" &&
+            method.definingClass.endsWith(
+                "/player/resource/dai/AviaDAIResourceProvider;",
+            )
     },
 )
 
 // ---------------------------------------------------------------------------
 // Patch 2: Pause ads — CbsPauseWithAdsOverlay state machine
-// Unchanged from v16.8.0.
 // ---------------------------------------------------------------------------
 
 internal object PauseAdOverlayFingerprint : Fingerprint(

--- a/patches/src/main/kotlin/app/morphe/patches/paramount/ParamountPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/paramount/ParamountPatch.kt
@@ -2,33 +2,34 @@
  * Paramount+ Android TV — Ad Suppression Patch
  *
  * Validated against:
- *   v16.8.0  (versionCode 520000464) — com.cbs.ott
+ *   v16.8.0  (versionCode 520000464) — com.cbs.ott  [empty-request era, see history]
  *   v16.12.0 (versionCode 520000571) — com.cbs.ott
+ *   v16.17.0 (versionCode 520000758) — com.cbs.ott  [current mechanism]
  *
- * Coverage:
- *   ✅ VOD SSAI ads  — createVodStreamRequest() returns empty zzcx →
- *                      DAI fails → bundled IMA SDK reports an
- *                      AdErrorType.LOAD/AdErrorCode.INTERNAL_ERROR failure
- *                      via the app's own onAdError() listener (unmodified
- *                      LOAD/PLAY filter already forwards it) →
- *                      ErrorCriticalEvent → nm0.c-equivalent fallback →
- *                      content plays from cbsaavideo.com without SSAI ads
- *   ✅ Pause ads     — CbsPauseWithAdsOverlay state machine
- *   ➡️ Live TV       — DAI untouched (live TV has no fallback content URL)
+ * MECHANISM (v16.17.0, on-device verified 2026-08-04):
+ *   The AVIA player's DAI resource provider
+ *   (com.paramount.android.avia.player.resource.dai.AviaDAIResourceProvider)
+ *   gates every ad pod through shouldPlayAd(AviaAdPod). Its position monitor
+ *   (AviaDAIResourceProvider$3) checks shouldPlayAd for each unwatched pod and,
+ *   when it returns false, takes the app's own native skip-the-pod path — the
+ *   ad break never starts, the DAI stream keeps playing, and content resumes
+ *   with no black screen. Forcing shouldPlayAd() -> false therefore removes
+ *   VOD pre-rolls (movies + TV) cleanly. Confirmed ad-free on titles that
+ *   previously served a 120s pre-roll; playback healthy.
  *
- * NOTE ON onAdError(): an earlier revision of this patch additionally
- * deleted the LOAD/PLAY type filter inside onAdError() (class Luk0; in
- * v16.8.0 / Lcl0; in v16.12.0), believing the empty-StreamRequest failure
- * fell outside that filter on v16.12.0. Bytecode tracing of the bundled IMA
- * SDK showed otherwise: requestStream() never throws synchronously in either
- * version, and the SDK's own async failure path (zzq.zza(Throwable)) always
- * classifies the resulting error as AdErrorType.LOAD, which the *unmodified*
- * filter already forwards to the fallback. Deleting the filter instead
- * forwarded every onAdError() call — including benign, non-fatal ad errors
- * unrelated to our induced empty request — straight into the critical-error
- * teardown path, killing otherwise-working VOD playback (spinner, then a
- * dark screen). That filter removal has been reverted; only Patches 1 and 2
- * below remain.
+ *   This SUPERSEDES the earlier empty-createVodStreamRequest approach, which
+ *   worked on v16.8.0 but on v16.17.0 kills the video entirely (v16.17 VOD is
+ *   DAI-only with no separate content stream to fall back to) and, on v16.12.0,
+ *   provoked an IMA retry storm / ANR. The empty-request and DAI-retry patches
+ *   have been removed in favour of the shouldPlayAd gate.
+ *
+ * Coverage (v16.17.0, on-device verified):
+ *   ✅ VOD ads, pre-roll AND mid-roll (movies + TV) — shouldPlayAd() gates every
+ *      pod, so both are skipped. Cosmetic seekbar markers may remain on TV
+ *      episodes but no ad plays through them.
+ *   ✅ Pause ads                     — CbsPauseWithAdsOverlay state machine
+ *   ✅ Live TV                       — preserved; streams cleanly (shouldPlayAd
+ *      is shared VOD/live but the live path is unaffected on-device)
  */
 
 package app.morphe.patches.paramount
@@ -40,41 +41,30 @@ import app.morphe.patches.shared.compat.AppCompatibilities
 @Suppress("unused")
 val paramountPatch = bytecodePatch(
     name = "Paramount+ Android TV",
-    description = "Removes VOD ads and pause ads while preserving live TV.",
+    description = "Removes VOD pre-roll ads and pause ads while preserving live TV.",
 ) {
     compatibleWith(AppCompatibilities.PARAMOUNT_TV)
 
     execute {
         // ------------------------------------------------------------------
-        // Patch 1: VOD SSAI — createVodStreamRequest (3-arg and 4-arg)
+        // Patch 1: VOD ad gate — DAIResourceProvider.shouldPlayAd(AviaAdPod)
         //
-        // Returns a valid but empty zzcx StreamRequest. No contentSourceId,
-        // videoId, or apiKey setters are called. Unchanged from v16.8.0.
-        // The bundled IMA SDK reports the resulting failure as
-        // AdErrorType.LOAD, which the app's own (unmodified) onAdError()
-        // listener already forwards to the AVIA ErrorCriticalEvent fallback.
+        // Return false for every pod so the provider's position monitor takes
+        // its native skip path instead of engaging the ad break.
         // ------------------------------------------------------------------
-        arrayOf(
-            VodStreamRequest3ArgFingerprint,
-            VodStreamRequest4ArgFingerprint,
-        ).forEach { fingerprint ->
-            fingerprint.method.addInstructions(
-                0,
-                """
-                    new-instance v0, Lcom/google/ads/interactivemedia/v3/impl/zzcx;
-                    sget-object v1, Lcom/google/ads/interactivemedia/v3/internal/zzafv;->zzd:Lcom/google/ads/interactivemedia/v3/internal/zzafv;
-                    invoke-direct {v0, v1}, Lcom/google/ads/interactivemedia/v3/impl/zzcx;-><init>(Lcom/google/ads/interactivemedia/v3/internal/zzafv;)V
-                    return-object v0
-                """.trimIndent(),
-            )
-        }
+        ShouldPlayAdFingerprint.method.addInstructions(
+            0,
+            """
+                const/4 v0, 0x0
+                return v0
+            """.trimIndent(),
+        )
 
         // ------------------------------------------------------------------
         // Patch 2: Pause ads — CbsPauseWithAdsOverlay state machine
         //
-        // Independent of IMA DAI. return-void prevents Glide image fetch,
-        // alpha fade-in, and overlay render. Overlay stays at alpha=0.
-        // Unchanged from v16.8.0.
+        // return-void prevents Glide image fetch, alpha fade-in, and overlay
+        // render. Overlay stays at alpha=0.
         // ------------------------------------------------------------------
         PauseAdOverlayFingerprint.method.addInstructions(
             0,

--- a/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
@@ -10,6 +10,7 @@ object AppCompatibilities {
     packageName = "com.cbs.ott",
     appIconColor = 0x0064FF,
     targets = listOf(
+        AppTarget("16.17.0"),
         AppTarget("16.12.0"),
         AppTarget("16.8.0"),
        ),


### PR DESCRIPTION
## Summary

Adds Paramount+ **v16.17.0** support and makes it the recommended version. The v16.8.0 mechanism (empty `createVodStreamRequest`) **breaks** v16.17.0 playback, so this switches to the AVIA player's own ad gate.

## Why the old approach failed on v16.17.0

v16.17.0 VOD is **DAI-only** — there's no separate content stream to fall back to. Emptying the ad `StreamRequest` therefore kills the video itself (black screen + allocation-storm ANR). This was cleanly isolated on-device: an ad-patch-**disabled** but identically-signed build plays the movie fine, so the ad patch was the sole cause.

## The fix

Force `AviaDAIResourceProvider.shouldPlayAd(AviaAdPod)` → **false**. The provider's position monitor (`AviaDAIResourceProvider$3`) then takes its **native skip-the-pod path** for every unwatched pod — ad breaks never start, the DAI stream keeps playing, content resumes with no black screen. One method, plus the existing pause-ad hook.

Removes the now-obsolete empty-StreamRequest and DAI-retry patches.

## On-device verification (v16.17.0, Onn 4K)

- ✅ VOD **pre-roll + mid-roll** ads removed — movies **and** TV shows
- ✅ Pause ads removed (`CbsPauseWithAdsOverlay`)
- ✅ **Live TV preserved** — streams cleanly (shared VOD/live method, live path unaffected)
- ✅ Resume-from-Continue-Watching, seeking/scrubbing — all work, no ANR

## Notes / follow-ups

- `shouldPlayAd→false` is expected to work on v16.8.0/v16.12.0 too (same AVIA library) but is **only on-device verified on v16.17.0**. v16.8.0 is kept as a **stable fallback** in the README; verify before changing that.
- Cosmetic seekbar markers may remain on some TV episodes, but no ad plays through them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)