### PR TITLE
feat(netflix): native ad-strip + privacy for the living-room Netflix app (clone-based, on-device verified)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ node_modules/
 # Ignore IDEA files
 .idea/
 local.properties
+
+# Netflix frida-gadget capture binary (large, ABI-specific, not ours to redistribute)
+patches/src/main/resources/netflix/native/**/*.so

--- a/experimental/netflix-native-adstrip/ADS-EMPTY-POD-SEAM.md
+++ b/experimental/netflix-native-adstrip/ADS-EMPTY-POD-SEAM.md
@@ -110,6 +110,55 @@ a && "v3"===a.manifestVersion && !a.processed && (
 NEXT: pick a seam (JS reviver vs native MSL) and build a SINGLE pre-playback proof-of-kill, verified
 against the `ads:[]/ads:[{}]` oracle. No re-patch loops.
 
+## PROOF-OF-KILL — ACHIEVED 2026-08-07 (prepareAdBreakStates seam) ✅
+
+Picked the **JS object seam** (covers both compressed pre-roll path AND uncompressed hydration
+mid-roll path — the native MSL/gunzip seam only covers the compressed path, see below).
+
+**Why native MSL was NOT used:** on-device hooks proved (a) libnetflix statically links OpenSSL
+(its own `EVP_DecryptUpdate @libnetflix+…`, 12k calls, 0 contained `adBreaks` → manifest is
+compressed at that layer); (b) `Manifest(a,b)` = `a.compressed ? JSON.parse(_uncompress(a.manifest,
+"gzip",false)) : a.manifest` — so **mid-roll hydration responses take the UNCOMPRESSED path** (already
+an object, no gunzip) → a native gunzip-output transform would miss mid-rolls. The JS object layer is
+the only convergence point for both.
+
+**The chokepoint:** `AdsState.prepareAdBreakStates(a)` (@4259343 in dump) — iterates every ad break,
+called from BOTH `adsState.rebuild()` and `createInnerWorkingPlaygraph()` right before
+`createAdsPlaygraph` builds ad segments. Runs on all paths, pre-segment-build.
+
+**The patch (single, pre-playback, length-preserving 128B, NO re-patch loop):** replace the loop body
+```
+OLD: var f=e.value;f.syncAdStates();f.state.isHydrated&&"viewable"!==f.metadata.source&&f.applyHydration(f.state.hydrationSequenceId)
+NEW: var f=e.value;f.metadata&&(f.metadata.ads.length&&(f.__adkill=f.metadata.ads.length),f.metadata.ads=[]);f.syncAdStates();/*...*/
+```
+→ empties `metadata.ads=[]` for every break so all consumers (segment build, lease, dropped-ads,
+duration) see no ads → `emptyAdBreakComplete` → content plays. The `f.__adkill=<count>` stamp is a
+self-proof: that property name exists ONLY if a break with `ads.length>0` (a real server ad) was
+emptied.
+
+**PROOF (read-only marker monitor, `nfverify/kill-observe.js`; log = `PROOF-prepareAdBreakStates-2026-08-07.log`):**
+```
+OBS7: KILLMARK=2 rawRealPods=3 ...  <<< patch emptied 2 break(s) that HAD real ads
+OBS9: KILLMARK=2 rawRealPods=3 ...
+```
+- `rawRealPods=3` = server delivered 3 real ad pods (raw-JSON `ads":[{`, data-only signature).
+- `KILLMARK=2` (baseline 1 = our own patch source; ≥2 = Hermes interned `__adkill` because we stamped a
+  real-ad break) = patch emptied genuinely-populated breaks.
+- On-screen: no ads played across many titles + many mid-roll seeks (pre-rolls AND mid-rolls gone).
+Server sent real ads → patch emptied them → nothing played. Demonstrated, not inferred.
+
+**Process lesson that made the proof possible:** "did an ad play" is a broken oracle (server empty-fills
+~2/3). The `__adkill` self-stamp + `rawRealPods` raw-JSON counter disambiguate our kill from server
+empty-fill — essential given the earlier chaos.
+
+### Remaining before shippable
+- Delivery is currently a runtime frida-heap source-patch (proof rig). Shippable form = in-process
+  native transform applied at appboot load (appboot JS is downloaded + hash-verified → patch in-process
+  past the signature; mind `milo_ignore_hash_errors`), OR bake into the clone's gadget bootstrap.
+- Ship WITHOUT the `__adkill` stamp (that was proof-only); the production edit is just
+  `f.metadata&&(f.metadata.ads=[]);` + padding.
+- Verify longevity across app restart / appboot re-download; re-confirm the OLD byte pattern per version.
+
 ## Tooling (read-only, in `nfverify/`)
 - `capture-real.js` — READ-ONLY periodic heap dumper (overwrites `real_*.bin` each cycle; pull while
   ad is on screen). Markers above.

--- a/experimental/netflix-native-adstrip/ADS-EMPTY-POD-SEAM.md
+++ b/experimental/netflix-native-adstrip/ADS-EMPTY-POD-SEAM.md
@@ -1,0 +1,83 @@
+# Netflix ad suppression — the `ads:[]` empty-pod seam (data-grounded) — 2026-08-07
+
+This supersedes the guess-and-check phase. We stopped trusting "did an ad play on screen"
+(a broken oracle) and captured the **actual decrypted manifest ad-break data** in-process
+during a confirmed live mid-roll. That gave us both a reliable oracle and the correct
+suppression transform.
+
+## The broken oracle (why results were "all over the place")
+
+Netflix's server **does not serve an ad on every ad break.** Unpatched baseline testing showed
+~2 of 3 titles play the pre-roll *marker* but **no ad** (empty fill). So every earlier
+"3 of 4 clean!" result was partly/entirely the server's own random ad-fill, not our patch.
+Judging a patch by whether an ad visibly played, at n=3–4, is meaningless. This matches the
+long-standing thesis in memory ("the app's own no-ad path runs 6/7 titles").
+
+## Ground truth captured (read-only heap dump during a live mid-roll)
+
+Method: `capture-real.js` (READ-ONLY; reads heap, writes dumps to app files dir, **no patching**).
+Clean data markers that are 0 at browse and non-zero only during a real ad:
+`adBreakToken, adEventToken, viewableAdBreakIndex, occurredAdBreaks, adBreakHydrated`.
+Forced a reliable real ad by **fast-forwarding to a mid-roll** (server empty-fills pre-rolls
+too often to be a dependable trigger). Pulled the fresh dump while the ad was on screen.
+
+The decrypted manifest response JSON is plaintext in the Hermes heap (past MSL). Two shapes:
+
+**Real ad served (populated):**
+```json
+"adverts":{"adBreaks":[{"ads":[{"timedAdEvents":[
+  {"event":"adProgress","timeMs":7500,"adEventToken":"BgiJvevcAxLmAp++..."},
+  {"event":"adProgress","timeMs":15000,"adEventToken":"BgiJvevcAxLmAmPy..."}],...},{...second ad...}],
+  "actionAdBreakEvents":{...},...}]}
+```
+
+**Server's own no-ad path (empty):**
+```json
+"adverts":{"adBreaks":[{"ads":[],"actionAdBreakEvents":{
+  "start":{"event":"adBreakStart","adEventToken":"BgiJvevcAxKXAiwx..."},
+  "stop":{"event":"adBreakStop","adEventToken":"BgiJvevcAxKXAlnH..."}},...}]}
+```
+
+**Oracle:** `"ads":[]` = no ad; `"ads":[{…}]` = real ad. Binary, readable in-process,
+independent of what the screen shows.
+
+Sample dumps saved: `nfverify/realad/SAMPLE_fullbreak.bin`, `SAMPLE_emptybreak.bin`.
+
+Also captured: the **hydration request** body (`fetchType:1`, movie `80210920`) carrying the real
+`adBreakToken` — confirms mid-rolls go through dynamic hydration (request → response with `ads[]`).
+
+## The correct suppression transform
+
+Rewrite `"ads":[{…}]` → `"ads":[]` inside each ad break of the **decrypted manifest response**,
+leaving `actionAdBreakEvents` (start/stop beacon shells) intact. This is **byte-identical to
+what Netflix's server returns 2/3 of the time**, so the client's own no-ad path handles it
+(`emptyAdBreakComplete` → content plays). No structural mutation, no lie to the server →
+**no `tvq-pb-101`.** Direct analogue of AdGuard emptying PV's ad pod / the AmazOff rig.
+
+### Why the earlier approaches failed (now explained)
+- `supportsAdBreakHydration=false` (lie to server) → `tvq-pb-101` (server refuses).
+- `NullAdPolicy dropAdBreak=true` / `hasAds=false` (remove breaks) → `tvq-pb-101` (playgraph
+  expects the breaks it was told about).
+- `enableAdPlaygraphs=false` → looked ~3/4 clean but that was mostly server empty-fill noise;
+  seek mid-rolls still played.
+- **Persistent 4s re-patch loop was corrupting the app** (writing JS source mid-load) → the
+  intermittent `tvq-pb-101`. Rule: apply any patch **once, pre-playback**; never hammer live memory.
+
+## The one hard problem left (well-defined)
+
+The `ads[]→[]` transform must hit the JSON **before `JSON.parse`** — post-parse heap edits do
+nothing, and MSL encryption blocks a network-layer MITM (unlike PV). Config says the manifest is
+parsed with a **reviver** (`transformationMethod:"reviver"`). NEXT: locate the manifest reviver /
+MSL-decrypt→parse boundary in the heap (the module that receives the decrypted manifest string and
+calls `JSON.parse(text, reviver)`), and apply the transform there — once per playback, reliably.
+
+## Tooling (read-only, in `nfverify/`)
+- `capture-real.js` — READ-ONLY periodic heap dumper (overwrites `real_*.bin` each cycle; pull while
+  ad is on screen). Markers above.
+- `run-diag.py <script> <secs>` — frida-17 attach/resume driver (native-only; no Java/JS bridge).
+- Sample ground-truth: `nfverify/realad/SAMPLE_fullbreak.bin` (ads populated),
+  `SAMPLE_emptybreak.bin` (ads:[]).
+
+## Discipline going forward
+Fixed test protocol; measure against the `ads:[]/ads:[{}]` oracle, not the screen. One pre-playback
+patch at a time. Never re-patch live memory in a loop.

--- a/experimental/netflix-native-adstrip/ADS-EMPTY-POD-SEAM.md
+++ b/experimental/netflix-native-adstrip/ADS-EMPTY-POD-SEAM.md
@@ -63,13 +63,52 @@ what Netflix's server returns 2/3 of the time**, so the client's own no-ad path 
 - **Persistent 4s re-patch loop was corrupting the app** (writing JS source mid-load) → the
   intermittent `tvq-pb-101`. Rule: apply any patch **once, pre-playback**; never hammer live memory.
 
-## The one hard problem left (well-defined)
+## The reviver / manifest-processing seam — LOCATED 2026-08-07 (offsets in hydrator-dump/big1.bin)
 
-The `ads[]→[]` transform must hit the JSON **before `JSON.parse`** — post-parse heap edits do
-nothing, and MSL encryption blocks a network-layer MITM (unlike PV). Config says the manifest is
-parsed with a **reviver** (`transformationMethod:"reviver"`). NEXT: locate the manifest reviver /
-MSL-decrypt→parse boundary in the heap (the module that receives the decrypted manifest string and
-calls `JSON.parse(text, reviver)`), and apply the transform there — once per playback, reliably.
+Decoded the manifest transform chain from the dump. Two precise seams, both found:
+
+**Walker — `reviveObject` (`ha`, @77423) + recursive `ka`:**
+```js
+ha=function(a,b){ null!==a && "object"===typeof a && ka(a,b,void 0,"") }
+ka=function(a,b,d,f){                 // a=value, b=reviver, d=parent, f=key
+  if(Array.isArray(a)) a.forEach(function(v,i){ v=ka(v,b,a,i); void 0!==v?a[i]=v:delete a[i] });
+  else if(object)      for(var k in a){ n=ka(a[k],b,a,k); void 0!==n?a[k]=n:delete a[k] }
+  return b.call(d, f, a)              // calls reviver(key,value) per node, this=parent
+}
+```
+Recurses the ENTIRE manifest object → **does visit `adverts→adBreaks[]→ads`**.
+
+**Reviver — `manifestV2V3Reviver` (`la`, @78725):**
+```js
+la=function(a,b){ return ja.reduce(function(b,d){return d.call(this,a,b)}.bind(this), b) }
+```
+`ja` = list of `createDuplicatingReviver` (`ba`, @77785) field-renamers (audioTracks↔audio_tracks,
+cdnList↔cdnlist, …). NO ad logic — passes `ads` through untouched. Exported in module `a(0)` at
+@70215 (`reviveObject`), @70571 (`createDuplicatingReviver`), @70627 (`manifestV2V3Reviver`).
+
+**Chokepoint — processor `b(a,b)` (@~2578970):**
+```js
+a && "v3"===a.manifestVersion && !a.processed && (
+  b.reviveObjectStart=nrdp.mono(),
+  "reviver"===u.transformationMethod ? reviveObject(a, manifestV2V3Reviver) : ... )
+```
+`a` = already-PARSED manifest object; runs ONCE (`!a.processed`), before ad consumption; bracketed by
+`mslParseStart/End` → `reviveObjectStart/End`.
+
+### Two delivery seams (both located)
+1. **JS reviver seam (post-parse object):** the reviver gets `(key,value)` per node. Force it to return
+   `[]` when `key==="ads"` → empties every ad pod (server-no-ad shape), once per manifest, pre-consumption.
+   Injection point = `la=function(a,b){…}` @78725. (Byte-patch length constraints TBD — the body is
+   `la=function(a,b){return ja.reduce(function(b,d){return d.call(this,a,b)}.bind(this),b)}`; an
+   in-place `"ads"===a` guard doesn't fit without displacing bytes — needs a code-cave or the reduce
+   seed swap. Design pending.)
+2. **Native MSL seam (pre-parse text):** `mslParseStart` precedes reviveObject → the raw decrypted
+   manifest JSON text exists at the native MSL-decrypt boundary in libnetflix (frida-17 native-friendly).
+   Apply the `ads:[{}]→ads:[]` TEXT transform there. True transport-layer seam, below the JS line,
+   analogue of the PV MITM rig. Locating the exact libnetflix decrypt→JSON.parse call is the next native step.
+
+NEXT: pick a seam (JS reviver vs native MSL) and build a SINGLE pre-playback proof-of-kill, verified
+against the `ads:[]/ads:[{}]` oracle. No re-patch loops.
 
 ## Tooling (read-only, in `nfverify/`)
 - `capture-real.js` — READ-ONLY periodic heap dumper (overwrites `real_*.bin` each cycle; pull while

--- a/experimental/netflix-native-adstrip/APPBOOT-ADBREAK-SEAM.md
+++ b/experimental/netflix-native-adstrip/APPBOOT-ADBREAK-SEAM.md
@@ -1,0 +1,82 @@
+# Netflix appboot — the ad-break resolver (seam found) — 2026-08-07
+
+Dumped the live appboot JS from the running clone's Hermes heap (frida memory dump,
+`nfverify/apbdump/apbad_0xb5740000_5533696.bin` = the ad-context range) and located the ad-break
+resolver. This is the in-process seam the whole reopening was after.
+
+## The resolver (verbatim from the heap, minified)
+
+`MediaEventsAdBreaksModel` — the source of truth for scheduled ad breaks:
+
+```js
+// ctor
+function a(d,b){
+  this.getMediaEventsCutoffTimestamp=d;
+  this.programsModel=b;
+  this.poiMap=new Map;
+  this.adBreaks=new Map;            // ad-break entries land here (via onAdBreakStart / media events)
+  this.normalizedAdBreaks=[];
+  this.normalizedAdBreaksDirty=!1
+}
+
+// THE accessor the player asks for scheduled breaks:
+a.prototype.getAdBreaks=function(){
+  var a=this;
+  if(this.normalizedAdBreaksDirty){
+    var b=this.adBreaks;
+    this.normalizedAdBreaks=Array.from(("function"===typeof b.values?b.values.bind(b):h.arrayValues.bind(null,b))())
+                                 .map(function(b){return a.toNormalizedAdBreak(b)});
+    this.normalizedAdBreaksDirty=!1
+  }
+  return this.normalizedAdBreaks    // <-- return [] here = no scheduled ad breaks
+};
+```
+
+And the public getter that fans out to it (CanonicalMediaEventsModel):
+
+```js
+Object.defineProperties(a.prototype,{adBreaks:{get:function(){return this.adBreaksModel.getAdBreaks()},...}});
+```
+
+## Netflix's OWN no-ad path (predicted by the thesis, confirmed)
+
+There is a built-in ad-DROP subsystem — the client already knows how to run with breaks removed:
+
+```js
+// _droppedAds / calculateDroppedAds / adPoliciesManager.setPoliciesForViewable
+...this._droppedAds.get(a.viewableId)...map(function(a){return a.dropAdBreak||a.dropAds})...
+var l=c.calculateDroppedAds(f,h,n); ... g=l.map(function(a){return a.dropAdBreak||a.dropAds});
+h.forEach(function(a,b){ ...a.state.droppedAdIndices = b.dropAdBreak ? (a.metadata.ads.map((_,i)=>i)) : b.dropAds.slice() });
+```
+
+`dropAdBreak` / `dropAds` are per-viewable flags the app honors to skip breaks — the same "no-ad path
+it runs constantly" (6/7 titles) that motivated reopening Netflix.
+
+## Seam options (in-process, past MSL + both anti-tampers)
+
+- **Seam B (empty the resolver):** force `MediaEventsAdBreaksModel.prototype.getAdBreaks` → `[]`
+  (or the `adBreaks` getter → `[]`). Direct Prime-Video `0===t.length` analogue.
+- **Seam C (use the built-in drop):** drive `calculateDroppedAds` / `dropAdBreak` so every break is
+  dropped — runs Netflix's own removal path.
+- **Seam A (data scrub):** empty `this.adBreaks` (the Map) / the media events that populate it before
+  `getAdBreaks` normalizes — pure data, orthogonal to code-integrity.
+
+## Weaponization (next design question)
+
+appboot JS is downloaded + hash/signature-verified at rest, so we can't patch it on disk. We already
+operate IN-PROCESS past the signature (that's the whole point). Delivery options to evaluate:
+1. Native in-process hook that rewrites the decrypted appboot JS text before Hermes compiles it
+   (seam-A/B on the source) — must not trip the milo hash (recall `milo_ignore_hash_errors`).
+2. Hook the DATA layer feeding `this.adBreaks` (media events / PRS) natively.
+3. Runtime JS override via the injected gadget (proof-of-kill first: overwrite `getAdBreaks` in the
+   Hermes heap to return []), then port to a shippable native transform.
+
+Proof-of-kill target for the next session: hook/replace `getAdBreaks` to return `[]` during a real
+pre-roll and confirm the ad is gone on-device.
+
+## Reproduce
+Clone runs past both anti-tampers (DexGuard CertCheck patch + `<queries>` for RJni_SignatureCheck),
+logged in. `nfverify/`: `nf-listen2.apk` (gadget+fix), `run-diag.py`, `dump-appboot.js`
+(dumps heap ranges via `File` to app files dir → `adb exec-out run-as … cat` to pull),
+`ctx.py`/`ctx2.py` (context extractors). Vocabulary counts that led here: `adBreakHydrator`,
+`getAdBreakData`, `adBreaksModel`, `dropAdBreak`, `getAdBreaks`.

--- a/experimental/netflix-native-adstrip/APPBOOT-ADBREAK-SEAM.md
+++ b/experimental/netflix-native-adstrip/APPBOOT-ADBREAK-SEAM.md
@@ -74,6 +74,28 @@ operate IN-PROCESS past the signature (that's the whole point). Delivery options
 Proof-of-kill target for the next session: hook/replace `getAdBreaks` to return `[]` during a real
 pre-roll and confirm the ad is gone on-device.
 
+## 2026-08-07 proof-of-kill attempt on getAdBreaks → NEGATIVE (wrong seam)
+
+Rewrote `MediaEventsAdBreaksModel.getAdBreaks` SOURCE in the Hermes heap to `return[]`
+(length-preserving, span 290B; `kill-getadbreaks.js`, patched the single live copy pre-playback so
+Hermes' lazy compile would pick it up). On-device with a logged-in ad-tier account: **the 15s pre-roll
+STILL PLAYED.** So `getAdBreaks` is NOT the insertion point — it's the reactive media-EVENTS model
+(`onAdBreakStart`/`occurredAdBreaks`) that records breaks as they happen for UI/telemetry; emptying it
+just blinds the UI. (Also can't rule out eager Hermes compilation, but the reactive-model reason is
+sufficient.)
+
+**Corrected seam = the ad-break HYDRATOR (scheduler).** Heap vocabulary (from the ad-context dump)
+points straight at it: `adBreakHydrator` (22), `adBreakLocationMs` (28), `canHydrate` (20),
+`isHydrated`/`hydrated`/`adBreakHydrated`, `hydrationSequenceId` (19), `unhydratedAdBreak` (9), and
+notably **`adBreakHydrationSkipped` (9)** — the app already has a skip path. This layer builds the
+scheduled breaks (incl. the pre-roll) from the server playbackContext BEFORE playback.
+
+**NEXT (precise):** dump during a live pre-roll, pull the `adBreakHydrator` / `canHydrate` /
+`unhydratedAdBreak` code, then try: force `canHydrate`→false, or drive `adBreakHydrationSkipped`, or
+empty the unhydrated-break list / scrub the server ad-break data in the playbackContext (seam A). Then
+re-run the on-device pre-roll test. Tooling ready (dump-appboot.js dumps ad-context ranges when
+`adBreak` markers appear during playback).
+
 ## Reproduce
 Clone runs past both anti-tampers (DexGuard CertCheck patch + `<queries>` for RJni_SignatureCheck),
 logged in. `nfverify/`: `nf-listen2.apk` (gadget+fix), `run-diag.py`, `dump-appboot.js`

--- a/experimental/netflix-native-adstrip/HANDOFF.md
+++ b/experimental/netflix-native-adstrip/HANDOFF.md
@@ -11,6 +11,37 @@ detail below (`PORTABILITY-ASSESSMENT.md`) remain the full architecture context;
 
 ---
 
+## 0. Session re-verify (2026-08-06, on-device 13.0.1-25028)
+
+Ran REOPENING.md **step 1** against the *current* device APK (Netflix updated 25009 → **25028**;
+pulled `split_config.armeabi_v7a.apk` off the Onn at `.211`, extracted `libnetflix.so`, 88.5 MB).
+**All seam markers survive** — architecture is unchanged by the bump:
+
+| marker | count | meaning |
+|---|---|---|
+| `HERMESATOM` | 1 | Hermes engine present |
+| `appboot_fail_nas_verify` / `appboot_key` | 2 / 5 | appboot signature door present |
+| `RSASSA` / `SPKI` | 15 / 31 | appboot pubkey verify present |
+| `getMslEncoderFactory` / `MslEncoderFormat` | 53 / 18 | MSL layer present |
+| `milo.prod.js` / `milo_update_url` / `milo_ignore_hash_errors` | 6 / 1 / 3 | milo present |
+| `libandroid_netflix` / `OpenSSL 3.2.1` | 1 / 43 | soname + crypto unchanged |
+
+**⭐ BONUS FINDING (upgrades the seam strategy):** the appboot / nrdp / milo layer is embedded as
+**plain minified JavaScript source**, NOT Hermes bytecode (HBC). Proof: the `appboot_fail_nas_verify`
+and `milo_ignore_hash_errors` strings appear *inside readable JS* — e.g. `l.declare({appboot_key:…,
+appboot_fail_nas_verify:["appboot_fail_nas_verify",!1],…})` and
+`if(fe.milo_ignore_hash_errors){…warn("Allowing insecure response…")}`. HERMESATOM=1 / "Hermes "=0
+means Hermes is the *runtime* but boot scripts are loaded as JS via `nrdp.gibbon.loadScript`.
+Consequence: **seams B and C (live-edit the appboot ad-break resolver to force its own empty return)
+are viable**, not just seam A (data scrub) — the resolver will be readable JS in the heap. This was
+the main open risk from the assessment ("if dumps are HBC, lead with seam A"); it is retired.
+
+Also surfaced: `appboot_test_response`, `appboot_drop_mt`, `appboot_ignore_retrycontrol` config
+knobs worth probing during dump analysis. **Next = REOPENING.md step 2 (build gadget APK).** Blocker:
+no armeabi-v7a frida-gadget `.so` present locally yet (only an unrelated arm64 frida-*server* on D:).
+
+---
+
 ## 1. What this was
 
 A portability experiment: *does the "native in-process ad-strip toolkit" (built from the Prime

--- a/experimental/netflix-native-adstrip/HANDOFF.md
+++ b/experimental/netflix-native-adstrip/HANDOFF.md
@@ -37,8 +37,42 @@ are viable**, not just seam A (data scrub) — the resolver will be readable JS 
 the main open risk from the assessment ("if dumps are HBC, lead with seam A"); it is retired.
 
 Also surfaced: `appboot_test_response`, `appboot_drop_mt`, `appboot_ignore_retrycontrol` config
-knobs worth probing during dump analysis. **Next = REOPENING.md step 2 (build gadget APK).** Blocker:
-no armeabi-v7a frida-gadget `.so` present locally yet (only an unrelated arm64 frida-*server* on D:).
+knobs worth probing during dump analysis.
+
+### Step 2 DONE — gadget capture APK built & verified (2026-08-06)
+
+- Downloaded `frida-gadget-17.9.1-android-arm` (ELF32 ARM), staged at
+  `patches/src/main/resources/netflix/native/armeabi-v7a/libgadget.so` (16 MB; **gitignored** via
+  `patches/src/main/resources/netflix/native/**/*.so`). Both gadget patches now list + enable in the
+  CLI. Merged base+armv7a → universal, patched → `nf-gadget.apk`. VERIFIED in the output APK:
+  `lib/armeabi-v7a/libgadget.so` + `libgadget.config.so`, `System.loadLibrary("gadget")` in
+  classes3.dex (absent in original), manifest `debuggable="true"` + `extractNativeLibs="true"`,
+  Morphe-signed. The build path is reproducible.
+
+### Step 3 BLOCKED — Netflix is a PREINSTALLED SYSTEM APP on the Onn (can't replace on non-root)
+
+On-device proof (`.211`): installed Netflix is Play-signed `bcfa260e`, `firstInstallTime=2008-12-31`
+(epoch → system image), and appears under `pm list packages -s`. Consequences:
+- In-place update of the Morphe-signed gadget build → `INSTALL_FAILED_UPDATE_INCOMPATIBLE`
+  (signatures differ). Expected.
+- `pm uninstall -k` only removed the **25028 update**, reverting to the **system-image base
+  12.1.1-23010**; the retained data still carries the old signer so the re-signed install still fails.
+- Full `adb uninstall` → **`DELETE_FAILED_INTERNAL_ERROR`** — a system app can't be removed without
+  root. So the gadget APK **cannot be installed over the stock package** on this non-rooted device.
+  This is the same wall as [[vix-onn-tv-keystore-mismatch]], but harder (system app, not just key
+  mismatch). **Device was restored**: reinstalled the original Play-signed 25028 splits via
+  `adb install-multiple` → Success, back to 25028/`bcfa260e`, login data preserved.
+
+### Unblock path = CLONE the package (next step)
+
+The gadget build only fails because it collides with the stock package identity. A **package-rename
+clone** (à la the repo's existing `CloneAppPatch` for Pluto/Peacock/PV) gives it a NEW package name →
+no signer/system collision → installs ALONGSIDE stock Netflix, debuggable + gadget-injected. The
+appboot bundle loads at boot/browse (before playback), so even if Widevine playback refuses inside a
+clone, `dump_appboot.js` (libc I/O taps + heap scan) can still fire during startup and yield the JS
+appboot dump. RISK: Netflix has many hardcoded package refs + per-package DRM provisioning; cloning
+may need more than a manifest rename. This is the recommended next investment; alternative is a rooted
+Netflix device / emulator where the stock package can be replaced directly.
 
 ---
 

--- a/experimental/netflix-native-adstrip/HANDOFF.md
+++ b/experimental/netflix-native-adstrip/HANDOFF.md
@@ -177,7 +177,41 @@ frida blocked because the gadget can't read /data/local/tmp under SELinux `untru
 Cert-bypassed clone data dir (via run-as, debuggable) has NO gibbon diskcache yet — it dies before
 fetching appboot, so there's no cached-JS shortcut.
 
-### RECOMMENDATION — switch to a rooted device/emulator (removes 3 of 4 walls)
+### 2026-08-07 (cont.) — NATIVE wall CRACKED: clone now RUNS past both anti-tampers
+
+Went with option 2 (native RE, non-root). Enabled frida via the gadget in **listen mode**
+(`on_load:wait` + `adb forward tcp:27042`; frida-python 17.9.1 drives it — note frida 17 removed the
+`Java`/`Module.findExportByName` globals, so scripts are native-only: get JNIEnv via
+`JNI_GetCreatedJavaVMs`, hook the shared JNI function table). Caught `GetObjectClass(null)` with a
+crash-proof `__android_log_write` backtrace:
+```
+GetObjectClass(NULL) <- libnetflix.so!0xeb0d68 <- nativeGibbonStartup+0xd4
+```
+Disassembled (r2) the helper at `0xeb0c3c` + resolved its pc-relative string literals →
+```
+getPackageManager().getPackageInfo("com.netflix.ninja", GET_SIGNATURES /*0x40*/)  -> null
+   source file literal: .../dpi/jni/RJni_SignatureCheck.cpp
+```
+**Root cause:** a SECOND, NATIVE anti-tamper (RJni_SignatureCheck, separate from the DexGuard Java
+CertCheck) hardcodes `getPackageInfo("com.netflix.ninja", GET_SIGNATURES)`. Under the renamed clone
+that's a CROSS-package query, blocked by Android 11+ package visibility → returns null → the JNI
+wrapper (0xea0978) hands back null → `GetObjectClass(null)` → SIGABRT. (Also confirmed it's a
+timing-sensitive path — frida overhead alone sometimes let it pass, which first hinted "race".)
+
+**FIX (shipped, no hooking):** CloneAppPatch now injects `<queries><package
+android:name="com.netflix.ninja"/></queries>`. That restores visibility so the query returns the
+STOCK Netflix PackageInfo — whose signature is the GENUINE Netflix cert — so the native check returns
+non-null AND passes. VERIFIED on-device: clean clone (no gadget, no frida) launches, NO crash, runs
+foreground stable at ~320MB, Widevine `GenerateKeyRequest` provisioning for `com.netflix.ninja.clone`,
+shows in the launcher app list. Both anti-tamper layers now defeated:
+DexGuard CertCheck (bytecode patch) + native RJni_SignatureCheck (`<queries>`).
+
+**NEXT:** rebuild the gadget+fix build (listen mode) and use frida on the now-RUNNING clone to dump
+the appboot bundle from the Hermes heap (REOPENING.md step 4/5): force a pre-roll, sweep for the
+ad-break schema + the empty-break guard (seam B). Open sub-question: does the clone reach login/browse
+(so appboot fully loads) or stall at DRM/network — needs a few minutes of observation / a login.
+
+### (earlier) RECOMMENDATION — switch to a rooted device/emulator (removes 3 of 4 walls)
 
 The clone route proved the CertCheck bypass works and got into Gibbon startup, but each remaining wall
 (native identity now, ESN/MSL/Widevine next) stems from the package RENAME. A **rooted** Android lets

--- a/experimental/netflix-native-adstrip/HANDOFF.md
+++ b/experimental/netflix-native-adstrip/HANDOFF.md
@@ -114,6 +114,43 @@ turn the passive dumper into an active bypass:
 Once the clone survives boot, resume REOPENING.md step 4/5 (force a pre-roll, sweep the Hermes heap
 for the ad-break schema, find the empty-break guard = seam B target).
 
+### DexGuard CertCheck DEFEATED (Java) — new wall is a JNI null in Gibbon startup (2026-08-06)
+
+Wrote the bypass: `patches/.../netflix/misc/security/{Fingerprints.kt,DisableCertCheckPatch.kt}`
+("Disable Netflix CertCheck", default-enabled). The check is one obfuscated Runnable.run() (build:
+`Lo/setReturnTransition$5;`) that calls a verifier `MoMD214(context, "<expected SHA-256>")` and, on
+false, logs `CertCheck failed, crash!!!` then reflectively kills the process. run()'s pass-path is
+just `return`, so the patch prepends `return-void` at index 0 → whole check is a no-op. Anchored on
+the unique crash string (only method in the app that has it), so it survives DexGuard name rotation.
+
+ON-DEVICE (clone, cert-bypass + gadget): the `CertCheck failed` crash is GONE — bypass confirmed.
+The clone now boots FURTHER and dies on a different, non-tamper crash:
+```
+F libc  : Fatal signal 6 (SIGABRT) ... (com.netflix.ninja.clone)
+Abort message: 'JNI DETECTED ERROR IN APPLICATION: java_object == null
+    in call to GetObjectClass
+    from void com.netflix.ninja.NetflixService.nativeGibbonStartup(Surface, String, String, String, boolean, int, int)'
+```
+This is progress: the app reached **Gibbon startup** (where appboot loads). The abort fires ONLY
+because our gadget patch forces `debuggable=true`, which turns on ART **CheckJNI**; a null object arg
+to `nativeGibbonStartup` that stock (non-debuggable) tolerates now hard-aborts. Call site =
+`NetflixService.smali` line ~5527, args v0..v7 = (this, Surface=p1, saveDir, dataDir, v4-string,
+p3, p4, Size.height). Likely-null = the **Surface** during Netflix's speculative/preload UI startup
+(or a clone-rename-broken string). CLI disable flag confirmed = `-d "<patch name>"`.
+
+**NEXT (start here tomorrow — cheap, decisive):**
+1. Build a diagnostic clone WITHOUT the gadget (so NOT debuggable → CheckJNI off):
+   `java -jar $CLI patch -f -e "Clone Netflix" -d "Bundle frida-gadget (Netflix appboot capture)" -d "Load frida-gadget (Netflix appboot capture)" -p $MPP -o nf-clone-nodbg.apk netflix-universal.apk`
+   Install + launch. If it BOOTS/plays → the JNI null was a CheckJNI artifact, and the clone itself
+   is viable; then re-add the gadget but make it NON-debuggable and have dump_appboot.js write dumps
+   to /sdcard (world-readable) instead of app-private + run-as.
+2. If it still crashes non-debuggable → the null is a real clone-rename regression; identify which
+   arg (add a targeted hook / check getSaveDir/getDataDir/StartupParameters under the clone package).
+3. Alternative if the gadget+debuggable combo stays incompatible: root a device/emulator, install the
+   cert-bypassed build over stock (frida-server, no clone, no debuggable-forced CheckJNI).
+Artifacts in scratchpad (nfverify/): netflix-universal.apk, nf-clone2.apk (cert-bypass+gadget),
+nf-clone-full/ (full apktool decode), clonelibs/ (extracted .so).
+
 ---
 
 ## 1. What this was

--- a/experimental/netflix-native-adstrip/HANDOFF.md
+++ b/experimental/netflix-native-adstrip/HANDOFF.md
@@ -1,0 +1,89 @@
+# Netflix ad-strip investigation — session handoff
+
+**For:** a fresh session picking this up. **Status:** ⚠️ **REOPENED** — the earlier
+"not strippable / research-parked / closed" verdict has been **withdrawn**. See
+**`REOPENING.md`** (read it first): the appboot signature was misread as a runtime wall
+when it is a **load-time door**, and the app's own **no-ad path runs 6 of 7 titles**
+(§3e). The live lead is **seam A — scrub ad-break markers from the decrypted manifest
+object in the Hermes heap**, downstream of both MSL and the signature. This doc + the
+detail below (`PORTABILITY-ASSESSMENT.md`) remain the full architecture context; only the
+*conclusion* changed.
+
+---
+
+## 1. What this was
+
+A portability experiment: *does the "native in-process ad-strip toolkit" (built from the Prime
+Video work) port to other APKs?* Test target: **Netflix Android TV** (`com.netflix.ninja`,
+`13.0.0-25009`, armeabi-v7a). Work committed on branch **`claude/toolkit-cross-apk-compat-ku719r`**
+under `experimental/netflix-native-adstrip/`.
+
+## 2. The answer (definitive)
+
+**Netflix's ads cannot be stripped with the toolkit's approach (or DNS, bytecode, or network
+MITM).** They are protected by three independent layers, confirmed both statically and empirically:
+
+```
+TLS (Cronet/static OpenSSL) → MSL (Message Security Layer, in JS) → appboot RSA/ECDSA signature
+```
+and delivered as **pure same-host SSAI** (ad served from the same `oca.nflxvideo.net` Open Connect
+hosts as content). No separate ad host, no third-party beacon, no blockable plane.
+
+The toolkit "ports in spirit but not in mechanism": its premise is hooking a native plaintext seam,
+but Netflix decrypts MSL inside an embedded **Hermes JS engine**, so the plaintext manifest is a
+JS-heap object, not a native buffer — and the ad-bearing player JS is signature-locked.
+
+## 3. Architecture map (measured, not guessed)
+
+- **`libnetflix.so`** (84 MB, soname `libandroid_netflix.so`) = the nrdp monolith: **Hermes** JS
+  engine + **Gibbon** renderer + static **OpenSSL 3.2.1** + **MSL** (implemented in JS). Application
+  subclass `Lcom/netflix/ninja/NetflixService…` → actually `Lcom/netflix/ninja/NetflixApplication;`
+  (`extractNativeLibs=false`). No `lib/` in base.apk; native libs are in the `config.armeabi_v7a`
+  split.
+- **milo** = downloadable JS **networking** layer (HTTP/WS/diskCache/MSL transport). Hash-checked
+  (`milo_ignore_hash_errors` bypass exists). Fetched from
+  `occ.a.nflxso.net/genc/nrdp/milo/<ver>/milo.prod.js`. **Contains NO ad logic** (it's plumbing).
+- **appboot UI app** = the player/UI JS (Gibbon-loaded from `appboot.netflix.com`). **This holds the
+  ad-break logic**, and is **RSA/ECDSA signature-verified** against a pubkey baked into
+  `libnetflix.so` (`appboot_key`/SPKI/RSASSA). This is the wall.
+- **dex** = thin Java shell; no milo loader / JS bridge / integrity class. Every "advert*" string in
+  the app is **Bluetooth LE / MDX casting** or Google Ad-ID, NOT video ads (proven by decompiling
+  `Lo/getArguments;` = the BLE advertiser agent — see `decompiled/BleAdvertiseAgent.deobfuscated.java`).
+- **Empirical capture:** a real 15s pre-roll session hit 18 unique hosts; the ONLY non-Netflix one is
+  `sessions.bugsnag.com` (crash telemetry). Ad came from the same OCA hosts as content = SSAI.
+  Frequency-capped (~7 movies no ad, then one) → ad decision is server-side/in-manifest.
+
+## 4. Committed artifacts (on the branch)
+
+- `experimental/netflix-native-adstrip/PORTABILITY-ASSESSMENT.md` — the full running assessment
+  (§0 toolkit self-check → §3e empirical capture → §8 verdict; also a prior-art survey table).
+- `experimental/netflix-native-adstrip/decompiled/BleAdvertiseAgent.deobfuscated.java` — deobfuscated
+  BLE agent (proof "advert"==Bluetooth, not video ads).
+- **Reusable tooling** (built this session, generic — works for any app in the harness):
+  - `testing/scripts/capture.sh` — drive PCAPdroid on the Onn over adb (start/stop/pull/run, `--decrypt`).
+  - `testing/scripts/analyze_pcap.py` — DNS+SNI host-footprint report from a pcap; `--ad MM:SS-MM:SS`
+    flags AD-ONLY hosts; `--vs ADFREE.pcap` A/B-diffs an ad title against an ad-free one. (needs `scapy`.)
+  - `testing/capture-runbook.md` — the timestamped capture + A/B protocol.
+  - `netflix` added to `testing/config/apps.conf`.
+
+## 5. Local environment / workflow (user's Windows PC + Onn TV)
+
+- **Onn Android TV** at `adb connect 192.168.12.210:5555`. Developer options + Network debugging on.
+- **PCAPdroid** installed on the Onn (`com.emanuelef.remote_capture`); needs its **Control permission**
+  granted for headless adb control. PCAP saves to `/sdcard/Download/PCAPdroid/`.
+- User has **Wireshark** (used tshark/GUI filters), **AdGuard Premium** (PC), and can rig a MITM.
+- **Division of labor:** the cloud session can't reach the LAN/Onn — the user runs captures on their
+  PC and uploads pcaps; the session analyzes them. (adb/PCAPdroid = user side; analyze_pcap = here.)
+- **Files the user has locally (NOT in repo, big/copyright):** the Netflix `.apkm` and its splits,
+  the reassembled `libnetflix.so` (sha256 `b3873f00…`), `milo.debug.js` (5.7 MB), the capture pcaps.
+  A fresh cloud session won't have these — re-request from the user if needed.
+
+## 6. If resuming
+
+- Nothing is pending on Netflix — it's closed. Reopen only if Netflix moves ads to a separable plane
+  (re-run the §3e capture to check for a new non-Netflix ad host).
+- The **capture→analyze pipeline is the real reusable win** — point it at a *softer* target next
+  (an app with clean bytecode ad hooks like the repo's working ones). `analyze_pcap.py --vs` is ideal
+  for any "which hosts are ad-specific" question.
+- Useful Wireshark display filter that nailed it: non-Netflix SNI →
+  `tls.handshake.extensions_server_name and not (…contains "nflx" or …contains "netflix")`.

--- a/experimental/netflix-native-adstrip/HANDOFF.md
+++ b/experimental/netflix-native-adstrip/HANDOFF.md
@@ -151,6 +151,45 @@ p3, p4, Size.height). Likely-null = the **Surface** during Netflix's speculative
 Artifacts in scratchpad (nfverify/): netflix-universal.apk, nf-clone2.apk (cert-bypass+gadget),
 nf-clone-full/ (full apktool decode), clonelibs/ (extracted .so).
 
+### 2026-08-07 — Gibbon null DIAGNOSED: it's NATIVE package-identity coupling, not a fixable arg
+
+Ran the non-debuggable clone: **still SIGABRTs at nativeGibbonStartup** — so the crash is NOT a
+debuggable/CheckJNI artifact (GetObjectClass(null) is a *fatal* JNI error ART aborts on regardless of
+CheckJNI). It's a real null.
+
+Chased which arg via a throwaway bytecode probe (logged args at the caller
+`NetflixService.MoMD214(Surface, StartupParameters, Z, I)` — anchored on the unique "gibbonStartup"
+string; now deleted). Result:
+`GIBPROBE surface=Surface(name=null)/@... params=o.getBackgroundDrawable@...` — **surface and params
+are both non-null.** Combined with static proof that the other two derived args can't be null
+(`getSaveDir`/`getDataDir` return "" on null; `v4 = DetailsSupportFragment.MoMD214(v10, launchUID)`
+returns its input or a built string, never null) → **ALL FOUR Java object args to nativeGibbonStartup
+are non-null.** The `java_object == null in GetObjectClass` therefore fires INSIDE the native impl:
+libnetflix.so calls back into Java for something (a package-keyed lookup / cached class-or-method ref
+/ asset) that returns null under the renamed `com.netflix.ninja.clone` package. (Note the Surface is
+`name=null` — invalid/early — but non-null, so not the abort cause.)
+
+**Conclusion:** the clone's remaining wall is **native package-identity coupling in libnetflix.so**,
+below the Java line — not patchable by fixing an arg. Behind it still looms ESN/MSL/Widevine identity
+(login/playback bound to package). Grinding this means native RE of nativeGibbonStartup (no symbols;
+frida blocked because the gadget can't read /data/local/tmp under SELinux `untrusted_app`).
+
+Cert-bypassed clone data dir (via run-as, debuggable) has NO gibbon diskcache yet — it dies before
+fetching appboot, so there's no cached-JS shortcut.
+
+### RECOMMENDATION — switch to a rooted device/emulator (removes 3 of 4 walls)
+
+The clone route proved the CertCheck bypass works and got into Gibbon startup, but each remaining wall
+(native identity now, ESN/MSL/Widevine next) stems from the package RENAME. A **rooted** Android lets
+us install the CertCheck-bypassed build directly OVER stock `com.netflix.ninja` (no clone, no rename →
+no identity regression) and use frida-server (reads anywhere, no SELinux script-path issue) to dump
+appboot in-process. That sidesteps walls #1 (system app), #3 (native identity), and #4 (ESN/MSL).
+Needs a rooted device — the Onn `.211` isn't. Options: root the Onn, a rooted spare, or an ARM
+Android VM with Widevine. If staying non-root, the only remaining clone path is native RE of
+libnetflix.so's nativeGibbonStartup to find + satisfy the package-keyed null (high effort, more walls
+likely). SHIPPED assets that survive regardless: the "Disable Netflix CertCheck" + "Clone Netflix"
+patches (committed) — both correct and reusable on any device.
+
 ---
 
 ## 1. What this was

--- a/experimental/netflix-native-adstrip/HANDOFF.md
+++ b/experimental/netflix-native-adstrip/HANDOFF.md
@@ -211,6 +211,35 @@ the appboot bundle from the Hermes heap (REOPENING.md step 4/5): force a pre-rol
 ad-break schema + the empty-break guard (seam B). Open sub-question: does the clone reach login/browse
 (so appboot fully loads) or stall at DRM/network — needs a few minutes of observation / a login.
 
+### 2026-08-07 — CAPTURE PATH PROVEN OPEN: appboot JS live in the clone heap
+
+Built the gadget+fix build (listen-mode gadget + `<queries>` fix + CertCheck bypass), attached frida
+to the running clone, and scanned RW memory (native `Memory.scanSync`, results via `__android_log_write`
+tag APBSCAN). Confirmed the appboot bundle is LIVE as PLAIN JS in-process:
+```
+marker "nrdp.gibbon": 943 hits  e.g. "nrdp.gibbon.GibbonWasmComponentContext,Re=n().function Pe(e,...t){const r=Re.was..."
+marker "appboot":     232 hits  e.g. "appboot.netflix.com;nrdp-cell4.prod.ftl.netflix.com;..."
+```
+End-to-end the reopening thesis holds: clone runs past BOTH anti-tampers → appboot loads as readable
+JS in the Hermes heap → readable in-process. "Not strippable" is fully retired.
+
+Tooling that works (scratchpad nfverify/): `nf-listen2.apk` (gadget+fix, listen mode),
+`run-diag.py` (frida-python driver: attach Gadget, load script, resume), `scan-appboot.js`
+(native marker scanner). Launch recipe: `am start` MainActivity (blocks at gadget wait) →
+`adb forward tcp:27042` → `py run-diag.py <script.js> <hold_s>` → re-`am start` to foreground so
+Gibbon keeps a visible Surface.
+
+**NEXT (REOPENING.md step 4/5):**
+1. DUMP the appboot JS: scan for `nrdp.gibbon`, walk the containing rw range, dump it to the app
+   files dir (run-as-pullable) or stream over frida. Reassemble the minified appboot source.
+2. Find the AD-BREAK RESOLVER (seam B): during a real pre-roll (log in first; ad-break markers
+   `adBreak`/`interstitial`/`cuePoint` only populate with playback context — the marker scan for
+   those returned nothing pre-login). Look for the `0===t.length`/empty-break analogue.
+3. Then choose the strip: frida hook (capture) vs a shippable transform (seam A data scrub of the
+   decrypted manifest object, or seam B forcing the resolver's empty return).
+Open: the clone stalls at DRM provisioning / pre-login; needs a login (or observe whether it reaches
+browse) for ad-break context to appear.
+
 ### (earlier) RECOMMENDATION — switch to a rooted device/emulator (removes 3 of 4 walls)
 
 The clone route proved the CertCheck bypass works and got into Gibbon startup, but each remaining wall

--- a/experimental/netflix-native-adstrip/HANDOFF.md
+++ b/experimental/netflix-native-adstrip/HANDOFF.md
@@ -71,8 +71,48 @@ no signer/system collision → installs ALONGSIDE stock Netflix, debuggable + ga
 appboot bundle loads at boot/browse (before playback), so even if Widevine playback refuses inside a
 clone, `dump_appboot.js` (libc I/O taps + heap scan) can still fire during startup and yield the JS
 appboot dump. RISK: Netflix has many hardcoded package refs + per-package DRM provisioning; cloning
-may need more than a manifest rename. This is the recommended next investment; alternative is a rooted
-Netflix device / emulator where the stock package can be replaced directly.
+may need more than a manifest rename.
+
+### Clone BUILT + INSTALLED + launches — but hits DexGuard CertCheck (2026-08-06)
+
+Wrote `patches/.../netflix/misc/clone/CloneAppPatch.kt` (opt-in, default=false), modeled on the
+Pluto clone but with a critical addition: Netflix declares components with RELATIVE names
+(`android:name=".NetflixApplication"`, 16 total), so the patch **expands every relative android:name
+/ targetActivity to its fully-qualified `com.netflix.ninja.*` form BEFORE renaming `package`** — else
+`.Foo` would re-resolve against `com.netflix.ninja.clone` and ClassNotFound at launch. Also renames
+the 3 provider authorities + 11 custom permissions (and propagates renames to
+`android:permission`/read/writePermission). VERIFIED in the built APK: package=`com.netflix.ninja.clone`,
+`.NetflixApplication`→`com.netflix.ninja.NetflixApplication`, zero relative names left, authorities +
+perms uniquified. Installed ALONGSIDE stock (`adb install` Success; both packages listed).
+
+On launch the clone got FURTHER than expected: `com.netflix.ninja.MainActivity` resolved, Widevine
+`createDrmPlugin[com.netflix.ninja.clone]` ran — then the process **died ~2.5s in**. Crash cause
+(logcat): **`E Loader: CertCheck failed, crash!!!`**, and `classes4.dex` contains
+`<DexGuardCertCheckException : DexGuard App CertCheck failed !`. → the final gate is **Guardsquare
+DexGuard's application CertCheck**: an obfuscated runtime check that reads the APK signing certificate
+and deliberately crashes when it isn't Netflix's official cert (this IS the `libc94d.so`/anti-tamper
+the assessment suspected). Note libnetflix.so only leaks `StrictCertCheck` (strings packed); the
+crashing check lives DEX-side in classes4.dex (DexGuard), likely native-reinforced.
+
+**Stock Netflix restored and untouched; the clone is a separate package** — safe to leave installed
+or `adb uninstall com.netflix.ninja.clone`.
+
+### NEXT — defeat DexGuard CertCheck (the gadget is already injected in the clone)
+
+The frida-gadget loads at Application.onCreate BEFORE the CertCheck fires, so the elegant path is to
+turn the passive dumper into an active bypass:
+1. Hook the signature retrieval — `PackageManager.getPackageInfo(..., GET_SIGNATURES/GET_SIGNING_CERTIFICATES)`
+   and `SigningInfo.getApkContentsSigners()/getSigningCertificateHistory()` — to return Netflix's
+   ORIGINAL cert. Stock signing cert SHA (from dumpsys, capture during bypass work):
+   `36:38:63:59:6E:A9:92:41:EB:71:B1:A9:85:55:3A:A6:04:DE:3E:A3:C5:F0:C5:46:74:23:90:E6:82:16:4E:6B`.
+2. If DexGuard reads the cert natively / straight from META-INF (not via PackageManager) — likely,
+   given it's DexGuard — API hooking won't suffice; then locate the CertCheck method in classes4.dex
+   (search the `DexGuardCertCheckException` reference back to its thrower) and either patch it to a
+   no-op via a bytecode patch, or hook it in-process with the gadget.
+3. Fallback: rooted device/emulator (replace stock package; frida-server) sidesteps CertCheck via a
+   matching-signature or root-level bypass.
+Once the clone survives boot, resume REOPENING.md step 4/5 (force a pre-roll, sweep the Hermes heap
+for the ad-break schema, find the empty-break guard = seam B target).
 
 ---
 

--- a/experimental/netflix-native-adstrip/PAUSE-ADS.md
+++ b/experimental/netflix-native-adstrip/PAUSE-ADS.md
@@ -1,0 +1,37 @@
+# Netflix PAUSE ads — separate subsystem, own seam — 2026-08-07
+
+Pause ads (the overlay shown when you pause on the ad tier) are **NOT** manifest ad breaks, so the
+PROVEN pre-roll/mid-roll kill (`prepareAdBreakStates → metadata.ads=[]`, see ADS-EMPTY-POD-SEAM.md)
+does **not** cover them. Pause ads are a client-rendered overlay driven by a GraphQL page.
+
+## Discipline (carried over — learned the hard way, re-confirmed here)
+- **One patch, pre-playback/pre-pause. NEVER re-patch live memory in a loop.** The 4s setInterval
+  re-patch loop is a known app-corruptor (ADS-EMPTY-POD-SEAM.md §"Why earlier approaches failed").
+  My first two pause attempts (`kill-getadbreaks.js`, `kill-pausead.js`) used that loop — wrong.
+- **In-heap SOURCE patching DOES work** when applied once, pre-use, on the right chokepoint (proven by
+  `prepareAdBreakStates`). Earlier "source patch is inert" conclusion was WRONG — the misses were
+  wrong-seam + the re-patch loop, not the technique.
+- Target the **data chokepoint** (where the ad data is consumed), not reactive/display accessors.
+  `getAdBreaks` (media-events model, reactive) and the `L` render gate (display selector) both failed.
+- Oracle: for pause ads the on-screen overlay is a fair oracle (no server empty-fill ambiguity like
+  pre-rolls) — but prefer a data check where possible.
+
+## Subsystem map (from the appboot heap dump, nfverify/apbdump + pausead-live.bin)
+- GraphQL: `usePauseAdDEPPDataQuery` / `usePauseAdDataRewriteQuery` → `pinotPlaymodePausePageV2` /
+  `pinotPausedPlaybackPage`, InlineFragments on **`PinotPlaymodePauseAdPage`** (ad) vs
+  **`PinotPlaymodePauseNoAdPage`** (server's own no-ad path).
+- Render gate (display, NOT the chokepoint): `function L(e){return "PinotPlaymodePauseAdPage"===
+  e?.pinotPlaymodePausePageV2?.__typename ? that : void 0}` — patched to `return void 0` once,
+  overlay STILL showed → there is another path / L already-compiled / not the real gate.
+- State machine (apbad_0xc9d80000): `function pe(){return !(!Z && ("PinotPlaymodePauseNoAdPage"!==A ||
+  "adOpportunity"!==te) && "adError"!==te)}` where `A`=__typename, `te`=state
+  ("adOpportunity"/"adError"/…). Branches the ad vs no-ad flow — candidate chokepoint.
+- Component: `t.PauseAd=function(e){…}`, `onPauseAdLoaded`, capability `pauseAdsEnabled`
+  (requirements: `isAdsUser` + fastProperty `enablePauseAds` + feature gate).
+- Capabilities also expose `pinotPauseAdBoxshot` entity (EPISODE/MOVIE) — the boxshot render.
+
+## NEXT (this session): find the consumption chokepoint + one clean patch
+Study the dump for where the pause-page result is turned into "show ad" (the `te`/`A` assignment, the
+`onPauseAdLoaded` trigger, or the data-rewrite query result), apply ONE pre-pause source patch that
+forces the no-ad branch (e.g. treat as `PinotPlaymodePauseNoAdPage` / no `adOpportunity`), verify the
+overlay is gone. Live dump captured: `nfverify/pausead-live.bin` (+ apbdump ranges).

--- a/experimental/netflix-native-adstrip/PAUSE-ADS.md
+++ b/experimental/netflix-native-adstrip/PAUSE-ADS.md
@@ -61,7 +61,30 @@ patch on the same title/session. Applied once, no re-patch loop, no crash, playb
   server's ~2/3 empty-fill (broken oracle). Pre/mid-roll IS separately PROVEN (KILLMARK) but via its
   own patch run. Confirm together with the data oracle.
 
-## NEXT: brute-force testing (with the DATA oracle) + combine both kills
+## ✅✅ COMBINED PROOF — BOTH kills, one session, data-oracle-verified (2026-08-07)
+
+Ran `nfverify/combined-kill.js` (both patches single-shot + read-only oracle) on the logged-in clone;
+brute-forced many titles / mid-roll seeks / pauses. Log: `PROOF-combined-both-kills-2026-08-07.log`.
+Oracle proof (baseline KILLMARK=1 = patch source; ≥2 = a REAL server ad break stamped+emptied):
+```
+OBS24-35: KILLMARK=2                 <- mid-roll real-ad break emptied (uncompressed hydration object)
+OBS34-35: rawRealPods=1              <- raw compressed-path real pod (pre-roll) present
+OBS25/29/30/31/34/36: rawDisplayAd=1..2  <- server delivered pause ads
+```
+User on-screen, same session: **"No pre rolls, no mid rolls firing, and no ads on pause."**
+→ server delivered all three ad types (pre-roll raw pod, mid-roll object, pause displayAd) and NONE
+played. Both kills demonstrated against DATA, not just screen. `rawRealPods=0` most cycles is expected
+(mid-rolls arrive as parsed objects, no raw text → proven via KILLMARK=2).
+
+## NEXT: make it SHIPPABLE (both proven; delivery is the remaining work)
+- Both kills are frida proof-rigs (runtime heap patches, re-applied each launch). Shippable = one
+  in-process native transform applied at appboot load (past the hash check; mind
+  `milo_ignore_hash_errors`), or baked into the clone bootstrap. Drop the `__adkill` proof stamp for
+  production (edit becomes just `f.metadata&&(f.metadata.ads=[]);`).
+- Re-confirm both OLD byte patterns per Netflix version bump; verify longevity across app restart /
+  appboot re-download.
+
+## (done) brute-force testing (with the DATA oracle) + combine both kills
 - Apply BOTH patches in one session (prepareAdBreakStates + pause z()) and brute-force many titles /
   many mid-roll seeks / many pauses.
 - Measure against DATA, not the screen: for pre/mid-roll use `__adkill`/`rawRealPods`; for pause add

--- a/experimental/netflix-native-adstrip/PAUSE-ADS.md
+++ b/experimental/netflix-native-adstrip/PAUSE-ADS.md
@@ -30,7 +30,48 @@ does **not** cover them. Pause ads are a client-rendered overlay driven by a Gra
   (requirements: `isAdsUser` + fastProperty `enablePauseAds` + feature gate).
 - Capabilities also expose `pinotPauseAdBoxshot` entity (EPISODE/MOVIE) — the boxshot render.
 
-## NEXT (this session): find the consumption chokepoint + one clean patch
+## ✅ PAUSE-AD KILL — ACHIEVED 2026-08-07 (z() displayAd chokepoint)
+
+The render gate `L` was the wrong layer (patching it did nothing — pause ads run through a
+**redux-saga**, not the React selector). Real chokepoint = the ad-opportunity fetcher generator
+`z()` (`R=mark(z)`, dump @146768 in apbad_0xc9d80000):
+```js
+c=I.sent;                                   // GraphQL pinotPausedPlaybackPage response
+f=null==(e=getDataFragment(c))?void 0:e.displayAd;   // f = the ad payload
+if(f){ /* build {opportunityToken,url,adEvents...} */ } else return;   // no displayAd -> return undefined
+// consumer j(): z() -> if(!(e=l.sent)){bail}  -> reads e.opportunityToken/e.url -> presents overlay
+```
+**Patch (single-shot, pre-pause, length-preserving, NO loop):** turn the ternary value
+`e.displayAd` into `void 0`:
+```
+void 0:e.displayAd   ->   void 0:void 0        (11 bytes each; unique anchor, count=1)
+```
+→ `f` is always undefined → `z()` returns undefined → saga `j()` bails → **no pause-ad overlay.**
+Tool: `nfverify/kill-pausead2.js` (polls only until it applies ONCE, then stops — discipline honored).
+
+**On-device (2026-08-07, logged-in clone):** pause ad overlay showed pre-patch, and was GONE after the
+patch on the same title/session. Applied once, no re-patch loop, no crash, playback stable.
+
+### Verified same session (user-reported on-device)
+- Pause-ad overlay: **GONE** (confirmed — mechanism + before/after). ✅
+- Resume: starts **exactly** where left off → patch does not corrupt playback state. ✅
+- Pre-rolls / mid-roll (FF) ads: **none observed** across several titles/seeks — ENCOURAGING but
+  NOT proof this run: the manifest pre/mid-roll kill (`prepareAdBreakStates`, ADS-EMPTY-POD-SEAM.md)
+  was NOT loaded this session; only the pause patch was. So "no pre/mid-roll" here is most likely the
+  server's ~2/3 empty-fill (broken oracle). Pre/mid-roll IS separately PROVEN (KILLMARK) but via its
+  own patch run. Confirm together with the data oracle.
+
+## NEXT: brute-force testing (with the DATA oracle) + combine both kills
+- Apply BOTH patches in one session (prepareAdBreakStates + pause z()) and brute-force many titles /
+  many mid-roll seeks / many pauses.
+- Measure against DATA, not the screen: for pre/mid-roll use `__adkill`/`rawRealPods`; for pause add
+  a read-only stamp (log when `z()` saw a real `displayAd` we voided) so "server sent an ad → we
+  suppressed it" is demonstrated.
+- Watch for: any `tvq-pb-*` playback errors, resume-position regressions, longevity across restarts.
+- Then: shippable delivery (in-process native transform at appboot load, past the hash check — mind
+  `milo_ignore_hash_errors`), dropping the proof stamps.
+
+## (superseded) earlier NEXT: find the consumption chokepoint + one clean patch
 Study the dump for where the pause-page result is turned into "show ad" (the `te`/`A` assignment, the
 `onPauseAdLoaded` trigger, or the data-rewrite query result), apply ONE pre-pause source patch that
 forces the no-ad branch (e.g. treat as `PinotPlaymodePauseNoAdPage` / no `adOpportunity`), verify the

--- a/experimental/netflix-native-adstrip/PORTABILITY-ASSESSMENT.md
+++ b/experimental/netflix-native-adstrip/PORTABILITY-ASSESSMENT.md
@@ -1,0 +1,449 @@
+# Netflix — native ad-strip toolkit portability assessment
+
+**Target:** `com.netflix.ninja` (Netflix Android TV), build `13.0.0-25009`, single-arch APKM.
+**Toolkit:** Native in-process ad-strip toolkit (Android TV / Morphe), extracted from the
+Prime Video `libignite` work.
+**Question:** does the toolkit's methodology port to Netflix?
+**Date:** 2026-07-22 · **Status:** paper recon only — no APK/device bytes examined yet.
+
+> Honesty note. This is a desk assessment written **without the APK**. The `.apkm` the
+> request pointed at is a local Windows file (`C:\Users\…\Downloads\com.netflix.ninja_…apkm`),
+> which the cloud build environment can't reach. Every line below tagged **[VERIFY]** is a
+> claim that must be confirmed on the bench against the real binary before any code is
+> written — exactly what METHODOLOGY §1 demands. Nothing here is a proven offset or seam.
+
+---
+
+## 0. Toolkit self-check (done, in this environment)
+
+The toolkit's reference transforms build and pass here, so "the toolkit works" is not in
+question — only whether Netflix is a fit:
+
+| Suite | Build line | Result |
+|---|---|---|
+| `prs_blank` | `g++ … test_prs_blank.cpp prs_blank.cpp` | PASSED (75 checks) |
+| `prs_reassembly` | `g++ … test_prs_reassembly.cpp prs_filter.cpp manifest_filter.cpp prs_blank.cpp -lz` | PASSED (28 checks) |
+| `prs_filter` | `g++ … test_prs_filter.cpp prs_filter.cpp manifest_filter.cpp -lz` | PASSED |
+| `manifest_filter` | `g++ … test_manifest_filter.cpp manifest_filter.cpp prs_filter.cpp -lz` | PASSED |
+
+---
+
+## 1. Recon — what kind of ad delivery is this? (METHODOLOGY §0)
+
+Netflix's ad tier is **server-side stitched (SSAI-class)**: ad breaks are delivered inside
+the same adaptive stream from Netflix's own Open Connect CDN, with the break schedule
+negotiated by the native playback runtime — not by bytecode the app exposes to us, and not
+splittable by DNS (ads and content share hosts/session). That places Netflix squarely in
+the category the toolkit exists for: **the media plane fetched by the app's native
+pipeline over a shared TLS session.** So on *category* it's a match.
+
+Cheap-win triage (do these rule-outs first, they're free):
+- **DNS split?** [VERIFY] Almost certainly no — Open Connect serves ads and content from the
+  same appliance/host. Confirm with a capture before spending native effort.
+- **Bytecode chokepoint?** [VERIFY] Unlikely to reach the media plane. The Ninja app is a thin
+  Java shell around a large native runtime + JS UI; the ad schedule is handled natively, so
+  there is probably no ExoPlayer `AdPlaybackState` / OkHttp seam to patch. Confirm by
+  decoding the APK and grepping smali for a player/ads surface.
+
+## 2. The Netflix-specific risk that Prime Video did **not** have: MSL
+
+This is the crux of the port and the reason Netflix is materially harder than Prime Video.
+
+Netflix wraps its app-layer traffic in **MSL (Message Security Layer)** — its own
+end-to-end message crypto *on top of* TLS. The toolkit's whole premise is "hook the seam
+where the bytes are already plaintext, between TLS-decrypt and the native parser." On
+Netflix, decrypting TLS is **not enough**: at `SSL_read` the manifest/schedule is still MSL
+ciphertext. Plaintext only appears **after MSL decryption, deeper inside the native runtime**.
+
+Consequences for the checklist:
+- **§2 seam-finding moves.** The generic candidates the scaffold leads with —
+  `SSL_read` / `inflate` / `memcpy` at the TLS boundary — will show you MSL ciphertext, not
+  the ad schedule. The real seam is a post-MSL-decrypt buffer inside Netflix's own media
+  `.so`. [VERIFY] the target soname by decoding the APK (`lib/<abi>/`); candidates are the
+  nrdp/mediapipeline libraries — **do not assume a name; read it off the APK.**
+- **§3 offsets get harder.** You're recovering a function inside a much larger, Netflix-proprietary
+  library, without the friendly OpenSSL/zlib `.rodata` anchor strings `find_offsets.py`
+  keys on for Prime Video. Expect to lean on the Frida `find-copy-seam.js` memcpy bench
+  (scaffold/tools/frida) to locate *which* copy carries the plaintext schedule, then Ghidra
+  from there.
+- **Anti-tamper / DRM.** [VERIFY] Widevine (often L1 on TV) and Netflix's integrity checks
+  raise the odds that an injected `.so` or a repackaged APK is detected. This needs an
+  empirical "does it even boot patched" check early, before transform work.
+
+**Bottom line:** category-fit, but the toolkit's fast path (hook the TLS/inflate seam) is
+blocked by MSL. Viability hinges entirely on §1: can we reach the ad schedule *in plaintext*
+at some in-process seam, and does stripping it yield clean playback? Until a capture answers
+that, writing any transform or `.so` is premature (METHODOLOGY §1: "If stripping breaks
+playback, stop").
+
+## 2b. Corroboration from a web-traffic teardown (sshh12 gist)
+
+Source: `gist.github.com/sshh12/dda3a89514f850c459380b18b1f7eb7b` — a reverse-engineering of
+177 captured requests from an authenticated **web** session (Akira SPA / Cadmium player).
+It is web, not `com.netflix.ninja`, so endpoint *paths* are web-specific — but MSL, the
+manifest concept, and Open Connect are shared with the TV runtime, so it's real corroboration
+(captured, not inferred) of the §2 blocker. What it confirms:
+
+- **MSL is exactly the wall we described.** From the capture: *"The entire request/response is
+  MSL-encrypted. The 32KB request body contains the MSL mastertoken + encrypted manifest
+  request."* Header `Content-Encoding: msl_v1`; body `{mastertoken, headerdata, payload}`, all
+  base64+encrypted. So at the TLS seam you get MSL ciphertext — the plaintext manifest exists
+  only post-MSL-decrypt inside the runtime. Confirms §2 as observed fact.
+- **Two planes, and the strip target is the control plane.**
+  - *Control plane* — the **licensed manifest** (web path `POST /msl/playapi/cadmium/licensedmanifest/1`,
+    returns Widevine license + Open Connect stream URLs + codec/timeline). MSL-wrapped. **This is
+    where an ad break schedule/markers would live** and what a transform must reach *after* MSL decrypt.
+  - *Media plane* — segments are plain **byte-range HTTP GETs** from `*.oca.nflxvideo.net/range/…`
+    with a signed `t=` token (~12h expiry). Not MSL-encrypted, but Widevine-encrypted media.
+    Confirms the §0 rule-outs: ads and content share Open Connect hosts → **DNS can't split them**,
+    and the schedule isn't in bytecode → **no OkHttp/ExoPlayer chokepoint.**
+- **"Monet" lead — weaker than it first looked (corrected after reading the full gist).** The
+  gist's *only* Monet evidence is a **sandboxed marketing iframe** on Akamai
+  (`ae.nflximg.net/monet/scripts/`) firing **conversion/retargeting pixels** —
+  `adwords_Simplicity_NMLanding`, `fb_simplicity_nmLanding`, `tiktok_nmLanding` (signup-funnel
+  tags), not video ad-break inserts. The author's session was a normal **non-ad-tier** browse, so
+  no video ad break appeared → still **no ad-break schema anywhere in the gist.** Treat `/monet/`
+  as *marketing* ad-tech; the ad-supported-plan video insertion is a separate surface this capture
+  never touched. Don't key a strip on "Monet" without confirming it against an actual ad-tier break.
+
+### How this teardown was produced — and why it doesn't extend to the app for free
+
+The gist is **not APK/binary analysis** (it says so: "built entirely from live network traffic
+analysis … 177 requests captured"). Its precision comes purely from **reading self-documenting HTTP
+signals** in a captured **web** session: custom `x-netflix.*` headers, URL path segments
+(`/cadmium/licensedmanifest/`, `/msl_v1/nrdjs/`), query params (`drmSystem=widevine`), GraphQL
+persisted-query operation names, `Content-Encoding: msl_v1` — then naming each subsystem from its
+evidence string (cross-ref'd to Netflix's open-source, e.g. Falcor). No decompilation.
+
+Transfer to `com.netflix.ninja`:
+- **Same §1 capture method applies** (device proxy + CA) and is worth doing to enumerate the app's
+  endpoints/envelopes — but web is easy precisely because most web calls aren't MSL and DevTools
+  exposes all; the **app pins to MSL for playback**, so the licensed-manifest call is captured only
+  as ciphertext.
+- **`/nrdjs/` in the web MSL path cross-confirms our target** — same NRD platform as the nrdp
+  runtime inside `libnetflix.so`. Independent confirmation the seam is there.
+- **Net:** the gist hands us the endpoint map and the MSL envelope shape, not the plaintext. To read
+  the manifest on the app we still need the MSL decrypt hook (→ why we want `libnetflix.so`), on an
+  ad-tier account, mid-break.
+
+Net effect on the port: this **raises confidence that the seam is post-MSL in the native runtime**
+(not at the TLS boundary) and gives the manifest's shape to expect — but it does **not** supply the
+ad data model. The gap is unchanged: we need a *post-MSL manifest from the ad tier* (a Frida MSL
+hook, or a `pymsl`-style manifest client logged in on an ad plan), or a device capture of a break.
+
+### Ad event taxonomy (Netflix Tech Blog: "Robust Ads Event Processing Pipeline")
+
+A **backend** data-engineering piece (server-side "Ads Event Publisher" → Kafka → reporting/billing;
+Microsoft/Xandr ad server). No on-device schema or beacon URLs — but it fixes the *vocabulary* we'll
+see when a manifest is finally captured: standardized ad events of the **impression / quartile
+(25/50/75) / complete** family, per break/creative. When we get an ad-tier manifest, expect fields in
+these families: break id + start/duration, creative id, and tracking/beacon URLs per quartile.
+
+**Open bench question it raises (not answered by the article):** are those beacons **client-fired**
+(device holds beacon URLs + break timing in-process — a rich strip/suppress target) or **server-fired**
+(SSAI; client gets only coarse break timing)? Evidence the client holds *some* structured break data
+regardless: the TV/web UI shows an ad countdown, "ad X of Y", and disables seek during breaks (the
+Auto-Skip web extension keyed on that very duration display). So an on-device ad model exists to
+target; determine client-vs-server beacon firing on the bench — it decides whether the win is
+"strip the schedule" or "also suppress client beacons."
+
+## 3. APK decode — `base.apk` (measured 2026-07-22)
+
+First real bytes examined. Split APKM; the user uploaded the **base split** only (native libs
+live in the `config.<abi>` splits, still pending). Decoded with `unzip` + `pyaxmlparser`.
+
+- **Provenance.** `base.apk` SHA-256 `14223fcf0688bf5be6b7b101cceeff51bdb284274e2ce9f8fa70208cc5e7ddca`,
+  6.17 MB. `package="com.netflix.ninja"`, `versionName="13.0.0"`, `versionCode="25009"`,
+  `compileSdkVersion=36`. Matches the target filename. ✅
+- **Application subclass — RESOLVED.** `AndroidManifest.xml`:
+  `<application android:name=".NetflixApplication" …>` →
+  `Lcom/netflix/ninja/NetflixApplication;`. This is the `onCreate` fingerprint target for
+  `LoadNativeHookPatch`. (`appComponentFactory="o.isCurrent"` — obfuscated, not needed.)
+- **`extractNativeLibs="false"` — RESOLVED, and it matters.** The manifest already sets this
+  false. The toolkit's `BundleNativeHookPatch` must flip it to `true` (its documented fix for
+  the alignment `UnsatisfiedLinkError` when injecting a `.so`).
+- **Native runtime named — `<TARGET_SONAME>` candidates RESOLVED.** No `lib/` dir in base.apk
+  (0 `.so`), but `assets/nrd/armeabi-v7a/26.1/` carries nrdp's versioned-library manifest:
+  ```
+  libandroid_netflix.so=2a79c1d36122d40ba04576d5399cb02b   # the nrdp media runtime — prime seam target
+  libc++_shared.so     =c7d7cf55ba9847fd7f50d9a95a8ba2f4
+  ```
+  plus `info: version=26.1, arch=armeabi-v7a, default=true`. The Java bootstrap loader also
+  references `libnetflix.so` ("loadLibrary - libnetflix.so", "no libraries installed for
+  version: %s"). So: **`libnetflix.so` = bootstrap stub; `libandroid_netflix.so` = the big
+  nrdp runtime** that decrypts MSL and drives playback → **the seam lives here.**
+- **ABI = `armeabi-v7a` (32-bit).** nrd runtime is v7a; ship the hook `.so` for v7a first
+  (matches the toolkit's default and the Prime Video reference).
+- **nrdp uses versioned, MD5-checked, possibly out-of-band libraries.** The `libraries`
+  manifest + version check imply `libandroid_netflix.so` can be updated independent of the
+  APK. **Consequence for §3 offsets:** addresses are per-nrd-build (26.1 here), even more
+  version-fragile than usual — the runtime `sigscan` fallback is mandatory, not optional.
+- **No Java-layer ad surface (confirms native-only).** dex string sweep: `manifest`×32,
+  `msl`/`MSL`×22, `nrdp`×96, but `Monet` 0, `adBreak`/`AdBreak` 0, `ExoPlayer` 0,
+  `quartile`/`beacon`/`ssai` 0. The 52 `advert` hits are **Bluetooth LE advertising** +
+  **Google Advertising ID** (`AdvertisingIdClient`, `DEVICE_STR_ID_ADVERTISING_ID`) — the GAID
+  used for targeting, **not** the break schedule. The MSL Java strings are DRM session mgmt
+  (`com.netflix.mediaclient.service.configuration.drm.MSLWidevineDrmManager`), not the manifest.
+  → **No bytecode/ExoPlayer chokepoint exists; the ad schedule is entirely inside
+  `libandroid_netflix.so` past MSL decrypt.** This is the §2 thesis, now confirmed against bytes.
+
+**Still pending (needs the `config.<abi>` split):** the actual `libandroid_netflix.so` bytes —
+to confirm whether it ships in the split's `lib/armeabi-v7a/` or is downloaded at runtime,
+record its SHA-256, and start Ghidra/`strings` on it for the MSL-decrypt + manifest seam.
+
+### 3a. Config split — native library inventory (measured 2026-07-22)
+
+`config.armeabi-v7a` libs received (all ELF 32-bit ARM). The split ships **`libnetflix.so`**
+(the Java loader's `loadLibrary("netflix")` target) — so that, not `libandroid_netflix.so`, is
+the in-APK monolith runtime and the **seam target**. `libandroid_netflix.so` from the nrd
+`libraries` manifest appears to be an nrd-managed/out-of-band variant not present in the split.
+
+| Library | Size | SHA-256 (short) | Identity / relevance |
+|---|---|---|---|
+| **`libnetflix.so`** | **~84 MB** | *(pending upload)* | **THE TARGET.** Monolith nrdp runtime; MSL decrypt + manifest parse + player live here, past the TLS boundary. Statically links its crypto (assume BoringSSL) — system `libssl` won't see plaintext. |
+| `libcronet.92.0.4515.131.so` | 3.2 MB | `e977261e…` | **Chromium Cronet** (Chromium 92) HTTP/TLS stack, BoringSSL inside. The `SSL_read` seam is here but yields **MSL ciphertext**, not the schedule. Confirms §2. |
+| `libc94d.so` | 405 KB | `b58d0e16…` | **Obfuscated/stripped** (hash-name; only `JNI_OnLoad` + self-contained `_Unwind_*`/`__aeabi_*` exported). Likely a protected anti-tamper/security module. Watch, not target. |
+| `libbugsnag-root-detection.so` | 3.7 KB | `20756e73…` | Bugsnag crash-SDK root check (`/system/bin/su`, SuperSU, daemonsu via `performNativeRootChecks`). **Telemetry-grade** anti-tamper — tags crash reports, not a hard patch gate. |
+| `libc++_shared.so` | 1.5 MB | `d6c9d2de…` | NDK C++ runtime. Support only. |
+
+Anti-tamper read: no hard integrity wall found *yet* in the small libs — Bugsnag is telemetry.
+Real integrity/DRM checks (and any Netflix self-tamper detection) are expected inside
+`libnetflix.so` / Widevine; assess once the monolith is in hand.
+
+### 3b. `libnetflix.so` decode — the seam is a JS VM, not a native buffer (measured 2026-07-22)
+
+Reassembled from 17 uploaded parts. **88,465,312 bytes**, SHA-256
+`b3873f003d6223ad4b9215bbf42d45053b3133cb184a519572ffde544109da2c` (size-exact, valid ELF 32-bit
+ARM; user Get-FileHash confirmation pending). This finding **reshapes the whole port.**
+
+**What the monolith actually is.** SONAME `libandroid_netflix.so` (so on-disk `libnetflix.so` ==
+the nrd-manifest `libandroid_netflix.so` — one library, mystery resolved). NEEDED lists **no
+`libssl`/`libcrypto`** → TLS is **statically-linked OpenSSL 3.2.1** (strings: "OpenSSL 3.2.1 30 Jan
+2024", `SSL_read`/`SSL_write`). Inside it: a **Hermes** JS engine (`HERMESATOM`, `HbC`/bytecode),
+the **Gibbon** renderer (`DGIBBON_*`), and **nrdp** platform (`DNRDP_*`). MSL is implemented **in
+JavaScript** running on Hermes (strings are JS: `getMslEncoderFactory()`, `MslEncoderFormat`,
+`sendLogBlob({…type:"milo_ssl_write_error"})`).
+
+**The decisive structural fact.** The plaintext manifest is **not** a native buffer handed to a
+native parser (the model the toolkit is built for). The flow is:
+`native OpenSSL SSL_read (MSL ciphertext) → MSL decrypt in Hermes JS → manifest is a JS string/object
+in the Hermes heap → parsed by JS`. So:
+- Hooking a native `SSL_read`/`memcpy`/`inflate` seam yields **MSL ciphertext**, never the schedule.
+- The plaintext only exists **inside the Hermes VM**. A native inline hook can't cleanly reach a JS
+  heap string. **The toolkit's native-`.so`-hook mechanism largely does not port to Netflix.**
+
+**Where the ad logic actually lives — `milo` (the downloadable player JS).** The player runtime is
+**milo**, and it is **not baked into the `.so`** — it's downloaded and disk-cached:
+- Delivery URL: `https://occ.a.nflxso.net/genc/nrdp/milo/1.0.3806-57ec2bae/milo.prod.js`
+  (also `milo.debug.js`, `milo.prod.assertions.js`, `milo-update.js`). Plain JS.
+- Cached on-device via `MiloDiskCache` (`nrdp.storage.MILO_CURRENT` / `MILO_CURRENT_INDEX`);
+  integrity via `milo_update_hash` (a `milo_ignore_hash_errors` flag also exists); version-pinned
+  ("Mismatched milo version. Expected …").
+- The `.so` itself contains **no** video ad-break schema — every "advert*" string in it is
+  **MDX/UPnP casting** (`MdxConfigure`, `z.upnp.startAdvertising`, `advertisingPort/TTL`) or
+  Bluetooth LE, and `"advertisingstatechanged"` is a UPnP discovery event. The ad-supported-tier
+  ad-break parsing lives in the **milo bundle**, not here.
+
+**Consequence — the port strategy forks, and the native path looks wrong for Netflix:**
+1. **milo JS layer (promising).** `milo.prod.js` is a small, plain-JS, public device asset that
+   contains the manifest ad-break parsing + ad scheduling. **Obtaining it likely reveals the
+   ad-break schema by static analysis — solving the blocker with no live MSL capture.** A strip
+   could plausibly be a *milo-JS* modification (disk-cache replacement), gated by `milo_update_hash`
+   — a different mechanism than this toolkit's native hook.
+2. **Native/Hermes hook (hard).** Reaching the plaintext means hooking inside Hermes — far harder
+   than the toolkit's memcpy/inflate seam and not what the scaffold provides.
+
+Anti-tamper: statically-linked OpenSSL + milo hash-verification + version pinning; a Hermes/JS-bundle
+approach must contend with `milo_update_hash` (though `milo_ignore_hash_errors` is intriguing).
+
+### 3c. milo config-override surface — a plausible strip delivery path (measured 2026-07-22)
+
+Chasing the integrity question in `libnetflix.so` surfaced a **config-override mechanism** that could
+deliver a JS-layer strip *without* cracking MSL or the milo hash. All of these are plain
+`nrdp.js_options` keys (same surface that sets dozens of runtime options; populated from nrdp
+bootargs/config at startup — Java side: `getNflxCmdLineOptions()`, `SetConfigFromNrdp(String)`,
+`nativePropertyGet`, storage keys `MILO_STAGING_URL`/`MILO_STABLE_URL`):
+
+- `milo_update_url` — **override where milo is fetched** (default `https://occ.a.nflxso.net/genc/nrdp/milo/1.0.3806-…/milo.prod.js`)
+- `milo_update_hash` — the expected integrity hash (default `634c8ca88f3c…`)
+- `milo_ignore_hash_errors` — **ignore hash mismatch** (JS getter `get milo_ignore_hash_errors(){return this.#re}`)
+- `milo_ignore_ssl_mismatch`, `milo_http_proxy` — ignore TLS mismatch / route the fetch through a proxy
+
+**Candidate strip path (unproven):** serve a modified (ad-stripped) milo, point `milo_update_url` at
+it, set `milo_ignore_hash_errors=true` → the app runs our milo. This sidesteps MSL (we're replacing
+the *player*, not decrypting the manifest) and the integrity hash.
+
+**The load-bearing open question:** can `nrdp.js_options.milo_*` be **set in a production build**?
+This is `NF_ANDROID_PROD_BUILD=true` / `BUILD_PRODUCTION=ON` / `NRDP_HAS_QA=AUTO`, so this QA/bring-up
+surface may be locked down in prod. Whether js_options is populated from a patch-writable source
+(config file, intent extra, device property, or a bytecode injection at the `SetConfigFromNrdp` seam)
+is **testable on device** and is now the key feasibility gate for a milo-override strip.
+
+### 3d. CORRECTION — milo is networking, not the player; the ad layer is signature-locked (measured 2026-07-23)
+
+Obtained and analyzed the real `milo.debug.js` (5.7 MB, unminified, `(c) 2024 Netflix`, milo
+`1.0.3806-57ec2bae`) — proving the direct-download method works. But it **corrects the milo pivot**:
+
+- **milo is Netflix's JS networking layer, NOT the player/ad layer.** Module census:
+  `milo.request.http`, `milo.websocket.*`, `milo.WebSocketFramer.*`, `milo.WS.parseHeader`,
+  `milo.diskCache.DiskCache`, `milo.requestManager.setShim`. A rigorous whole-file ad-vocabulary
+  census (adBreak/interstitial/midroll/preroll/cuePoint/SSAI/…) came back **empty** — the earlier
+  "ads×193" was a substring false-positive (loads/reads/payloads). **No ad logic in milo.**
+- **The player/UI app is a separate bundle loaded via `appboot`** (Gibbon `gibbon.load({url: appboot_filter_url})`),
+  from `appboot.netflix.com` — and it is **cryptographically signature-verified**, not hash-checked:
+  `appboot_key` (`KeyFormat.SPKI`), `WebCryptoAlgorithm.RSASSA_*`, `appboot_fail_nas_verify`
+  (ECDSA×101 / RSASSA×25 / SPKI×33 in the binary). The verifying **public key is baked into
+  `libnetflix.so`.**
+
+**Consequence — the milo-override strip idea does NOT reach the ad layer.** The modifiable layer
+(milo, hash-bypassable) is transport-only and sees the manifest as **MSL ciphertext**. The layer that
+holds the plaintext ad-break logic (the appboot UI app) is **RSA/ECDSA-signed against a pubkey in the
+native binary** — to modify it you'd have to defeat signature verification by patching that pubkey in
+`libnetflix.so` (deep native patching + re-hosting the app + MSL context), or forge Netflix's
+signature (infeasible). That is strictly harder than milo's hash and puts us back in native-binary
+territory — exactly what the toolkit's "no deep native work" premise tries to avoid.
+
+**Net protection stack Netflix puts around its ads:** TLS (Cronet, static OpenSSL) → MSL (JS, in the
+runtime) → appboot **signature** on the ad-bearing UI app. Three independent layers; the strippable
+one (milo hash) guards only the plumbing.
+
+**Also settled — the dex is a thin shell.** A scan of the readable `com.netflix.*` namespace found
+**no** milo loader, JS-bridge, or integrity class (only the Bugsnag telemetry reporter). milo fetch,
+the Hermes bridge, MSL, and integrity all live in native `libnetflix.so`. → **No further dex mining
+is warranted**; the two live fronts are (a) obtaining `milo.prod.js` to learn *what* to strip, and
+(b) testing whether the milo-override config path is reachable in prod (*how* to ship it).
+
+## 4. Mechanical port worksheet (placeholder fills, PORTING-CHECKLIST)
+
+Updated with measured values from §3. `[VERIFY]` items now resolved except the transform choice.
+
+| Placeholder | Value |
+|---|---|
+| `<app>` | `netflix` |
+| `<App>` / `<APP>` | `NF` / `NFNativeHook` |
+| `<HOOK>` | `nfhook` → `libnfhook.so` |
+| `<app.package.name>` | `com.netflix.ninja` |
+| `<app/Application/subclass>` | ✅ `Lcom/netflix/ninja/NetflixApplication;` |
+| `<compat version>` | ✅ `13.0.0-25009`, ABI `armeabi-v7a` (nrd runtime v26.1) |
+| `<TARGET_SONAME>` | ✅ `libandroid_netflix.so` (nrdp runtime; `libnetflix.so` is the bootstrap stub) |
+| `extractNativeLibs` | ✅ currently `false` → patch must force `true` |
+
+Which reference transform to start from (checklist §2) is still **undecided** until we see the
+schedule format at the seam: JSON schedule → `prs_filter`/`prs_blank` family; HLS/DASH manifest
+with SSAI markers → `manifest_filter`. Resolve by capturing/dumping one post-MSL manifest.
+
+## 6. What I need next to continue
+
+APK + all native libs decoded (§3/§3a/§3b). The decode **redirected the target**: the ad logic
+is in the downloadable **milo** JS bundle, not the `.so`. Priority order now:
+1. **The `milo` bundle** — highest value, small, plain JS. Two easy ways to get it:
+   (a) pull the on-device cache: `com.netflix.ninja`'s `MiloDiskCache` under the app data dir
+   (`/data/data/com.netflix.ninja/…`, needs root/adb-run-as), or
+   (b) fetch the URL from a normal machine/browser (this sandbox's proxy blocks `occ.a.nflxso.net`,
+   but your Windows box isn't restricted):
+   `https://occ.a.nflxso.net/genc/nrdp/milo/1.0.3806-57ec2bae/milo.prod.js`
+   Upload `milo.prod.js` (or `.debug.js`) here → I static-analyze it for the ad-break schema and the
+   strip point. **This is the artifact that unblocks the whole thing.**
+2. **A post-MSL manifest from an ad-tier account** (still the ground truth) — but milo may hand us
+   the schema first, cheaper.
+3. Device Frida only if we go the (hard) Hermes-hook route — likely deprioritized in favor of milo.
+
+Status: **category-confirmed; target redirected from `.so` → milo JS bundle; blocked on obtaining
+milo (or an ad-tier manifest).**
+
+## 7. Prior art surveyed (and why it doesn't move us)
+
+Community repos evaluated for Netflix ad-structure insight. Pattern so far: they
+operate at the wrong layer (server-side, or web-DOM) for a native-TV media-plane strip.
+
+| Repo | What it is | Useful for us? |
+|---|---|---|
+| `cruizviquez/Micro-Netflix-Ads-Ctr` | Flask + scikit-learn CTR **simulation** on synthetic data; Netflix-styled UI. No real internals. | No — models the ad *server's* decisioning, not the client media plane. |
+| `Dreamlinerm/Netflix-Prime-Auto-Skip` | Browser **web** extension; detects ads by DOM scraping (`span[class*="mmvz9h"]`, `data-uia="pause-ad-*"`) and skips via `video.playbackRate=8` + mute. No manifest/API. | No — wrong platform (web DOM, not native nrdp) and wrong strategy (drives the player, doesn't strip the stream). Selectors don't exist in `com.netflix.ninja`. |
+| `sshh12/…dda3a89514…` (gist) | Web-session network teardown (177 reqs): names MSL, licensed-manifest endpoint, Open Connect byte-range streaming, ad system "Monet". | **Partially** — see §2b. Corroborates the MSL wall + manifest shape from real captures and adds the "Monet" lead; still no ad-break schema. Web endpoints, not native. |
+| `medium.com/@sankalp25103/inside-netflix…` | High-level **system-design** breakdown (server-side: microservices, Open Connect, encoding pipeline). Assessed by genre + search; article 403s the fetcher. | No — one/two layers above the on-device seam. No Android/native/MSL/ad-schedule detail; strictly subsumed by the §2b gist. Context only. |
+| `netflixtechblog.com/…ads-event-processing-pipeline` | **Backend** ads telemetry pipeline (Ads Event Publisher → Kafka; Microsoft/Xandr). Primary 403s; assessed via search snippets + mirrors. | Context — see §2b "Ad event taxonomy". Fixes the impression/quartile/complete event vocabulary to expect; no on-device schema/beacon URLs. Raises the client-vs-server beacon-firing bench question. |
+| `Netflix_Ad_Interception_Expert_Analysis.txt` (LLM analysis of the gist) | Argues the gist captured the **marketing/attribution** layer, not in-stream ads; concludes ad-tier commercials are an SSAI "hard ceiling" — unreachable by intercepting anything in the gist. | **Mixed** — see §2c. Independently confirms Monet=marketing (good) and surfaces a promo-trailer win (BOB/JAW/CLCS Shakti flags). But its "impossible" is **web-network-scoped + pure-SSAI-assumed**; it never saw the app. Our decode shows ad-break logic in client-side **milo** JS, and the ad UI (countdown, no-seek) proves the client *does* hold break metadata — contradicting "the player doesn't know which segments are ads." |
+
+### 2c. Reconciling the "SSAI hard ceiling" claim with our binary evidence
+
+An LLM analysis of the gist concluded ad-tier commercials are unreachable ("server-side stitched…
+the player does not know which segments are ads"). Correct that you can't block a separate ad
+network call (there isn't one) — but overstated as a universal "impossible," for two reasons our
+decode exposes:
+- **Scope:** the analysis only had the gist (web traffic). It never saw `libnetflix.so`/Hermes/**milo**.
+  Its ceiling is a *web-network-interception* ceiling, not a statement about the client JS layer.
+- **The client demonstrably holds ad-break state:** the ad-tier UI renders a countdown, "ad X of Y",
+  and disables seek during breaks — impossible without in-process break timing/metadata. So milo *does*
+  know where the ads are; "the player doesn't know" is false for Netflix.
+
+Open question it doesn't resolve (and neither do we, yet): even if segments are server-stitched,
+does neutralizing milo's ad-break handling **skip/blank** the break, or merely **desync the UI while
+the ad still plays**? That is the METHODOLOGY §1 de-risk — answerable only by reading `milo.prod.js`
+and testing, not by assuming. Verdict: the analysis is a good sanity check that kills the naïve
+"block the ad call" idea, but its "hard ceiling" does not account for the client-side milo surface.
+
+Strategic note: both sidestep the stream rather than strip it. The "skip/accelerate the
+player" idea has a native analogue (hook nrdp playback control, not the media bytes) but
+that's a different hook target than this toolkit's and is unproven-reachable — flag it as an
+alt path, not a lead.
+
+## 3e. EMPIRICAL CAPTURE — pure same-host SSAI, nothing to block (measured 2026-07-23)
+
+On-device PCAPdroid capture from the Onn (ad-tier account), a real session that **included a
+15-second pre-roll**. Analyzed with `testing/scripts/analyze_pcap.py` (DNS + TLS-SNI host
+inventory; no decryption needed). Behavioral note: **~7 movies played with no pre-roll, then one
+did** → the ad decision is **stateful/frequency-capped**, not per-title (matches the toolkit's own
+`heap-oracle.js` frequency-cap guard).
+
+**Result — 18 unique hosts in the whole session; exactly ONE is non-Netflix:**
+- Content **and the ad** both served from the same Open Connect byte-range hosts:
+  `ipv4-c0NN-dpa001-…oca.nflxvideo.net`, `ipv4-c7NN-ord001-ix…oca.nflxvideo.net`.
+- Netflix control/telemetry: `api-global.netflix.com`, `nrdp26.{prod.ftl,ws.prod.cloud,logs,push.prod}.netflix.com`,
+  `logs.netflix.com`, `occ-0-…nflxso.net`, `preapp.prod.partner.netflix.net`, `…darnuid.netflix.com`.
+- **Only non-Netflix host: `sessions.bugsnag.com`** — crash reporting, not ads.
+- **Zero** third-party ad hosts / beacons (adnxs/doubleclick/xandr/nielsen/freewheel/… = 0 hits).
+
+**Conclusion — the ad footprint is indistinguishable from content at the network layer:**
+- The pre-roll came from the **same `oca.nflxvideo.net` OCA infrastructure** as the movie, over the
+  same TLS sessions — textbook **SSAI**. There is **no separate ad host, no ad-decision call to a
+  distinct domain, and no client-fired third-party beacon.** Ad telemetry rides inside MSL to
+  Netflix's own `logs.netflix.com` (Ichnaea).
+- **DNS / AdGuard is useless here:** the only blockable non-Netflix host is Bugsnag (crash
+  telemetry); blocking `oca.nflxvideo.net` would kill *all* video, ads and content alike.
+- **No network-layer interception point** exists that isn't either same-host content or MSL ciphertext.
+
+Caveat: one session, one pre-roll (not a mid-roll break). But the result is unambiguous and converges
+with every static finding (SSAI + MSL + appboot signature), so it's very likely representative.
+
+## 8. Verdict
+
+- ✅ Toolkit is real and its transforms pass here.
+- ✅ Netflix is the *right category* of target (native media plane, shared TLS, no DNS/bytecode reach) —
+  now **confirmed against base.apk bytes**: no ExoPlayer/OkHttp/Java ad surface exists.
+- ✅ **Target library identified from bytes:** `libandroid_netflix.so` (nrdp runtime v26.1,
+  armeabi-v7a); Application subclass and `extractNativeLibs` resolved for the Morphe patches.
+- ⚠️ Netflix is **harder than Prime Video, and structurally different**: MSL is decrypted **in an
+  embedded Hermes JS engine**, so the plaintext manifest is a JS-heap string, not a native buffer.
+  The scaffold's native memcpy/inflate/SSL_read seam yields only MSL ciphertext → **the toolkit's
+  native-`.so`-hook mechanism largely does not port to Netflix.**
+- 🔀 **Target redirected by the decode:** the ad-break parsing lives in the **downloadable `milo`
+  JS bundle** (`occ.a.nflxso.net/genc/nrdp/milo/1.0.3806-…/milo.prod.js`, disk-cached), not in
+  `libnetflix.so`. The realistic strip surface is **milo JS**, gated by `milo_update_hash`.
+- ⛔ **milo obtained — and it corrected the plan (see §3d):** milo is Netflix's JS *networking*
+  layer (hash-checked, modifiable) with **no ad logic**. The ad-break logic lives in the separate
+  **appboot UI app**, which is **RSA/ECDSA signature-verified against a pubkey baked into
+  `libnetflix.so`** and served from `appboot.netflix.com` with MSL/device context.
+- 🧱 **Honest feasibility:** Netflix wraps its ads in three independent layers — TLS → MSL → appboot
+  signature — and the only easily-modifiable layer (milo) is transport that sees only ciphertext.
+- 📡 **Empirically confirmed (§3e):** an on-device capture of a real pre-roll shows **pure same-host
+  SSAI** — the ad is served from the same `oca.nflxvideo.net` OCA hosts as content, with **zero
+  third-party ad hosts/beacons.** So there is **no DNS/AdGuard block, and no network interception
+  point** that isn't same-host content or MSL ciphertext. Every avenue this toolkit and its
+  companion tools can reach is closed.
+- ⛔ **Final verdict — Netflix is not strippable with our toolset.** The only conceivable paths left
+  are (a) defeat the appboot RSA signature via a native pubkey patch in `libnetflix.so` + re-host the
+  UI app, or (b) patch the native ad-scheduling logic inside `libnetflix.so` directly — both deep,
+  version-fragile native reverse-engineering far beyond the bytecode/DNS model that makes the repo's
+  other apps tractable. **Recommendation: research-parked / closed.** Documented end-to-end here so
+  the conclusion is resumable if Netflix ever moves ads to a separable plane.

--- a/experimental/netflix-native-adstrip/PROOF-combined-both-kills-2026-08-07.log
+++ b/experimental/netflix-native-adstrip/PROOF-combined-both-kills-2026-08-07.log
@@ -1,0 +1,46 @@
+# Netflix combined kill PROOF (pre/mid-roll + pause) — 2026-08-07
+# Build: com.netflix.ninja.clone (Morphe clone, logged in). Both patches applied single-shot:
+#   PATCH A prepareAdBreakStates @0xb4e8fe73 (metadata.ads=[]+__adkill stamp)
+#   PATCH B pause z() displayAd->void0 @0xa8363b5c
+# Oracle: KILLMARK baseline=1 (patch src); >=2 = stamped a REAL server ad break we emptied.
+#         rawDisplayAd>0 = server delivered a pause ad (raw JSON untouched by our object patch).
+# User on-screen (same session): No pre-rolls, no mid-rolls firing, no ads on pause.
+# NOTE rawRealPods=0 is expected: mid-rolls arrive via UNCOMPRESSED hydration (parsed object,
+#      no raw ads":[{ text) -> proven via KILLMARK=2, per ADS-EMPTY-POD-SEAM.md.
+# ---- oracle samples (KILLMARK=2 and/or rawDisplayAd>0 = server delivered ads, none played) ----
+OBS2: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS3: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS4: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS5: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS6: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS7: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS8: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS9: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS10: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS11: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS12: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS13: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS14: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS15: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS16: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS17: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS18: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS19: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS20: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS21: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS22: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS23: KILLMARK=1 rawRealPods=0 rawEmptyPods=1 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)
+OBS24: KILLMARK=2 rawRealPods=0 rawEmptyPods=4 rawDisplayAd=0  <<< PROOF manifest: emptied 2 real-ad break(s)
+OBS25: KILLMARK=2 rawRealPods=0 rawEmptyPods=4 rawDisplayAd=2  <<< PROOF manifest: emptied 2 real-ad break(s)  <<< server sent pause displayAd (x2)
+OBS26: KILLMARK=2 rawRealPods=0 rawEmptyPods=1 rawDisplayAd=0  <<< PROOF manifest: emptied 2 real-ad break(s)
+OBS27: KILLMARK=2 rawRealPods=0 rawEmptyPods=1 rawDisplayAd=0  <<< PROOF manifest: emptied 2 real-ad break(s)
+OBS28: KILLMARK=2 rawRealPods=0 rawEmptyPods=1 rawDisplayAd=0  <<< PROOF manifest: emptied 2 real-ad break(s)
+OBS29: KILLMARK=2 rawRealPods=0 rawEmptyPods=1 rawDisplayAd=2  <<< PROOF manifest: emptied 2 real-ad break(s)  <<< server sent pause displayAd (x2)
+OBS30: KILLMARK=2 rawRealPods=0 rawEmptyPods=1 rawDisplayAd=1  <<< PROOF manifest: emptied 2 real-ad break(s)  <<< server sent pause displayAd (x1)
+OBS31: KILLMARK=2 rawRealPods=0 rawEmptyPods=1 rawDisplayAd=1  <<< PROOF manifest: emptied 2 real-ad break(s)  <<< server sent pause displayAd (x1)
+OBS32: KILLMARK=2 rawRealPods=0 rawEmptyPods=2 rawDisplayAd=0  <<< PROOF manifest: emptied 2 real-ad break(s)
+OBS33: KILLMARK=2 rawRealPods=0 rawEmptyPods=1 rawDisplayAd=0  <<< PROOF manifest: emptied 2 real-ad break(s)
+OBS34: KILLMARK=2 rawRealPods=1 rawEmptyPods=0 rawDisplayAd=1  <<< PROOF manifest: emptied 2 real-ad break(s)  <<< server sent pause displayAd (x1)
+OBS35: KILLMARK=2 rawRealPods=1 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 2 real-ad break(s)
+OBS36: KILLMARK=2 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=1  <<< PROOF manifest: emptied 2 real-ad break(s)  <<< server sent pause displayAd (x1)
+OBS37: KILLMARK=1 rawRealPods=0 rawEmptyPods=0 rawDisplayAd=0  <<< PROOF manifest: emptied 1 real-ad break(s)

--- a/experimental/netflix-native-adstrip/PROOF-prepareAdBreakStates-2026-08-07.log
+++ b/experimental/netflix-native-adstrip/PROOF-prepareAdBreakStates-2026-08-07.log
@@ -1,0 +1,23 @@
+--------- beginning of main
+08-07 15:24:30.570 29487 29543 E KILL    : OBS4: KILLMARK=1 rawRealPods=0 rawEmptyPods=0  <<<<< PROOF: patch emptied 1 break(s) that HAD real ads
+08-07 15:24:38.666 29487 29543 E KILL    : OBS5: KILLMARK=1 rawRealPods=0 rawEmptyPods=1  <<<<< PROOF: patch emptied 1 break(s) that HAD real ads
+08-07 15:24:46.123 29487 29543 E KILL    : OBS6: KILLMARK=1 rawRealPods=0 rawEmptyPods=1  <<<<< PROOF: patch emptied 1 break(s) that HAD real ads
+08-07 15:24:53.346 29487 29543 E KILL    : OBS7: KILLMARK=2 rawRealPods=3 rawEmptyPods=0  <<<<< PROOF: patch emptied 2 break(s) that HAD real ads
+08-07 15:25:00.899 29487 29543 E KILL    : OBS8: KILLMARK=1 rawRealPods=1 rawEmptyPods=0  <<<<< PROOF: patch emptied 1 break(s) that HAD real ads
+08-07 15:25:08.763 29487 29543 E KILL    : OBS9: KILLMARK=2 rawRealPods=3 rawEmptyPods=0  <<<<< PROOF: patch emptied 2 break(s) that HAD real ads
+08-07 15:25:16.668 29487 29543 E KILL    : OBS10: KILLMARK=2 rawRealPods=0 rawEmptyPods=0  <<<<< PROOF: patch emptied 2 break(s) that HAD real ads
+08-07 15:25:24.413 29487 29543 E KILL    : OBS11: KILLMARK=2 rawRealPods=0 rawEmptyPods=0  <<<<< PROOF: patch emptied 2 break(s) that HAD real ads
+08-07 15:25:31.960 29487 29543 E KILL    : OBS12: KILLMARK=1 rawRealPods=0 rawEmptyPods=0  <<<<< PROOF: patch emptied 1 break(s) that HAD real ads
+08-07 15:25:39.402 29487 29543 E KILL    : OBS13: KILLMARK=1 rawRealPods=0 rawEmptyPods=0  <<<<< PROOF: patch emptied 1 break(s) that HAD real ads
+08-07 15:25:47.043 29487 29543 E KILL    : OBS14: KILLMARK=1 rawRealPods=0 rawEmptyPods=0  <<<<< PROOF: patch emptied 1 break(s) that HAD real ads
+08-07 15:25:54.861 29487 29543 E KILL    : OBS15: KILLMARK=1 rawRealPods=0 rawEmptyPods=0  <<<<< PROOF: patch emptied 1 break(s) that HAD real ads
+08-07 15:26:02.264 29487 29543 E KILL    : OBS16: KILLMARK=1 rawRealPods=0 rawEmptyPods=0  <<<<< PROOF: patch emptied 1 break(s) that HAD real ads
+08-07 15:26:10.028 29487 29543 E KILL    : OBS17: KILLMARK=1 rawRealPods=0 rawEmptyPods=0  <<<<< PROOF: patch emptied 1 break(s) that HAD real ads
+08-07 15:26:17.643 29487 29543 E KILL    : OBS18: KILLMARK=1 rawRealPods=0 rawEmptyPods=0  <<<<< PROOF: patch emptied 1 break(s) that HAD real ads
+08-07 15:26:24.867 29487 29543 E KILL    : OBS19: KILLMARK=0 rawRealPods=0 rawEmptyPods=0
+08-07 15:26:32.302 29487 29543 E KILL    : OBS20: KILLMARK=1 rawRealPods=0 rawEmptyPods=0  <<<<< PROOF: patch emptied 1 break(s) that HAD real ads
+08-07 15:26:39.697 29487 29543 E KILL    : OBS21: KILLMARK=1 rawRealPods=0 rawEmptyPods=0  <<<<< PROOF: patch emptied 1 break(s) that HAD real ads
+08-07 15:26:47.186 29487 29543 E KILL    : OBS22: KILLMARK=1 rawRealPods=0 rawEmptyPods=0  <<<<< PROOF: patch emptied 1 break(s) that HAD real ads
+08-07 15:26:54.806 29487 29543 E KILL    : OBS23: KILLMARK=1 rawRealPods=0 rawEmptyPods=0  <<<<< PROOF: patch emptied 1 break(s) that HAD real ads
+08-07 15:27:02.465 29487 29543 E KILL    : OBS24: KILLMARK=1 rawRealPods=0 rawEmptyPods=0  <<<<< PROOF: patch emptied 1 break(s) that HAD real ads
+08-07 15:27:09.913 29487 29543 E KILL    : OBS25: KILLMARK=1 rawRealPods=0 rawEmptyPods=0  <<<<< PROOF: patch emptied 1 break(s) that HAD real ads

--- a/experimental/netflix-native-adstrip/REOPENING.md
+++ b/experimental/netflix-native-adstrip/REOPENING.md
@@ -1,0 +1,149 @@
+# Netflix ad-strip — REOPENED (walls-are-doors methodology)
+
+**Supersedes the "research-parked / closed" verdict in `PORTABILITY-ASSESSMENT.md` §8.**
+That verdict was correct about the *network* (pure same-host SSAI, nothing to block) and about
+the *at-rest* layers (TLS, MSL, appboot signature). It was wrong about the conclusion, because it
+stopped at "appboot is signed" and read a **load-time door** as a **runtime wall**.
+
+This document reopens Netflix on the same principle that cracked Prime Video:
+
+> Ads are changeable. Netflix cannot play the same commercials to everyone all day, so the ad
+> schedule must be **asked for and assembled at runtime**, in a form **the client's own code can
+> read** — and the client necessarily carries a **"no ads" path**, because it runs it constantly.
+
+---
+
+## 1. The observation the "closed" verdict walked past
+
+The prior assessment's own data contains the proof that the wall is a door:
+
+- **§3e, measured:** *"~7 movies played with no pre-roll, then one did."* The **same signed
+  appboot** ran its **own graceful no-ad path six times out of seven.** The client-side empty-break
+  branch is not hypothetical — it executes several times an hour, on your device, with the retail
+  signature fully intact.
+- **§3b/§3d, measured:** the ad-break logic is **plaintext JavaScript** running in an embedded
+  **Hermes** engine inside `libnetflix.so`. The manifest is decrypted (past MSL) into a **JS
+  string/object in the Hermes heap**, then parsed by JS.
+
+Put those together and the shape is *identical* to Prime Video: a JS player, ad logic in plaintext
+at runtime, with a built-in no-ad path. The only difference is the engine name (Hermes vs QuickJS)
+and the at-rest protection (signature vs hash-pin). Neither at-rest protection survives execution —
+**that is the whole methodology.**
+
+## 2. Why "signed" ≠ "sealed"
+
+The appboot RSA/ECDSA signature (pubkey baked into `libnetflix.so`) is a **verify-on-load** gate.
+Its job is to reject a *modified bundle at rest*. It has nothing to say about the bundle **after**
+it has been verified, decompressed, and handed to Hermes as executing source/bytecode:
+
+- Signature check happens **once**, before execution.
+- After it passes, the player JS — including the ad-break resolver **and its own empty-break
+  branch** — lives as plaintext in the **Hermes heap**.
+- We never modify the signed bytes at rest. We operate on the **runtime heap**, downstream of the
+  check, exactly as the Prime Video strip patched `ignitionx` live in QuickJS RAM (that bundle was
+  *hash-pinned* — same lesson: at-rest integrity is irrelevant once the plaintext is executing).
+
+The signature is a door the app must walk through on every launch. We let it walk through, then
+operate on the far side.
+
+## 3. Three seams, mapped from the Prime Video win
+
+Netflix's post-MSL Hermes runtime exposes the same three surgical seams, in the same order of
+precision. All three live **after** MSL-decrypt and **after** the appboot signature check.
+
+| # | Prime Video (proven) | Netflix analogue | Signature touched? |
+|---|---|---|---|
+| **A** | Strip `type:"Remote"` items from PRS payload | **Scrub ad-break markers from the decrypted manifest object** before appboot's ad resolver reads it | **No** — it's *data* in the heap, never the signed code |
+| **B** | Path-1 count-gate `0===t.length` → always-empty | **Live-edit appboot's ad-break resolver in the Hermes heap** to force its own empty-break return | No — edits heap plaintext *after* load-time verify |
+| **C** | Path-2 regolith response-blanking → designed empty path | **Feed appboot's ad resolver an empty break list** so it runs the no-ad branch it already runs 6/7 movies | No — drives the app's own designed path |
+
+**Seam A is the cleanest and the recommended de-risk lead**: because it only rewrites the *manifest
+data* the player consumes — not the player — it is completely orthogonal to the signature, to milo's
+hash, and to MSL (MSL already decrypted it for us; we read it in the clear in the heap). It is the
+Netflix expression of "the app reads the ad schedule before it plays it, in a form its own code can
+read."
+
+## 4. Where the seam physically is (recon targets, bench-executable)
+
+The plaintext manifest transits: `native OpenSSL SSL_read (MSL ciphertext) → MSL decrypt in Hermes
+JS → manifest is a JS string/object in the Hermes heap → appboot ad-break resolver`. Seam A/B/C all
+sit in the last two arrows. Recon to locate them, all doable on the Onn with Frida (the binary/device
+are on the user's bench; the cloud session cannot reach them):
+
+1. **Confirm the no-ad branch exists in appboot** (schema-level, no device): obtain the **appboot UI
+   bundle** the same direct-download way milo was obtained (Gibbon loads it from
+   `appboot.netflix.com`; it is also disk-cached on device). Static-grep it for the ad-break
+   vocabulary the Prime Video bundle used its no-ad path on — `adBreak`, `interstitial`, `cuePoint`,
+   `breakStart`/`breakDuration`, quartile/beacon fields — and for the **empty-guard** pattern
+   (`length === 0`, `return []`, an `if (!breaks.length)` early-out). Finding that guard *names the
+   seam-B edit* the same way `0===t.length` did for Prime Video.
+2. **Fingerprint the manifest string in the heap** (device, Frida): Hermes exposes string/GC
+   primitives. Hook the JSON parse / manifest-ingest path and dump the object that carries the
+   ad-break array during a **known pre-roll session** (the §3e frequency cap tells you how to force
+   one: burn ~7 titles, then capture). This is the Netflix analogue of the Prime Video `memcpy`
+   import hook that surfaced the PRS payload.
+3. **A/B the heap object** ad vs ad-free: capture the same code path on an ad-free title (6/7 of them)
+   and on the pre-roll title. The diff **is** the ad-break schema — the field(s) seam A must scrub
+   and the branch seam B/C must force.
+
+`testing/scripts/analyze_pcap.py --vs` already does A/B at the *network* layer; step 3 is the same
+idea moved to the *heap* layer, which is where Netflix's difference actually lives (network is
+same-host SSAI — identical bytes — so the difference is only visible in-process, confirming this is
+the right altitude).
+
+## 5. What is genuinely different from Prime Video (honest deltas)
+
+Not pretending these are free:
+
+- **Hermes vs QuickJS.** QuickJS parses plaintext *source*; Hermes usually executes *bytecode* (HBC).
+  If appboot ships as HBC, seam **B** (edit the JS source in the heap) needs a Hermes-bytecode-aware
+  edit, not a UTF-8 string patch. **This is exactly why seam A leads** — the *manifest data* is a
+  normal JS string/object regardless of whether the *code* is HBC, so A sidesteps the HBC question
+  entirely. Determine appboot's on-heap form during recon step 1/2.
+- **Reaching the Hermes heap from a native hook.** The toolkit's inline `memcpy`/`SSL_read` seam
+  gave Prime Video plaintext directly; here the native hook has to land on the **Hermes ingest of the
+  manifest** (the boundary where the decrypted MSL payload becomes a JS value). That boundary is a
+  native call — locatable with the Frida bench, then Ghidra — it is one seam deeper than Prime Video,
+  not a different kind of problem.
+- **No power-of-two/zlib-window hazard**, but **do** preserve Hermes string invariants (length,
+  encoding, GC) on any in-place edit — the analogue of Prime Video's same-length-rewrite rule.
+
+None of these is the signature. The signature is settled: it's a load-time door and we operate past it.
+
+## 6. De-risk order (METHODOLOGY §1 — stop if stripping breaks playback)
+
+1. **Get the appboot bundle, static-analyze for the ad-break schema + its empty-guard.** (No device.
+   Highest information per unit effort. Confirms seam B/C exist as code.)
+2. **Frida-dump the decrypted manifest object from the Hermes heap during a forced pre-roll.**
+   Confirms the *data* seam A operates on, and gives the field to scrub.
+3. **A/B ad vs ad-free heap object** → lock the exact scrub.
+4. **Prove seam A on device**: scrub the ad-break field in the heap, observe whether the break is
+   **skipped/blanked** (win) or the **UI desyncs while the ad still plays** (SSAI stitched the video
+   irreversibly — the one outcome that would re-close it). This is the single load-bearing empirical
+   question; everything before it is cheap.
+5. Only if A desyncs, fall back to B/C (force the player's no-ad control path so it never *requests*
+   the stitched ad segments).
+
+## 7. What this session can do without the bench
+
+The binary and device are on the user's Windows/Onn side. From the cloud I can, on request:
+
+- **Static-analyze the appboot bundle** for the ad-break schema and empty-guard (step 1) — the exact
+  artifact that unblocked Prime Video's understanding. *Upload `appboot`/the UI JS as milo was
+  uploaded.*
+- Write the **Frida recon scripts** (Hermes manifest-ingest hook, heap-object dumper, ad/ad-free A/B
+  harness) for steps 2–3, mirroring `scaffold/tools/frida/find-copy-seam.js`.
+- Draft the **seam-A manifest-scrub transform** against the schema once step 1/2 hands it over.
+
+## 8. Verdict (reopened)
+
+- ❌ **"Not strippable" is withdrawn.** It generalized a *load-time* signature and a *network* SSAI
+  result into a *runtime* impossibility. Both at-rest layers are irrelevant to a heap-level strip.
+- ✅ **Netflix fits the methodology exactly:** ads vary per-viewer → assembled at runtime → the
+  decrypted manifest is a plaintext JS object the player's own code reads → the player carries a
+  **no-ad path it demonstrably runs 6 of 7 titles.**
+- ✅ **Lead seam = A (manifest-scrub in the Hermes heap):** orthogonal to the signature, to milo's
+  hash, and to MSL. The one real risk is SSAI irreversibility (step 4), which is empirical and cheap
+  to settle — not the architectural wall the prior verdict assumed.
+- 🔑 **The lock was only ever on the outside.** Netflix runs the player, decrypts the manifest, and
+  executes its no-ad path for us on every launch. It is carrying the key every time it plays.

--- a/experimental/netflix-native-adstrip/autotest/AUTONOMOUS-TESTING.md
+++ b/experimental/netflix-native-adstrip/autotest/AUTONOMOUS-TESTING.md
@@ -1,0 +1,57 @@
+# Autonomous patch testing (drive the app + monitor logs) — workflow capability
+
+A reusable capability for this repo: the agent can drive a patched app over `adb`
+(launch, resume a title, seek, pause/resume) **and** read the data oracle at the
+same time — so ad-suppression + playback + resume can be validated without a human
+holding the remote. First proven on the Netflix clone (`nf-autotest.sh`).
+
+## What it validates (Netflix example)
+- Patches self-applied at launch (`KILL … apply DONE A/B/FP`).
+- Playback continuity (media-session `position` advancing at ~1x, no stalls).
+- Resume/pause correctness (position preserved across pause→resume).
+- Ad suppression under stress (seek to mid-rolls, pause for pause-ads) via the
+  in-app oracle: `KILLMARK≥2` (real manifest ad break emptied), `rawDisplayAd>0`
+  (server pause-ad suppressed), `rawRealPods>0` (raw pre-roll pod present).
+- No `tvq-pb` / crashes / ANRs.
+
+## HARD RULES (learned the hard way — do not skip)
+Blind, open-ended navigation on a logged-in account is DANGEROUS. In an early run
+a free-roaming driver (DOWN×N / RIGHT×N + CENTER) wandered into an Add-Profile /
+sign-up flow and launched a *different* app (Apple TV), because once the target
+app got backgrounded, the keypresses landed on the launcher. Rules that prevent
+this:
+
+1. **No open-ended directional navigation.** Only `CENTER`-to-resume
+   (Continue-Watching) + in-player keys (`MEDIA_FAST_FORWARD`, `MEDIA_PLAY_PAUSE`,
+   `BACK`). Never sweep rows/tiles blindly — the screen is a secure surface
+   (no screenshots, no accessibility tree), so you cannot see what you select.
+2. **Foreground-guard before every input.** Check the top activity; if the target
+   package is not foreground, ABORT immediately — never send keys blind.
+3. **Verify before stressing.** After the resume, confirm the media session is
+   actually `PLAYING` with `position>0`. If not, `BACK` once and stop — do not
+   keep poking.
+4. **Bounded + clean-stop.** Fixed cycle count, then `BACK` to home. Re-check
+   foreground at the end.
+5. **Read-only oracle.** Ad/error/position monitoring is pure logcat + dumpsys —
+   zero input. Keep the driving minimal and the observing rich.
+
+## Run it
+```bash
+bash experimental/netflix-native-adstrip/autotest/nf-autotest.sh [cycles]   # default 4
+```
+Prereqs: the clone (`com.netflix.ninja.clone`) installed + logged in, stock
+Netflix enabled (clone reads its signature), device on `adb`. The bundled gadget
+script self-logs the `KILL/OBS` oracle, so no frida attach is needed.
+
+## Generalizing to other apps
+The pattern is app-agnostic; only the specifics change:
+- `PKG`/`ACT`, the "resume a known-good item" action, and the oracle signal.
+- Playback position: `dumpsys media_session` works for any app that publishes a
+  MediaSession with a real `position` (Netflix does; verify per app).
+- Ad/behavior oracle: reuse the app's in-process monitor (like `killads.js`'s
+  OBS line) or a read-only logcat signal. If an app HAS a screen you can read
+  (standard Android views / accessibility tree), navigation can be less blind —
+  but keep the foreground-guard and verify-before-act rules regardless.
+
+Keep the same hard rules. The value is "drive minimally, observe richly, never
+send input you can't verify the target for."

--- a/experimental/netflix-native-adstrip/autotest/nf-autotest.sh
+++ b/experimental/netflix-native-adstrip/autotest/nf-autotest.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# ─────────────────────────────────────────────────────────────────────────────
+# Netflix clone — GUARDRAILED autonomous ad/playback test (no blind navigation).
+#
+# Drives ONLY safe, verified actions: launch -> confirm patches armed -> a single
+# controlled resume of Continue-Watching -> IN-PLAYER stress (seek to mid-rolls,
+# pause/resume) -> clean stop. Monitors media-session position (continuity) and
+# the in-app KILL/OBS oracle (ad suppression) + logcat for errors.
+#
+# HARD RULES (learned the hard way — see AUTONOMOUS-TESTING.md):
+#  * NEVER do open-ended directional navigation (DOWN/RIGHT wandering hits
+#    profile/account/other-app tiles). Only CENTER-to-resume + in-player keys.
+#  * FOREGROUND-GUARD before every input: if the clone is not foreground, ABORT
+#    (so stray keys can't land on the launcher / another app).
+#  * VERIFY playback actually started before stressing; back out safely if not.
+#
+# Usage: bash nf-autotest.sh [cycles]     (default 4 in-player stress cycles)
+# ─────────────────────────────────────────────────────────────────────────────
+PKG=com.netflix.ninja.clone
+ACT=$PKG/com.netflix.ninja.MainActivity
+CYCLES=${1:-4}
+
+K(){ adb shell input keyevent "$1" >/dev/null 2>&1; }
+FG(){ adb shell dumpsys activity activities 2>/dev/null | grep -oE 'topResumedActivity=ActivityRecord\{[a-f0-9]+ u0 [^ }]+' | grep -oE '[^ ]+$' | head -1; }
+POS(){ adb shell dumpsys media_session 2>/dev/null | grep -oE 'state=[A-Z]+\([0-9]\), position=[0-9]+' | grep -vE 'position=0$' | head -1; }
+lg(){ echo "$(date +%H:%M:%S) $*"; }
+guard(){ case "$(FG)" in *"$PKG"*) return 0;; *) lg "ABORT: clone not foreground (fg=$(FG)) — refusing to send input"; return 1;; esac; }
+
+lg "=== launch + confirm patches armed ==="
+adb shell am force-stop "$PKG" >/dev/null 2>&1
+adb logcat -c >/dev/null 2>&1
+adb shell monkey -p "$PKG" -c android.intent.category.LAUNCHER 1 >/dev/null 2>&1
+sleep 22
+armed=$(adb logcat -d 2>/dev/null | grep -cE 'KILL.*apply DONE')
+lg "patches armed: $([ "$armed" -gt 0 ] && echo YES || echo 'NO — aborting')"
+[ "$armed" -gt 0 ] || exit 1
+
+guard || exit 1
+lg "=== controlled resume (CENTER x2 on Continue-Watching) ==="
+K KEYCODE_DPAD_CENTER; sleep 4; K KEYCODE_DPAD_CENTER; sleep 12
+S=$(POS)
+if [ -z "$S" ]; then lg "no playback started — backing out, exiting"; K KEYCODE_BACK; sleep 2; exit 0; fi
+lg "playing: $S"
+
+for c in $(seq 1 "$CYCLES"); do
+  guard || break
+  lg "--- cycle $c: seek to mid-rolls (FF x6) ---"
+  for s in 1 2 3 4 5 6; do K KEYCODE_MEDIA_FAST_FORWARD; sleep 1; done
+  K KEYCODE_DPAD_CENTER; sleep 6; lg "cycle $c seeked: $(POS)"
+  guard || break
+  lg "--- cycle $c: pause (pause-ad window) + resume ---"
+  K KEYCODE_MEDIA_PLAY_PAUSE; sleep 7; lg "cycle $c paused: $(POS)"
+  K KEYCODE_MEDIA_PLAY_PAUSE; sleep 8; lg "cycle $c resumed: $(POS)"
+  errs=$(adb logcat -d 2>/dev/null | grep -icE 'tvq-pb|FATAL|has died.*clone|SIGABRT')
+  [ "$errs" -gt 0 ] && lg "cycle $c WARNING: $errs error line(s) in logcat"
+done
+
+guard && { lg "=== clean stop (back to home) ==="; K KEYCODE_BACK; sleep 2; K KEYCODE_BACK; sleep 2; }
+
+lg "=== REPORT ==="
+lg "ad deliveries + kills (non-baseline OBS):"
+adb logcat -d 2>/dev/null | grep -oE 'OBS[0-9]+: KILLMARK=[0-9]+ rawRealPods=[0-9]+ rawDisplayAd=[0-9]+.*' | grep -vE 'KILLMARK=[01] rawRealPods=0 rawDisplayAd=0' | tail -12
+lg "errors:"; adb logcat -d 2>/dev/null | grep -iE 'tvq-pb|FATAL|has died.*clone|SIGABRT' | tail -4 | grep . || echo "  none"
+lg "final fg: $(FG)"
+lg "=== DONE ==="

--- a/experimental/netflix-native-adstrip/autotest/nf-matrix.sh
+++ b/experimental/netflix-native-adstrip/autotest/nf-matrix.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# ─────────────────────────────────────────────────────────────────────────────
+# Netflix clone — EXTENDED deterministic test matrix (NO blind navigation).
+#
+# Exercises many titles (new/old movies + shows) and scenarios — from-beginning,
+# end-credits, start-over, pause/resume, and Continue-Watching resume — by
+# DEEP-LINKING directly to specific title IDs (nflx/https VIEW intent), never by
+# guessing at unseen UI. Foreground-guard before every input. Captures the in-app
+# KILL/OBS ad-oracle + media-session position (continuity) + logcat errors.
+#
+# Titles are Netflix ORIGINALS (broadly available); if one isn't playable for this
+# account/region, playback simply never starts and the harness logs it + moves on.
+#
+# Usage: bash nf-matrix.sh
+# ─────────────────────────────────────────────────────────────────────────────
+PKG=com.netflix.ninja.clone
+ACT=$PKG/com.netflix.ninja.MainActivity
+
+# id|label|kind  (kind is informational only)
+TITLES=(
+  "81231974|Wednesday|show-new"
+  "80057281|Stranger Things|show-old"
+  "81161626|Red Notice|movie-new"
+  "80175798|The Irishman|movie-old"
+  "80240715|Roma|movie-old"
+)
+
+K(){ adb shell input keyevent "$1" >/dev/null 2>&1; }
+FG(){ adb shell dumpsys activity activities 2>/dev/null | grep -oE 'topResumedActivity=ActivityRecord\{[a-f0-9]+ u0 [^ }]+' | grep -oE '[^ ]+$' | head -1; }
+POS(){ adb shell dumpsys media_session 2>/dev/null | grep -oE 'state=[A-Z]+\([0-9]\), position=[0-9]+' | grep -vE 'position=0$' | head -1; }
+lg(){ echo "$(date +%H:%M:%S) $*"; }
+guard(){ case "$(FG)" in *"$PKG"*) return 0;; *) lg "  ABORT: clone not foreground (fg=$(FG))"; return 1;; esac; }
+
+# Wait up to ~45s for 'apply DONE' (patches armed) after a launch.
+wait_armed(){ local n=0; while [ $n -lt 15 ]; do adb logcat -d 2>/dev/null | grep -q 'KILL.*apply DONE' && return 0; sleep 3; n=$((n+1)); done; return 1; }
+
+deeplink(){ adb shell am start -n "$ACT" -a android.intent.action.VIEW -d "$1" >/dev/null 2>&1; }
+
+oracle(){ adb logcat -d 2>/dev/null | grep -oE 'OBS[0-9]+: KILLMARK=[0-9]+ rawRealPods=[0-9]+ rawDisplayAd=[0-9]+.*' | grep -vE 'KILLMARK=[01] rawRealPods=0 rawDisplayAd=0' | tail -6; }
+errs(){ adb logcat -d 2>/dev/null | grep -icE 'tvq-pb|FATAL|has died.*clone|SIGABRT|ANR in com.netflix.ninja.clone'; }
+
+lg "################ EXTENDED MATRIX START ################"
+for entry in "${TITLES[@]}"; do
+  id="${entry%%|*}"; rest="${entry#*|}"; label="${rest%%|*}"; kind="${rest##*|}"
+  lg ""
+  lg "======== [$label] ($kind) id=$id ========"
+  adb shell am force-stop "$PKG" >/dev/null 2>&1
+  adb logcat -c >/dev/null 2>&1
+
+  # ---- FROM BEGINNING: deep-link fresh launch ----
+  lg "  launch (deep-link, from beginning)"
+  deeplink "nflx://www.netflix.com/watch/$id"; sleep 6
+  if ! guard; then deeplink "https://www.netflix.com/watch/$id"; sleep 6; fi
+  wait_armed && lg "  patches armed: YES" || lg "  patches armed: NO (continuing, will still record)"
+
+  # wait for playback
+  S=""; n=0; while [ $n -lt 10 ] && [ -z "$S" ]; do S=$(POS); [ -z "$S" ] && sleep 3; n=$((n+1)); done
+  if [ -z "$S" ]; then lg "  NO PLAYBACK (unavailable for account/region?) — skipping title"; K KEYCODE_BACK; sleep 2; continue; fi
+  lg "  FROM-BEGINNING playing: $S"
+
+  # ---- END CREDITS: big forward seek toward end ----
+  guard || continue
+  lg "  seek toward END CREDITS (FF x18)"
+  for s in $(seq 1 18); do K KEYCODE_MEDIA_FAST_FORWARD; sleep 0.6; done
+  K KEYCODE_DPAD_CENTER; sleep 8; lg "  near-end pos: $(POS)  (watching for post-credit auto-advance / errors)"
+  sleep 6; lg "  post-credit pos: $(POS)  fg=$(FG)"
+
+  # ---- PAUSE (pause-ad window) at end region ----
+  guard && { lg "  pause 7s + resume"; K KEYCODE_MEDIA_PLAY_PAUSE; sleep 7; lg "  paused: $(POS)"; K KEYCODE_MEDIA_PLAY_PAUSE; sleep 5; lg "  resumed: $(POS)"; }
+
+  # ---- START OVER: rewind to the beginning ----
+  guard && { lg "  START OVER (RW x18)"; for s in $(seq 1 18); do K KEYCODE_MEDIA_REWIND; sleep 0.6; done; K KEYCODE_DPAD_CENTER; sleep 6; lg "  after start-over pos: $(POS)"; }
+
+  lg "  errors so far: $(errs)"; oracle | sed 's/^/    ORACLE: /'
+  guard && { K KEYCODE_BACK; sleep 2; K KEYCODE_BACK; sleep 2; }
+
+  # ---- RESUME: relaunch same title, expect bookmark > 0 ----
+  lg "  RESUME test: relaunch same title"
+  adb shell am force-stop "$PKG" >/dev/null 2>&1; sleep 2
+  deeplink "nflx://www.netflix.com/watch/$id"; sleep 6
+  R=""; n=0; while [ $n -lt 8 ] && [ -z "$R" ]; do R=$(POS); [ -z "$R" ] && sleep 3; n=$((n+1)); done
+  lg "  RESUME pos: ${R:-<none>}  (>0 position = bookmark honored)"
+  guard && { K KEYCODE_BACK; sleep 2; K KEYCODE_BACK; sleep 2; }
+done
+
+# ---- Continue-Watching CENTER resume (row-0 tile) as a final continuity check ----
+lg ""
+lg "======== Continue-Watching resume (CENTER path) ========"
+adb shell am force-stop "$PKG" >/dev/null 2>&1
+adb logcat -c >/dev/null 2>&1
+adb shell monkey -p "$PKG" -c android.intent.category.LAUNCHER 1 >/dev/null 2>&1
+wait_armed && lg "  patches armed: YES" || lg "  patches armed: NO"
+guard && { K KEYCODE_DPAD_CENTER; sleep 4; K KEYCODE_DPAD_CENTER; sleep 12; lg "  CW resume pos: $(POS)"; K KEYCODE_BACK; sleep 2; K KEYCODE_BACK; sleep 2; }
+
+lg ""
+lg "################ MATRIX REPORT ################"
+lg "non-baseline ad oracle across whole run:"
+adb logcat -d 2>/dev/null | grep -oE 'OBS[0-9]+: KILLMARK=[0-9]+ rawRealPods=[0-9]+ rawDisplayAd=[0-9]+.*' | grep -vE 'KILLMARK=[01] rawRealPods=0 rawDisplayAd=0' | tail -20 | sed 's/^/  /' || echo "  (none)"
+lg "GAID/FP/patch arming lines:"
+adb logcat -d 2>/dev/null | grep -oE 'KILL *: (PATCH (GAID|FP|A|B)|apply DONE).*' | tail -6 | sed 's/^/  /'
+lg "error lines:"
+adb logcat -d 2>/dev/null | grep -iE 'tvq-pb|FATAL|has died.*clone|SIGABRT|ANR in com.netflix.ninja.clone' | tail -6 | sed 's/^/  /' | grep . || echo "  none"
+lg "final fg: $(FG)"
+lg "################ DONE ################"

--- a/experimental/netflix-native-adstrip/combined-kill.js
+++ b/experimental/netflix-native-adstrip/combined-kill.js
@@ -1,0 +1,74 @@
+'use strict';
+// BOTH kills, single-shot each (NO re-patch loop), + read-only data oracle.
+//  (A) manifest pre/mid-roll: AdsState.prepareAdBreakStates -> stamp __adkill, empty metadata.ads=[]
+//  (B) pause overlay: z() saga -> force f=e.displayAd to void 0 -> no ad opportunity
+//  OBSERVE (read-only): KILLMARK(__adkill)/rawRealPods(ads":[{) prove manifest kills; rawDisplayAd
+//  ("displayAd":{) = server sent a pause ad (our object/code patch leaves raw JSON intact -> oracle).
+var logw = new NativeFunction(Module.findGlobalExportByName('__android_log_write'),
+  'int', ['int', 'pointer', 'pointer']);
+var TAG = Memory.allocUtf8String('KILL');
+function L(m){ logw(6, TAG, Memory.allocUtf8String(m)); }
+function pat(s){ return s.split('').map(function(c){return ('0'+c.charCodeAt(0).toString(16)).slice(-2);}).join(' '); }
+function bytesOf(s){ var b=[]; for (var i=0;i<s.length;i++) b.push(s.charCodeAt(i)); return b; }
+
+// ---------- (A) manifest patch ----------
+var A_OLD = 'var f=e.value;f.syncAdStates();f.state.isHydrated&&"viewable"!==f.metadata.source&&f.applyHydration(f.state.hydrationSequenceId)';
+var A_NEW = 'var f=e.value;f.metadata&&(f.metadata.ads.length&&(f.__adkill=f.metadata.ads.length),f.metadata.ads=[]);f.syncAdStates();/*...*/';
+var aDone=false;
+function patchA(rs){
+  if(aDone) return;
+  if(A_NEW.length!==A_OLD.length){ L('A length mismatch OLD='+A_OLD.length+' NEW='+A_NEW.length+' — ABORT A'); aDone=true; return; }
+  var p=pat(A_OLD);
+  for(var i=0;i<rs.length;i++){ var r=rs[i]; if(r.size>128*1024*1024)continue;
+    try{ var h=Memory.scanSync(r.base,r.size,p);
+      for(var j=0;j<h.length;j++){ Memory.protect(h[j].address,A_NEW.length,'rw-'); h[j].address.writeByteArray(bytesOf(A_NEW)); aDone=true; L('PATCH A: prepareAdBreakStates @'+h[j].address+' (metadata.ads=[]+__adkill stamp)'); } }catch(e){}
+  }
+}
+
+// ---------- (B) pause patch ----------
+var B_ANCHOR='void 0:e.displayAd', B_OLD='e.displayAd', B_NEW='void 0     '; // 11==11
+var bDone=false;
+function patchB(rs){
+  if(bDone) return;
+  var p=pat(B_ANCHOR);
+  for(var i=0;i<rs.length;i++){ var r=rs[i]; if(r.size>128*1024*1024)continue;
+    try{ var h=Memory.scanSync(r.base,r.size,p);
+      for(var j=0;j<h.length;j++){ var t=h[j].address.add('void 0:'.length);
+        var cur=null; try{cur=t.readCString(B_OLD.length);}catch(e){}
+        if(cur!==B_OLD) continue;
+        Memory.protect(t,B_NEW.length,'rw-'); t.writeByteArray(bytesOf(B_NEW)); bDone=true;
+        L('PATCH B: pause z() displayAd->void0 @'+t); } }catch(e){}
+  }
+}
+
+// ---------- apply (poll until BOTH applied, then stop) ----------
+var tries=0;
+function apply(){
+  tries++;
+  var rs=Process.enumerateRanges('rw-');
+  var loaded=false, gp=pat('nrdp.gibbon');
+  for(var i=0;i<rs.length && !loaded;i++){ if(rs[i].size>128*1024*1024)continue; try{ if(Memory.scanSync(rs[i].base,rs[i].size,gp).length) loaded=true; }catch(e){} }
+  if(loaded){ patchA(rs); patchB(rs); }
+  if((aDone&&bDone)||tries>90){ L('apply stop: A='+aDone+' B='+bDone+' tries='+tries); return; }
+  setTimeout(apply, 2000);
+}
+
+// ---------- observe (read-only) ----------
+var KILLMARK=pat('__adkill'), REALPOD=pat('ads":[{'), EMPTYPOD=pat('ads":[]'), DISPAD=pat('displayAd":{');
+var cyc=0;
+function observe(){
+  cyc++;
+  var rs=Process.enumerateRanges('rw-'); var kill=0,real=0,empty=0,disp=0;
+  for(var i=0;i<rs.length;i++){ var r=rs[i]; if(r.size>64*1024*1024||r.size<256)continue;
+    try{ kill+=Memory.scanSync(r.base,r.size,KILLMARK).length; real+=Memory.scanSync(r.base,r.size,REALPOD).length;
+      empty+=Memory.scanSync(r.base,r.size,EMPTYPOD).length; disp+=Memory.scanSync(r.base,r.size,DISPAD).length; }catch(e){}
+  }
+  var tag=kill>0?'  <<< PROOF manifest: emptied '+kill+' real-ad break(s)':'';
+  var ptag=disp>0?'  <<< server sent pause displayAd (x'+disp+')':'';
+  L('OBS'+cyc+': KILLMARK='+kill+' rawRealPods='+real+' rawEmptyPods='+empty+' rawDisplayAd='+disp+tag+ptag);
+  if(cyc<160) setTimeout(observe, 2500);
+}
+
+L('combined-kill ready (A manifest + B pause, single-shot; read-only oracle)');
+setTimeout(apply, 5000);
+setTimeout(observe, 8000);

--- a/experimental/netflix-native-adstrip/decompiled/BleAdvertiseAgent.deobfuscated.java
+++ b/experimental/netflix-native-adstrip/decompiled/BleAdvertiseAgent.deobfuscated.java
@@ -1,0 +1,227 @@
+// Deobfuscated reconstruction of  Lo/getArguments;  (com.netflix.ninja 13.0.0-25009)
+// Original class dumped into R8's generic `o` package. Log tag: "nf_bt_agent".
+// This is Netflix's BLE advertiser agent used for MDX / second-screen device
+// discovery — NOT video-ad logic. Reconstructed from dex bytecode; names are
+// inferred from Android BLE types, log strings, and native-method signatures.
+//
+// Base class  Lo/getActivity;  (renamed conceptually to `NrdAgentBase`) provides:
+//   Context getContext();  NetflixService getService();
+//   void doInit(); void initCompleted(callback); void destroy();
+
+package com.netflix.ninja.bluetooth;   // inferred
+
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothManager;
+import android.bluetooth.le.*;
+import android.content.*;
+import android.os.*;
+import java.util.concurrent.TimeUnit;
+
+final class BleAdvertiseAgent extends NrdAgentBase {
+
+    private static final String TAG = "nf_bt_agent";
+    // <clinit>: TimeUnit.MILLISECONDS.convert(10, MINUTES)
+    private static final long ADVERTISE_TIMEOUT_MS = TimeUnit.MILLISECONDS.convert(10, TimeUnit.MINUTES);
+    public static final Companion Companion = new Companion();
+
+    private BluetoothLeAdvertiser bleAdvertiser;                 // M135Cu0D
+    private AdvertiseCallback     advertiseCallback;             // M1cMYXGO
+    private AdvertiseSettings     advertiseSettings;             // M5_IQXaH
+    private AdvertiseData         advertiseData;                 // MoMD214    (primary)
+    private AdvertiseData         scanResponseData;              // M6H_IiaF   (optional scan-response)
+    private boolean isBluetoothEnabled;                          // M1gJHszj
+    private boolean isBleSupported;                              // M51RPBJe
+    private boolean isLeExtendedAdvertisingSupported;            // M4mrObfZ
+    private boolean isLePeriodicAdvertisingSupported;            // M5K_ewhl
+    private final BroadcastReceiver bluetoothStateReceiver;      // M4znfYdB ($M135Cu0D)
+    private Handler timeoutHandler;                              // M6xubM8G
+
+    BleAdvertiseAgent(NrdAgentConfig config) {                   // <init>(Lo/getActivity$M1cMYXGO;)
+        super(config);
+        this.advertiseSettings = new AdvertiseSettings.Builder()
+                .setAdvertiseMode(1)      // ADVERTISE_MODE_BALANCED
+                .setConnectable(false)
+                .setTimeout(0)
+                .build();
+        this.bluetoothStateReceiver = new BluetoothStateReceiver(this);   // $M135Cu0D
+    }
+
+    // ---- lifecycle (from base NrdAgentBase) ------------------------------
+
+    @Override public void doInit() {
+        Log.i(TAG, "Bluetooth::init start ");
+        initBluetoothState();
+        initCompleted(/* AGENT_BLUETOOTH */ Agents.BLUETOOTH);
+    }
+
+    @Override public void destroy() {
+        Log.i(TAG, "Bluetooth::destroy");
+        getContext().unregisterReceiver(bluetoothStateReceiver);
+        super.destroy();
+    }
+
+    // MoMD214(): init() — used as a re-init + (re)start entry point
+    public void init() {                                        // MoMD214()V
+        initBluetoothState();
+        startAdvertising();
+    }
+
+    // ---- state / capability probing -------------------------------------
+
+    private void initBluetoothState() {                        // M1gJHszj()V
+        BluetoothManager bm = (BluetoothManager) getContext().getSystemService(Context.BLUETOOTH_SERVICE);
+        BluetoothAdapter adapter = bm.getAdapter();
+        this.isBluetoothEnabled = adapter != null && adapter.isEnabled();
+        this.isBleSupported = getContext().getPackageManager()
+                .hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE);   // "android.hardware.bluetooth_le"
+        if (isBleSupported) {
+            this.bleAdvertiser = (adapter != null) ? adapter.getBluetoothLeAdvertiser() : null;
+            if (Build.VERSION.SDK_INT >= 26) {
+                this.isLeExtendedAdvertisingSupported =
+                        adapter != null && adapter.isLeExtendedAdvertisingSupported();
+                this.isLePeriodicAdvertisingSupported =
+                        adapter != null && adapter.isLePeriodicAdvertisingSupported();
+            }
+            this.advertiseCallback = createAdvertiseCallback();
+            getContext().registerReceiver(
+                    bluetoothStateReceiver,
+                    new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED),
+                    Context.RECEIVER_NOT_EXPORTED /* 4 */);
+        }
+        NetflixService svc = getService();
+        try {
+            if (svc != null) {
+                svc.nativeSetBluetoothStatus(isBluetoothEnabled, isBleSupported,
+                        isLeExtendedAdvertisingSupported, isLePeriodicAdvertisingSupported);
+            }
+        } catch (SecurityException e) {
+            Log.e(TAG, "SecurityException " + e);
+        }
+    }
+
+    private boolean checkPermissions() {                       // M1cMYXGO()Z
+        if (AndroidUtils.isAtLeastS()) {                       // AndroidUtils.M5K_ewhl()
+            if (getContext().checkSelfPermission(android.Manifest.permission.BLUETOOTH_ADVERTISE)
+                    != PackageManager.PERMISSION_GRANTED) {
+                if (MainActivity.isRunning()) {                // MainActivity.M0s8NeYn()
+                    Log.i(TAG, "Permission android.permission.BLUETOOTH_ADVERTISE not granted, requesting...");
+                    EventBus.getDefault().post(new CommonEvent(CommonEvent.CommonEvents.REQUEST_BT_PERMISSION));
+                }
+                return false;
+            }
+        }
+        if (getContext().checkSelfPermission(android.Manifest.permission.BLUETOOTH_ADMIN)
+                != PackageManager.PERMISSION_GRANTED) {
+            Log.e(TAG, "Permission android.permission.BLUETOOTH_ADMIN not granted, cannot continue !!!");
+            return false;
+        }
+        return true;
+    }
+
+    // ---- advertise control ----------------------------------------------
+
+    public void startAdvertising() {                           // M135Cu0D()V
+        if (!isBluetoothEnabled) {
+            NetflixService svc = getService();
+            if (svc != null) svc.nativeSetBluetoothAdvertiseStarted(2 /* BT_DISABLED */);
+            return;
+        }
+        if (!isBleSupported) {
+            NetflixService svc = getService();
+            if (svc != null) svc.nativeSetBluetoothAdvertiseStarted(1 /* BLE_UNSUPPORTED */);
+            return;
+        }
+        if (!checkPermissions()) return;
+
+        Log.i(TAG, "Bluetooth::startAdvertising of data " + advertiseData);
+        if (scanResponseData != null) {
+            if (bleAdvertiser != null) {
+                bleAdvertiser.startAdvertising(advertiseSettings, advertiseData, scanResponseData, advertiseCallback);
+            }
+        } else if (bleAdvertiser != null) {
+            bleAdvertiser.startAdvertising(advertiseSettings, advertiseData, advertiseCallback);
+        }
+        // arm the 10-minute auto-stop
+        this.timeoutHandler = new Handler(Looper.getMainLooper());
+        timeoutHandler.postDelayed(new AdvertiseTimeoutRunnable(this), ADVERTISE_TIMEOUT_MS);  // $getDefaultViewModelProviderFactory
+
+        NetflixService svc = getService();
+        if (svc != null) svc.nativeSetBluetoothAdvertiseStarted(4 /* STARTED */);
+    }
+
+    public void stopAdvertising() {                            // M0s8NeYn()V
+        Log.i(TAG, "Bluetooth::stopAdvertising");
+        if (bleAdvertiser != null) {
+            bleAdvertiser.stopAdvertising(advertiseCallback);
+        }
+        NetflixService svc = getService();
+        if (svc != null) svc.nativeSetBluetoothAdvertiseStopped();
+    }
+
+    // Called from a Handler when ADVERTISE_TIMEOUT_MS elapses.
+    private static void onTimeout(BleAdvertiseAgent self) {    // M51RPBJe(Lo/getArguments;)V
+        Log.i(TAG, "AdvertiserService has reached timeout of " + ADVERTISE_TIMEOUT_MS + " milliseconds, stopping advertising.");
+        self.stopAdvertising();
+    }
+
+    // type: 0 = scan-response slot, 1 = advertise slot
+    public void clearAdvertiseData(int type) {                 // M0s8NeYn(I)V
+        if (type == 0)       this.scanResponseData = null;
+        else if (type == 1)  this.advertiseData    = null;
+    }
+
+    public boolean setAdvertisingSettings(int mode, boolean connectable, int timeoutMs) {  // N(I Z I)Z
+        Log.i(TAG, "Bluetooth::setAdvertisingSettings");
+        try {
+            this.advertiseSettings = new AdvertiseSettings.Builder()
+                    .setAdvertiseMode(mode)
+                    .setConnectable(connectable)
+                    .setTimeout(timeoutMs)
+                    .build();
+            return true;
+        } catch (Exception e) {
+            Log.e(TAG, "Bluetooth::setAdvertisingSettings FAILED with exception " + e.getMessage());
+            return false;
+        }
+    }
+
+    // Builds an AdvertiseData; `dataType` (last-ish arg) routes to advertise vs scan-response slot.
+    public boolean addAdvertiseData(int dataType, boolean includeDeviceName, String serviceUuid,
+                                    boolean includeTxPower, String serviceDataUuid, boolean hasSolicitationUuid,
+                                    String solicitationUuid, String serviceData, boolean hasServiceData,
+                                    int manufacturerId, String manufacturerData, boolean hasManufacturerData,
+                                    boolean includeTxPowerLevel) {          // N(I Z String Z String Z String String Z I String Z Z)Z
+        Log.i(TAG, "Bluetooth::addAdvertiseData");
+        try {
+            AdvertiseData.Builder b = new AdvertiseData.Builder()
+                    .setIncludeDeviceName(includeDeviceName)
+                    .setIncludeTxPowerLevel(includeTxPowerLevel);
+            if (includeTxPower && serviceUuid != null && serviceUuid.length() != 0) {
+                b.addServiceUuid(ParcelUuid.fromString(serviceUuid));
+            }
+            if (hasServiceData && serviceData != null && serviceData.length() != 0
+                    && serviceDataUuid != null && serviceDataUuid.length() != 0) {
+                b.addServiceData(ParcelUuid.fromString(serviceDataUuid),
+                                 serviceData.getBytes(/* UTF-8 */));
+            }
+            if (hasManufacturerData) {
+                byte[] mfg = (manufacturerData != null) ? manufacturerData.getBytes() : null;
+                b.addManufacturerData(manufacturerId, mfg);
+            }
+            if (Build.VERSION.SDK_INT >= 31 && hasSolicitationUuid
+                    && solicitationUuid != null && solicitationUuid.length() != 0) {
+                b.addServiceSolicitationUuid(ParcelUuid.fromString(solicitationUuid));
+            }
+            if (dataType == 0)      this.scanResponseData = b.build();
+            else if (dataType == 1) this.advertiseData    = b.build();
+            return true;
+        } catch (Exception e) {
+            Log.e(TAG, "Bluetooth::addAdvertiseData FAILED with exception " + e.getMessage());
+            return false;
+        }
+    }
+
+    private AdvertiseCallback createAdvertiseCallback() {       // N()Lo/getArguments$MoMD214;
+        return new BleAdvertiseCallback(this);                 // $MoMD214
+    }
+}

--- a/experimental/netflix-native-adstrip/frida/README.md
+++ b/experimental/netflix-native-adstrip/frida/README.md
@@ -1,0 +1,85 @@
+# Acquiring the Netflix appboot bundle on a **non-rooted** Onn (frida-gadget)
+
+`dump_appboot.js` captures the appboot player JS in-process — **after** MSL-decrypt and
+**after** the load-time appboot signature check — so it never touches the signed bytes at rest.
+No root: Frida runs as **frida-gadget**, a `.so` loaded inside Netflix's own process.
+
+## Why this is offset-free
+`libnetflix.so` is stripped + statically links OpenSSL/Hermes/Gibbon, so symbol hooks are
+unreliable. The script uses only **libc file I/O** (always exported) + **generic memory scanning**
++ **export recon**. It also tags each dump `JS` vs `HBC` (Hermes bytecode) — which decides whether
+seam B (edit the ad resolver as source) is available or we lean on seam A (scrub the manifest data).
+
+## Step 1 — get frida-gadget into Netflix (two routes)
+
+**Route A — reuse the toolkit (recommended).** The Morphe `LoadNativeHookPatch` already injects a
+native `.so` and loads it in `Lcom/netflix/ninja/NetflixApplication;` `onCreate` (the subclass the
+assessment resolved for exactly this). Point it at **`libgadget.so`** instead of the hook lib:
+1. Download frida-gadget for **armeabi-v7a** (match the app ABI), rename to `libgadget.so`.
+2. Drop a gadget config next to it so it loads our script in listen mode:
+   ```json
+   // libgadget.config.so  (frida looks for <soname>.config.so)
+   { "interaction": { "type": "script", "path": "/data/local/tmp/dump_appboot.js" } }
+   ```
+   (or `"type":"listen"` to attach live from your PC — see Step 3).
+3. Run the patcher against `com.netflix.ninja` so the gadget + config ship in the APK and
+   `extractNativeLibs` is forced `true` (the toolkit's `BundleNativeHookPatch` already does this).
+4. **Also flip `android:debuggable="true"`** in the repackaged manifest — lets you `adb pull`/`run-as`
+   the dumps without root.
+
+**Route B — plain apktool.** `apktool d base.apk` → add `lib/armeabi-v7a/libgadget.so` +
+`libgadget.config.so` → inject `System.loadLibrary("gadget")` at the top of
+`NetflixApplication.onCreate` in smali → `apktool b` → `apksigner sign` with your own key.
+(Same effect; Route A is just your toolkit doing this for you.)
+
+Either way you re-sign the **APK** with your own key — that's fine. The **appboot** signature is
+Netflix's *internal* signature on the downloaded UI bundle, separate from the Android APK signature;
+account login and playback are unaffected by re-signing the APK.
+
+## Step 2 — push the script + install
+
+```
+adb -s 192.168.12.210:5555 push dump_appboot.js /data/local/tmp/dump_appboot.js
+adb -s 192.168.12.210:5555 install -r netflix.patched.apk
+adb -s 192.168.12.210:5555 shell monkey -p com.netflix.ninja 1   # launch
+```
+
+The gadget loads on boot, arms the libc taps immediately, runs export recon at +5 s, and does the
+first heap sweep at +20 s.
+
+## Step 3 — force an appboot load, then a pre-roll
+
+1. Just launching the app fetches + caches appboot → the **libc I/O taps** and the **heap sweep**
+   should catch it. Watch logcat: `adb logcat -s frida:* | grep appboot-dump` (gadget logs to
+   logcat), or attach live: `frida -U -n com.netflix.ninja` then `%resume` and call
+   `rpc.exports.sweep()` / `rpc.exports.sweepfor("adBreak")`.
+2. To capture the **manifest with ad-break markers** (seam A's target data), reproduce §3e: play
+   ~7 titles to trip the frequency cap, then the title that shows a pre-roll — during that session
+   call `sweepfor("adBreak")` (and try `interstitial`, `cuePoint`, `breakStart`).
+
+## Step 4 — pull the dumps
+
+```
+# app external dir (no root, no debuggable needed):
+adb -s 192.168.12.210:5555 pull /sdcard/Android/data/com.netflix.ninja/files/nfdump ./nfdump
+# or, if you set debuggable=true, from the internal files dir:
+adb -s 192.168.12.210:5555 shell run-as com.netflix.ninja ls files/nfdump
+```
+
+## Step 5 — upload to the session
+
+Drag-and-drop the `nfdump/` files (especially any tagged `_JS_` with a `gibbon`/`appboot`/`adBreak`
+marker) **into the chat**, same as `milo.debug.js`. I'll static-analyze for:
+- the **ad-break schema** (fields seam A must scrub), and
+- the **empty-break guard** (the `length===0 → return []` branch that seam B forces) —
+the Netflix equivalents of Prime Video's `resolveWithAdBreaks` / `0===t.length`.
+
+## If nothing lands
+- **All dumps tagged `HBC`** → appboot ships as Hermes bytecode. Good to know early: it means seam B
+  needs an HBC-aware edit, so we lead with **seam A** (manifest data is a normal JS object regardless).
+  Send an HBC dump anyway — I can disassemble it.
+- **Gadget doesn't load / app crashes on boot** → the repackage tripped an integrity check
+  (`libc94d.so` is the suspect from §3a). That's the "does it even boot patched" gate; tell me the
+  logcat and we adjust (e.g. load the gadget later, or from a separate process).
+- **No netflix paths in the I/O log** → appboot may be served from memory only; rely on the heap
+  sweep and `sweepfor()` with the markers above.

--- a/experimental/netflix-native-adstrip/frida/dump_appboot.js
+++ b/experimental/netflix-native-adstrip/frida/dump_appboot.js
@@ -1,0 +1,207 @@
+/*
+ * dump_appboot.js — offset-free acquisition of the Netflix appboot UI bundle
+ * ---------------------------------------------------------------------------
+ * Goal: capture the appboot player JS (where the ad-break logic + its own
+ *       empty-break branch live) as it exists AFTER MSL-decrypt and AFTER the
+ *       load-time appboot signature check — i.e. plaintext in-process.
+ *
+ * Design constraint: libnetflix.so (soname libandroid_netflix.so, ~84 MB) is
+ *   stripped and statically links OpenSSL + Hermes + Gibbon, so symbol-based
+ *   hooks are unreliable. This script therefore uses only:
+ *     (1) libc file I/O taps  — catch the on-disk cache read/write of appboot
+ *     (2) generic heap scan   — sweep RW memory for appboot/ad-break markers
+ *     (3) module/export recon — enumerate what IS hookable for a precise v2
+ *   None of these need a Netflix offset. Works under frida-gadget (no root).
+ *
+ * It also classifies every dump as PLAIN JS vs HERMES BYTECODE (HBC), which
+ * answers the load-bearing seam-B question: can we string-edit the ad-break
+ * resolver in the heap (plain JS) or must we operate on the manifest data only
+ * (seam A) because the code ships as HBC?
+ *
+ * Run (gadget/listen mode, non-root): the app loads libgadget.so via the
+ *   toolkit's LoadNativeHookPatch; this script is the gadget's `path` config.
+ * Run (interactive, if you have a host): frida -U -n com.netflix.ninja -l dump_appboot.js
+ *
+ * Output: files written to OUT_DIR (adb-pullable without root). See README.md.
+ */
+
+'use strict';
+
+// ---- config ---------------------------------------------------------------
+// App-specific external dir: app can always write here w/o a permission, and
+// `adb pull` can read it without root. If your repackage set debuggable=true,
+// you can instead point this at the internal files dir and use `run-as`.
+var OUT_DIR = '/sdcard/Android/data/com.netflix.ninja/files/nfdump';
+var PATH_HINTS = ['appboot', 'gibbon', 'milo', 'nrdp', 'nrd/', 'netflix', 'DiskCache', 'storage'];
+var JS_MARKERS = ['gibbon.load', 'appboot', 'adBreak', 'interstitial', 'cuePoint',
+                  'nrdp', 'function(', 'milo', 'MslEncoder'];
+var HEAP_SWEEP_DELAY_MS = 20000;   // appboot is fetched/cached shortly after boot
+var HEAP_REGION_PAD     = 0x200000; // dump ±2 MB around a marker hit
+var MIN_DUMP_BYTES      = 4096;     // ignore tiny incidental buffers
+var HBC_MAGIC = [0x1f, 0x1b, 0xc0, 0x9f]; // Hermes bytecode file magic (0x1F1BC09F)
+
+// ---- tiny util ------------------------------------------------------------
+var _seq = 0;
+function ts() { return new Date().toISOString().replace(/[:.]/g, '-'); }
+function log(m) { console.log('[appboot-dump] ' + m); }
+
+function ensureDir(d) {
+  try { new File(d + '/.keep', 'w').close(); } catch (e) {
+    // File() can't mkdir -p; fall back to a syscall via libc mkdir chain
+    try {
+      var mkdir = new NativeFunction(Module.getExportByName('libc.so', 'mkdir'),
+                                     'int', ['pointer', 'int']);
+      var parts = d.split('/'); var cur = '';
+      for (var i = 0; i < parts.length; i++) {
+        if (!parts[i]) continue; cur += '/' + parts[i];
+        mkdir(Memory.allocUtf8String(cur), 0x1ff /*0777*/);
+      }
+    } catch (e2) { log('mkdir fallback failed: ' + e2); }
+  }
+}
+
+function classify(bytes) {
+  if (bytes.length >= 4 &&
+      bytes[0] === HBC_MAGIC[0] && bytes[1] === HBC_MAGIC[1] &&
+      bytes[2] === HBC_MAGIC[2] && bytes[3] === HBC_MAGIC[3]) return 'HBC';
+  // sniff for readable JS: sample first 2 KB for high ASCII-printable ratio
+  var n = Math.min(bytes.length, 2048), printable = 0;
+  for (var i = 0; i < n; i++) {
+    var c = bytes[i];
+    if (c === 9 || c === 10 || c === 13 || (c >= 32 && c < 127)) printable++;
+  }
+  return (printable / n > 0.85) ? 'JS' : 'BIN';
+}
+
+function markerHit(bytes) {
+  // cheap ASCII search over the head of the buffer
+  var head = '';
+  var n = Math.min(bytes.length, 65536);
+  for (var i = 0; i < n; i++) { var c = bytes[i]; head += (c >= 32 && c < 127) ? String.fromCharCode(c) : ' '; }
+  for (var j = 0; j < JS_MARKERS.length; j++) if (head.indexOf(JS_MARKERS[j]) !== -1) return JS_MARKERS[j];
+  return null;
+}
+
+function dump(bytes, tag, extra) {
+  if (bytes.length < MIN_DUMP_BYTES) return;
+  var kind = classify(bytes);
+  var hit  = markerHit(bytes);
+  if (kind === 'BIN' && !hit) return;        // not appboot-ish, skip noise
+  var name = OUT_DIR + '/' + (_seq++) + '_' + tag + '_' + kind +
+             (hit ? '_' + hit.replace(/[^a-z0-9]/gi, '') : '') + '_' + ts() +
+             (kind === 'JS' ? '.js' : '.bin');
+  try {
+    var f = new File(name, 'wb');
+    f.write(bytes.buffer ? bytes.buffer : bytes);
+    f.close();
+    log('DUMPED ' + name + '  (' + bytes.length + ' bytes, ' + kind +
+        (hit ? ', marker="' + hit + '"' : '') + (extra ? ', ' + extra : '') + ')');
+  } catch (e) { log('write failed (' + name + '): ' + e); }
+}
+
+// ---- (3) recon: what is actually hookable in the monolith -----------------
+function recon() {
+  Process.enumerateModules().forEach(function (m) {
+    if (/netflix|hermes|gibbon|cronet|ssl|crypto/i.test(m.name))
+      log('module ' + m.name + ' @ ' + m.base + ' size=' + m.size);
+  });
+  var mono = Process.findModuleByName('libnetflix.so') ||
+             Process.findModuleByName('libandroid_netflix.so');
+  if (!mono) { log('monolith not loaded yet at recon time'); return; }
+  var interesting = /appboot|gibbon|hermes|evaluate|runBytecode|SSL_read|milo|manifest|adbreak/i;
+  var exps = mono.enumerateExports().filter(function (e) { return interesting.test(e.name); });
+  log('monolith ' + mono.name + ' exports matching seam terms: ' + exps.length);
+  exps.slice(0, 60).forEach(function (e) { log('  export ' + e.type + ' ' + e.name + ' @ ' + e.address); });
+}
+
+// ---- (1) libc file-I/O taps: catch the disk-cache read/write of appboot ---
+var fdPath = {};   // fd -> path, only for netflix-ish files
+function pathIsInteresting(p) {
+  if (!p) return false;
+  var lp = p.toLowerCase();
+  for (var i = 0; i < PATH_HINTS.length; i++) if (lp.indexOf(PATH_HINTS[i]) !== -1) return true;
+  return lp.indexOf('com.netflix.ninja') !== -1;
+}
+
+function hookOpen(sym) {
+  var addr = Module.findExportByName('libc.so', sym);
+  if (!addr) return;
+  Interceptor.attach(addr, {
+    onEnter: function (a) { this.p = (sym === 'openat') ? a[1].readUtf8String() : a[0].readUtf8String(); },
+    onLeave: function (r) {
+      var fd = r.toInt32();
+      if (fd >= 0 && pathIsInteresting(this.p)) { fdPath[fd] = this.p; log('open ' + fd + ' <- ' + this.p); }
+    }
+  });
+}
+
+function hookIO(sym) {
+  var addr = Module.findExportByName('libc.so', sym);
+  if (!addr) return;
+  Interceptor.attach(addr, {
+    onEnter: function (a) { this.fd = a[0].toInt32(); this.buf = a[1]; this.len = a[2].toInt32(); },
+    onLeave: function (r) {
+      if (!(this.fd in fdPath)) return;
+      var n = (sym === 'write' || sym === 'pwrite64' || sym === 'pwrite') ? this.len : r.toInt32();
+      if (n <= MIN_DUMP_BYTES) return;
+      try { dump(new Uint8Array(this.buf.readByteArray(n)), 'io_' + sym + '_fd' + this.fd, fdPath[this.fd]); }
+      catch (e) {}
+    }
+  });
+}
+
+// ---- (2) generic heap sweep for appboot markers ---------------------------
+function heapSweep() {
+  log('heap sweep starting…');
+  var pattern = null;
+  // scan for the most appboot-specific literal we expect in the bundle
+  var needle = 'gibbon.load';
+  Process.enumerateRanges('rw-').forEach(function (r) {
+    if (r.size > 64 * 1024 * 1024) return; // skip the huge mappings; appboot is a few MB
+    try {
+      Memory.scan(r.base, r.size, needleToHex(needle), {
+        onMatch: function (addr) {
+          var start = addr.sub(HEAP_REGION_PAD); if (start.compare(r.base) < 0) start = r.base;
+          var end = addr.add(HEAP_REGION_PAD);
+          var span = end.compare(r.base.add(r.size)) > 0 ? r.base.add(r.size).sub(start) : end.sub(start);
+          try { dump(new Uint8Array(Memory.readByteArray(start, span.toInt32())), 'heap_' + addr, 'sweep@' + needle); }
+          catch (e) {}
+          return 'stop'; // one dump per range is plenty
+        },
+        onError: function () {}, onComplete: function () {}
+      });
+    } catch (e) {}
+  });
+  log('heap sweep done.');
+}
+function needleToHex(s) {
+  var h = []; for (var i = 0; i < s.length; i++) h.push(('0' + s.charCodeAt(i).toString(16)).slice(-2));
+  return h.join(' ');
+}
+
+// ---- boot -----------------------------------------------------------------
+ensureDir(OUT_DIR);
+log('output dir: ' + OUT_DIR);
+['open', 'openat'].forEach(hookOpen);
+['read', 'pread64', 'pread', 'write', 'pwrite64', 'pwrite'].forEach(hookIO);
+setTimeout(recon, 5000);
+setTimeout(heapSweep, HEAP_SWEEP_DELAY_MS);
+
+// interactive helpers if you have a host session
+rpc.exports = {
+  recon: recon,
+  sweep: heapSweep,
+  sweepfor: function (needle) {                 // sweep for a custom literal
+    Process.enumerateRanges('rw-').forEach(function (r) {
+      if (r.size > 64 * 1024 * 1024) return;
+      try { Memory.scan(r.base, r.size, needleToHex(needle), {
+        onMatch: function (addr) {
+          var start = addr.sub(HEAP_REGION_PAD); if (start.compare(r.base) < 0) start = r.base;
+          try { dump(new Uint8Array(Memory.readByteArray(start, HEAP_REGION_PAD * 2)), 'heap_' + addr, 'sweep@' + needle); } catch (e) {}
+          return 'stop';
+        }, onError: function () {}, onComplete: function () {} }); } catch (e) {}
+    });
+    return 'sweep(' + needle + ') queued';
+  }
+};
+log('armed: libc I/O taps live; recon in 5s; heap sweep in ' + (HEAP_SWEEP_DELAY_MS / 1000) + 's.');

--- a/experimental/netflix-native-adstrip/kill-pausead2.js
+++ b/experimental/netflix-native-adstrip/kill-pausead2.js
@@ -1,0 +1,47 @@
+'use strict';
+// Kill Netflix pause ads at the DATA chokepoint (single-shot, pre-pause, no loop).
+// z() saga: f = getDataFragment(c)?.displayAd; if(f){build ad} else return undefined -> saga bails.
+// Force f falsy by turning the ternary value `e.displayAd` into `void 0`:
+//   ...?void 0:e.displayAd)...  ->  ...?void 0:void 0     )...   (length-preserving)
+var logw = new NativeFunction(Module.findGlobalExportByName('__android_log_write'),
+  'int', ['int', 'pointer', 'pointer']);
+var TAG = Memory.allocUtf8String('PA2');
+function LG(m){ logw(6, TAG, Memory.allocUtf8String(m)); }
+function pat(s){ return s.split('').map(function(c){return ('0'+c.charCodeAt(0).toString(16)).slice(-2);}).join(' '); }
+function bytesOf(s){ var b=[]; for (var i=0;i<s.length;i++) b.push(s.charCodeAt(i)); return b; }
+
+var ANCHOR = 'void 0:e.displayAd';        // unique; the ternary no-ad?void0 : e.displayAd
+var OLD = 'e.displayAd';                   // 11 bytes
+var NEW = 'void 0     ';                    // 11 bytes (void 0 + 5 spaces) -> always undefined
+var applied = false;
+
+function tryApply() {
+  if (applied) return true;
+  var rs = Process.enumerateRanges('rw-'), p = pat(ANCHOR), n = 0;
+  for (var i = 0; i < rs.length; i++) {
+    var hits; try { hits = Memory.scanSync(rs[i].base, rs[i].size, p); } catch (e) { continue; }
+    for (var j = 0; j < hits.length; j++) {
+      var tern = hits[j].address;                 // points at "void 0:e.displayAd"
+      var target = tern.add('void 0:'.length);    // points at "e.displayAd"
+      // verify
+      var cur = null; try { cur = target.readCString(OLD.length); } catch (e) {}
+      if (cur !== OLD) { LG('anchor found but bytes mismatch: ' + JSON.stringify(cur)); continue; }
+      try {
+        Memory.protect(target, NEW.length, 'rw-');
+        target.writeByteArray(bytesOf(NEW));
+        applied = true; n++;
+        LG('PATCHED displayAd->void0 @ ' + target + ' now="' + tern.readCString(18) + '"');
+      } catch (e) { LG('write err ' + e); }
+    }
+  }
+  return applied;
+}
+
+LG('kill-pausead2 ready (single-shot)');
+// poll ONLY until applied once, then stop (no persistent re-patch loop)
+var tries = 0;
+var t = setInterval(function () {
+  tries++;
+  if (tryApply() || tries > 60) { clearInterval(t); LG('done: applied=' + applied + ' after ' + tries + ' polls'); }
+}, 1000);
+rpc.exports = { apply: tryApply };

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/misc/clone/CloneAppPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/misc/clone/CloneAppPatch.kt
@@ -94,6 +94,28 @@ val cloneAppPatch = resourcePatch(
             // ── 1. Rename the package ───────────────────────────────────────
             document.documentElement.setAttribute("package", newPackageName)
 
+            // ── 1b. Grant visibility of the STOCK package ───────────────────
+            // A second, NATIVE anti-tamper (libnetflix RJni_SignatureCheck.cpp,
+            // separate from the DexGuard Java CertCheck) hardcodes
+            //   getPackageManager().getPackageInfo("com.netflix.ninja",
+            //                                       GET_SIGNATURES /*0x40*/)
+            // to read + verify the app's signing cert. Under the renamed clone
+            // that becomes a CROSS-package query, which Android 11+ package
+            // visibility blocks -> getPackageInfo returns null -> native
+            // GetObjectClass(null) -> SIGABRT ~2.5s into launch
+            // (NetflixService.nativeGibbonStartup). Declaring a <queries> entry
+            // for the original package makes it visible again: the query then
+            // returns the STOCK Netflix's PackageInfo, whose signature is the
+            // GENUINE Netflix cert, so the native check both returns non-null
+            // AND passes. (packageName is still the original here.)
+            val queries = (document.getElementsByTagName("queries").item(0) as? Element)
+                ?: document.createElement("queries").also {
+                    document.documentElement.appendChild(it)
+                }
+            queries.appendChild(document.createElement("package").apply {
+                setAttribute("android:name", packageName)
+            })
+
             // ── 2. Custom permissions ───────────────────────────────────────
             // A <permission> android:name must be device-unique. Rename each
             // declaration, keep matching <uses-permission> and any component

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/misc/clone/CloneAppPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/misc/clone/CloneAppPatch.kt
@@ -1,0 +1,178 @@
+package ajstrick81.morphe.patches.netflix.misc.clone
+
+import app.morphe.patcher.patch.resourcePatch
+import ajstrick81.morphe.patches.netflix.shared.Constants
+import org.w3c.dom.Element
+
+// Suffix appended to the original applicationId for the cloned package, e.g.
+// com.netflix.ninja -> com.netflix.ninja.clone
+private const val CLONE_SUFFIX = "clone"
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Clone Netflix (side-by-side install) — capture-tooling enabler
+//
+// On the Onn 4K TV (and most Android TVs / Fire TV) Netflix ships as a
+// PREINSTALLED SYSTEM app: it can't be uninstalled without root, so a
+// Morphe-signed build can't replace it (INSTALL_FAILED_UPDATE_INCOMPATIBLE;
+// full uninstall -> DELETE_FAILED_INTERNAL_ERROR). Proven on-device, see
+// experimental/netflix-native-adstrip/HANDOFF.md §0.
+//
+// Renaming the applicationId alone is NOT enough on two counts:
+//
+//   1. Device-unique identifiers. A ContentProvider's android:authorities and
+//      any custom <permission> android:name must be UNIQUE device-wide,
+//      independent of applicationId. They stay pinned to the original package
+//      string, so PackageManager rejects the install with
+//      INSTALL_FAILED_CONFLICTING_PROVIDER / duplicate-permission while the
+//      stock app is present.
+//
+//   2. RELATIVE component names. Unlike Pluto, Netflix's manifest declares its
+//      components with package-relative names (android:name=".NetflixApplication",
+//      ".MainActivity", ".NetflixService", 16 in all). A relative name resolves
+//      against the manifest `package` attribute AT PARSE TIME, so simply
+//      changing `package` would make ".NetflixApplication" resolve to
+//      <clone>.NetflixApplication — a class that does NOT exist in the DEX
+//      (the bytecode is still com.netflix.ninja.*) -> ClassNotFoundException at
+//      launch. We therefore EXPAND every relative android:name to its fully
+//      qualified com.netflix.ninja.* form BEFORE renaming the package, pinning
+//      each component to the real DEX class regardless of the new applicationId.
+//
+// Intent actions and <queries> package targets are left untouched: they are not
+// device-unique and are matched by literal string on both ends.
+//
+// ⚠️ CAPTURE-ONLY / EXPERIMENTAL. This exists to get the frida-gadget appboot
+// capture (bundleGadgetPatch/loadGadgetPatch) installable alongside stock
+// Netflix. Netflix ties ESN/MSL identity and Widevine provisioning to the
+// package name, so the clone may fail login/playback; that's acceptable for the
+// capture goal because the appboot JS bundle loads at boot/browse, before
+// playback. NOT a shipping ad-strip. Opt-in (default = false).
+//
+// Runs in finalize {} so the rename happens after all other patches, at manifest
+// write time.
+// ─────────────────────────────────────────────────────────────────────────────
+@Suppress("unused")
+val cloneAppPatch = resourcePatch(
+    name = "Clone Netflix",
+    description = "Installs the patched Netflix as a separate app alongside the stock one, " +
+        "instead of replacing it. Required on devices where Netflix is a preinstalled system " +
+        "app that can't be uninstalled (Onn, Fire TV, most Android TV boxes). The clone gets its " +
+        "own package (suffix .$CLONE_SUFFIX). EXPERIMENTAL capture tooling — Netflix binds " +
+        "ESN/MSL/Widevine to the package name, so the clone may not log in or play. Opt-in.",
+    default = false,
+) {
+    compatibleWith(Constants.COMPATIBILITY)
+
+    finalize {
+        val packageName = packageMetadata.packageName
+        val newPackageName = "$packageName.$CLONE_SUFFIX"
+
+        // Authorities may be an @string/... reference rather than a literal; any
+        // such string resource names are collected here and rewritten below.
+        val providerStringResources = mutableSetOf<String>()
+
+        document("AndroidManifest.xml").use { document ->
+            // ── 0. Expand relative component names FIRST ────────────────────
+            // Must happen before the `package` attribute changes, so ".Foo"
+            // pins to the ORIGINAL packageName.Foo (the real DEX class), not the
+            // clone's non-existent one. Covers every element type that carries a
+            // relative android:name (application/activity/service/receiver/
+            // provider/activity-alias, etc.).
+            val allNodes = document.getElementsByTagName("*")
+            for (i in 0 until allNodes.length) {
+                val node = allNodes.item(i) as? Element ?: continue
+                val name = node.getAttribute("android:name")
+                if (name.startsWith('.')) {
+                    node.setAttribute("android:name", packageName + name)
+                }
+                // activity-alias targetActivity is also package-relative.
+                val target = node.getAttribute("android:targetActivity")
+                if (target.startsWith('.')) {
+                    node.setAttribute("android:targetActivity", packageName + target)
+                }
+            }
+
+            // ── 1. Rename the package ───────────────────────────────────────
+            document.documentElement.setAttribute("package", newPackageName)
+
+            // ── 2. Custom permissions ───────────────────────────────────────
+            // A <permission> android:name must be device-unique. Rename each
+            // declaration, keep matching <uses-permission> and any component
+            // android:permission / android:readPermission / writePermission in
+            // sync so self-guarded components still resolve.
+            val permissions = document.getElementsByTagName("permission")
+            val renamedPermissions = mutableMapOf<String, String>()
+            for (i in 0 until permissions.length) {
+                val permission = permissions.item(i) as? Element ?: continue
+                val oldName = permission.getAttribute("android:name")
+                if (oldName.startsWith('.')) continue
+                val newName = if (oldName.startsWith("$packageName.")) {
+                    oldName.replaceFirst(packageName, newPackageName)
+                } else {
+                    "${newPackageName}_$oldName"
+                }
+                permission.setAttribute("android:name", newName)
+                renamedPermissions[oldName] = newName
+            }
+
+            // Propagate the permission renames to every attribute that can
+            // reference a permission by name.
+            if (renamedPermissions.isNotEmpty()) {
+                val permAttrs = listOf(
+                    "android:name",            // <uses-permission>
+                    "android:permission",       // component guards
+                    "android:readPermission",   // provider
+                    "android:writePermission",  // provider
+                )
+                for (i in 0 until allNodes.length) {
+                    val node = allNodes.item(i) as? Element ?: continue
+                    // Skip the <permission> declarations themselves (already done).
+                    if (node.tagName == "permission") continue
+                    for (attr in permAttrs) {
+                        val v = node.getAttribute(attr)
+                        val mapped = renamedPermissions[v]
+                        if (mapped != null) node.setAttribute(attr, mapped)
+                    }
+                }
+            }
+
+            // ── 3. Provider authorities ─────────────────────────────────────
+            // android:authorities is a ';'-separated list; each entry must be
+            // device-unique. Rewrite literals and defer @string references.
+            val providers = document.getElementsByTagName("provider")
+            for (i in 0 until providers.length) {
+                val provider = providers.item(i) as? Element ?: continue
+                val authorities = provider.getAttribute("android:authorities").split(';')
+                val newAuthorities = authorities.map {
+                    when {
+                        it.startsWith("$packageName.") ->
+                            it.replaceFirst(packageName, newPackageName)
+                        it.startsWith('@') -> {
+                            providerStringResources.add(it.removePrefix("@string/"))
+                            it
+                        }
+                        else -> "${newPackageName}_$it"
+                    }
+                }
+                provider.setAttribute("android:authorities", newAuthorities.joinToString(";"))
+            }
+        }
+
+        // ── 4. @string-backed authorities ───────────────────────────────────
+        if (providerStringResources.isNotEmpty()) {
+            document("res/values/strings.xml").use { document ->
+                val children = document.documentElement.childNodes
+                for (i in 0 until children.length) {
+                    val node = children.item(i) as? Element ?: continue
+                    if (node.getAttribute("name") in providerStringResources) {
+                        val authority = node.textContent
+                        node.textContent = if (authority.startsWith("$packageName.")) {
+                            authority.replaceFirst(packageName, newPackageName)
+                        } else {
+                            "${newPackageName}_$authority"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/misc/privacy/MinimizeNetworkFingerprintPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/misc/privacy/MinimizeNetworkFingerprintPatch.kt
@@ -1,0 +1,52 @@
+package ajstrick81.morphe.patches.netflix.misc.privacy
+
+import app.morphe.patcher.patch.resourcePatch
+import ajstrick81.morphe.patches.netflix.nativehook.bundleGadgetPatch
+import ajstrick81.morphe.patches.netflix.shared.Constants
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Minimize local-network fingerprinting (OPT-IN, default OFF).
+//
+// The appboot builds a device signal `u.ifList` from the nrdp native interface
+// list — function c() maps each interface to
+//   {connected, default, ip:e.ipAddress, ipv6:i(e), mac:e.macAddress,
+//    name:e.ifname, ssid:e.ssid, type:e.physicalLayerType}
+// i.e. it reports your LOCAL IP(s), MAC address and Wi-Fi SSID. This patch, when
+// enabled, flips the FP_ENABLED flag in the bundled ad-kill script so its runtime
+// FP pass blanks ip/ipv6/mac/ssid (keeping the harmless ifname/type) before the
+// signal is sent — reducing what the app fingerprints about your network.
+//
+// HONEST SCOPE: this only changes what is REPORTED, not the device's real
+// networking. It does NOT stop Netflix's server-side "household / I'm traveling"
+// check — that is driven by your PUBLIC IP, which the servers see on every
+// connection regardless of the app (only a VPN/proxy changes that). This is a
+// privacy-reduction measure, not a household-enforcement bypass.
+//
+// Delivery: the FP pass lives in the gadget's bundled script
+// (lib/armeabi-v7a/libgadget.script.so) shipped OFF; this patch just turns it on,
+// so it composes with the ad kills without a second script. Opt-in / experimental.
+// ─────────────────────────────────────────────────────────────────────────────
+@Suppress("unused")
+val minimizeNetworkFingerprintPatch = resourcePatch(
+    name = "Minimize Network Fingerprint",
+    description = "Blanks the local IP / MAC / Wi-Fi SSID the Netflix app reports about your " +
+        "network (keeps interface name/type). Reduces network fingerprinting. Does NOT stop the " +
+        "server-side \"I'm traveling\"/household check (that's driven by your public IP — use a " +
+        "VPN for that). Opt-in / experimental; test on-device.",
+    default = false,
+) {
+    compatibleWith(Constants.COMPATIBILITY)
+
+    // The ad-kill gadget must have written the bundled script first.
+    dependsOn(bundleGadgetPatch)
+
+    execute {
+        val script = get("lib/armeabi-v7a/libgadget.script.so")
+        val text = script.readText()
+        require(text.contains("FP_ENABLED=false")) {
+            "minimizeNetworkFingerprintPatch: FP_ENABLED flag not found in bundled script — " +
+                "killads.js/BundleGadgetPatch out of sync."
+        }
+        script.writeText(text.replaceFirst("FP_ENABLED=false", "FP_ENABLED=true"))
+    }
+}

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/misc/privacy/MinimizeNetworkFingerprintPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/misc/privacy/MinimizeNetworkFingerprintPatch.kt
@@ -30,9 +30,10 @@ import ajstrick81.morphe.patches.netflix.shared.Constants
 val minimizeNetworkFingerprintPatch = resourcePatch(
     name = "Minimize Network Fingerprint",
     description = "Blanks the local IP / MAC / Wi-Fi SSID the Netflix app reports about your " +
-        "network (keeps interface name/type). Reduces network fingerprinting. Does NOT stop the " +
-        "server-side \"I'm traveling\"/household check (that's driven by your public IP — use a " +
-        "VPN for that). Opt-in / experimental; test on-device.",
+        "network (keeps interface name/type) and stops the app from reporting your advertising " +
+        "ID (GAID) in its ad-collection telemetry. Reduces network + ad fingerprinting. Does NOT " +
+        "stop the server-side \"I'm traveling\"/household check (that's driven by your public IP " +
+        "— use a VPN for that). Opt-in / experimental; test on-device.",
     default = false,
 ) {
     compatibleWith(Constants.COMPATIBILITY)
@@ -42,11 +43,17 @@ val minimizeNetworkFingerprintPatch = resourcePatch(
 
     execute {
         val script = get("lib/armeabi-v7a/libgadget.script.so")
-        val text = script.readText()
+        var text = script.readText()
         require(text.contains("FP_ENABLED=false")) {
             "minimizeNetworkFingerprintPatch: FP_ENABLED flag not found in bundled script — " +
                 "killads.js/BundleGadgetPatch out of sync."
         }
-        script.writeText(text.replaceFirst("FP_ENABLED=false", "FP_ENABLED=true"))
+        require(text.contains("GAID_ENABLED=false")) {
+            "minimizeNetworkFingerprintPatch: GAID_ENABLED flag not found in bundled script — " +
+                "killads.js/BundleGadgetPatch out of sync."
+        }
+        text = text.replaceFirst("FP_ENABLED=false", "FP_ENABLED=true")
+        text = text.replaceFirst("GAID_ENABLED=false", "GAID_ENABLED=true")
+        script.writeText(text)
     }
 }

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/misc/security/DisableCertCheckPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/misc/security/DisableCertCheckPatch.kt
@@ -1,0 +1,37 @@
+package ajstrick81.morphe.patches.netflix.misc.security
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import ajstrick81.morphe.patches.netflix.shared.Constants
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Disable Netflix's DexGuard application CertCheck (anti-tamper).
+//
+// Any Morphe-signed Netflix build trips DexGuard's runtime signing-cert check
+// and self-crashes ~2.5s after launch (see DexGuardCertCheckFingerprint). This
+// is a hard prerequisite for EVERY Netflix patch on this repo: without it a
+// re-signed Netflix never stays up long enough to do anything.
+//
+// The check's whole run() method does nothing but "verify cert → else crash".
+// Its non-crash outcome is simply to return, so neutralising it is a no-op:
+// prepend `return-void` at index 0 so run() returns before the verifier or the
+// kill path can execute. No register use, no fallout — the app proceeds exactly
+// as it would on a genuine-cert pass.
+//
+// Anchored purely on the unique crash string, so it survives DexGuard's
+// per-build name rotation. Default-enabled: it must run for any re-signed build.
+// If DexGuard adds native-side reinforcement in a later version this Java no-op
+// may not be sufficient — re-check logcat for a new crash tag if a bump breaks it.
+// ─────────────────────────────────────────────────────────────────────────────
+@Suppress("unused")
+val disableCertCheckPatch = bytecodePatch(
+    name = "Disable Netflix CertCheck",
+    description = "Neutralises Netflix's DexGuard signing-certificate anti-tamper check so a " +
+        "re-signed build doesn't self-crash on launch. Required for every Netflix patch.",
+) {
+    compatibleWith(Constants.COMPATIBILITY)
+
+    execute {
+        DexGuardCertCheckFingerprint.method.addInstructions(0, "return-void")
+    }
+}

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/misc/security/Fingerprints.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/misc/security/Fingerprints.kt
@@ -1,0 +1,32 @@
+package ajstrick81.morphe.patches.netflix.misc.security
+
+import app.morphe.patcher.Fingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DexGuard application CertCheck (anti-tamper).
+//
+// Netflix is protected by Guardsquare DexGuard, which injects a runtime check
+// that reads the APK signing certificate and DELIBERATELY CRASHES the process
+// when it isn't Netflix's official cert — so ANY re-signed build (clone or in
+// place) dies ~2.5s after launch with, in logcat:
+//     E Loader: CertCheck failed, crash!!!
+// and a "DexGuardCertCheckException : DexGuard App CertCheck failed !" handled
+// exception. Verified on-device (Onn, 13.0.1-25028); see
+// experimental/netflix-native-adstrip/HANDOFF.md.
+//
+// The check lives in an obfuscated Runnable whose run() method:
+//   - fetches the expected SHA-256 fingerprint (a hardcoded string literal),
+//   - calls an obfuscated verifier returning Z (true = cert matches),
+//   - on false: Log.e("Loader", "CertCheck failed, crash!!!") then reflectively
+//     invokes a killer that tears the process down.
+//
+// Obfuscated names (class Lo/setReturnTransition$5;, verifier MoMD214, etc.)
+// rotate every build, so we anchor on the ONE stable, unique artifact: the
+// literal crash string. Confirmed the only method in the app referencing it.
+// ─────────────────────────────────────────────────────────────────────────────
+internal object DexGuardCertCheckFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC),
+    returnType = "V",
+    strings = listOf("CertCheck failed, crash!!!"),
+)

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/nativehook/BundleGadgetPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/nativehook/BundleGadgetPatch.kt
@@ -1,0 +1,83 @@
+package ajstrick81.morphe.patches.netflix.nativehook
+
+import app.morphe.patcher.patch.resourcePatch
+import ajstrick81.morphe.patches.netflix.shared.Constants
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bundles frida-gadget into com.netflix.ninja so we can capture the appboot UI
+// bundle in-process on a NON-rooted Onn (no frida-server needed — the gadget
+// runs inside Netflix's own process). Acquisition tooling for the reopened
+// seam-A/B work; see experimental/netflix-native-adstrip/REOPENING.md and
+// frida/README.md.
+//
+// Writes three things into the decoded APK:
+//   1. lib/armeabi-v7a/libgadget.so         — the frida-gadget binary (supplied)
+//   2. lib/armeabi-v7a/libgadget.config.so  — gadget config (generated here)
+//   3. manifest flips: extractNativeLibs=true, debuggable=true
+//
+// The gadget binary is NOT checked into the repo (large, ABI-specific, and not
+// ours to redistribute). Drop the armeabi-v7a frida-gadget, renamed to
+// libgadget.so, at:
+//   patches/src/main/resources/netflix/native/armeabi-v7a/libgadget.so
+//
+// SCAFFOLD — not registered in the build. Companion to loadGadgetPatch, which
+// injects the System.loadLibrary("gadget") call and dependsOn() this so the
+// .so + config are in place first.
+// ─────────────────────────────────────────────────────────────────────────────
+@Suppress("unused")
+val bundleGadgetPatch = resourcePatch(
+    name = "Bundle frida-gadget (Netflix appboot capture)",
+    description = "Packages libgadget.so + its config into com.netflix.ninja for " +
+        "in-process, non-root capture of the appboot UI bundle (post-MSL, post-signature).",
+) {
+    compatibleWith(Constants.COMPATIBILITY)
+
+    execute {
+        val abi = "armeabi-v7a"
+
+        // ── 1. Copy the supplied frida-gadget into lib/<abi>/ ────────────────
+        val resourcePath = "/netflix/native/$abi/libgadget.so"
+        val soBytes = object {}.javaClass.getResourceAsStream(resourcePath)
+            ?.use { it.readBytes() }
+            ?: error("bundleGadgetPatch: $resourcePath not found on the patch " +
+                "classpath — download the $abi frida-gadget, rename to libgadget.so, " +
+                "and drop it at patches/src/main/resources/netflix/native/$abi/")
+
+        get("lib/$abi/libgadget.so").apply {
+            parentFile?.mkdirs()
+            writeBytes(soBytes)
+        }
+
+        // ── 2. Generate the gadget config next to the .so ────────────────────
+        // frida-gadget auto-loads "<soname>.config.so" from the same dir. In
+        // "script" interaction mode it runs the JS at `path` on load with no
+        // host attach required (works in a pure listen-less capture run). The
+        // script is pushed separately to /data/local/tmp (see frida/README.md);
+        // on_change=reload lets you iterate the script without reinstalling.
+        val config = """
+            {
+              "interaction": {
+                "type": "script",
+                "path": "/data/local/tmp/dump_appboot.js",
+                "on_change": "reload"
+              }
+            }
+        """.trimIndent()
+        get("lib/$abi/libgadget.config.so").apply {
+            parentFile?.mkdirs()
+            writeText(config)
+        }
+
+        // ── 3. Manifest flips ────────────────────────────────────────────────
+        document("AndroidManifest.xml").use { document ->
+            val application = document.getElementsByTagName("application").item(0)
+                    as? org.w3c.dom.Element ?: return@use
+            // base.apk ships extractNativeLibs="false"; injected libs that
+            // aren't page-aligned fail to mmap → force extraction to sidestep.
+            application.setAttribute("android:extractNativeLibs", "true")
+            // debuggable=true makes the dumps in the app's private files dir
+            // pullable via `run-as` without root (see frida/README.md Step 4).
+            application.setAttribute("android:debuggable", "true")
+        }
+    }
+}

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/nativehook/BundleGadgetPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/nativehook/BundleGadgetPatch.kt
@@ -49,17 +49,29 @@ val bundleGadgetPatch = resourcePatch(
         }
 
         // ── 2. Generate the gadget config next to the .so ────────────────────
-        // frida-gadget auto-loads "<soname>.config.so" from the same dir. In
-        // "script" interaction mode it runs the JS at `path` on load with no
-        // host attach required (works in a pure listen-less capture run). The
-        // script is pushed separately to /data/local/tmp (see frida/README.md);
-        // on_change=reload lets you iterate the script without reinstalling.
+        // frida-gadget auto-loads "<soname>.config.so" from the same dir.
+        //
+        // We use "listen" (not "script"): "script" mode reads its JS from a
+        // filesystem path, but on a non-root device the only writable spot the
+        // app can also READ is its own files dir — /data/local/tmp is blocked by
+        // SELinux (untrusted_app can't read shell_data_file). "listen" sidesteps
+        // that: the gadget opens a local TCP port and we drive it from the PC
+        // over `adb forward` with the frida CLI/python (no root, no on-device
+        // script file, live hot-reload of scripts).
+        //
+        // "on_load":"wait" BLOCKS the process at gadget load (Application.onCreate
+        // index 0) until a client connects — essential so hooks are installed
+        // BEFORE Netflix's native init (nativeGibbonStartup) runs.
+        //   host:   adb forward tcp:27042 tcp:27042
+        //           frida -H 127.0.0.1:27042 -n Gadget -l <script.js>
         val config = """
             {
               "interaction": {
-                "type": "script",
-                "path": "/data/local/tmp/dump_appboot.js",
-                "on_change": "reload"
+                "type": "listen",
+                "address": "127.0.0.1",
+                "port": 27042,
+                "on_port_conflict": "fail",
+                "on_load": "wait"
               }
             }
         """.trimIndent()

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/nativehook/BundleGadgetPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/nativehook/BundleGadgetPatch.kt
@@ -48,30 +48,32 @@ val bundleGadgetPatch = resourcePatch(
             writeBytes(soBytes)
         }
 
-        // ── 2. Generate the gadget config next to the .so ────────────────────
-        // frida-gadget auto-loads "<soname>.config.so" from the same dir.
-        //
-        // We use "listen" (not "script"): "script" mode reads its JS from a
-        // filesystem path, but on a non-root device the only writable spot the
-        // app can also READ is its own files dir — /data/local/tmp is blocked by
-        // SELinux (untrusted_app can't read shell_data_file). "listen" sidesteps
-        // that: the gadget opens a local TCP port and we drive it from the PC
-        // over `adb forward` with the frida CLI/python (no root, no on-device
-        // script file, live hot-reload of scripts).
-        //
-        // "on_load":"wait" BLOCKS the process at gadget load (Application.onCreate
-        // index 0) until a client connects — essential so hooks are installed
-        // BEFORE Netflix's native init (nativeGibbonStartup) runs.
-        //   host:   adb forward tcp:27042 tcp:27042
-        //           frida -H 127.0.0.1:27042 -n Gadget -l <script.js>
+        // ── 2a. Bundle the ad-kill script INSIDE the apk (next to the .so) ───
+        // SHIPPABLE (self-contained): the gadget runs the script itself at load —
+        // no PC, no frida-CLI. "script" mode normally can't read /data/local/tmp
+        // (SELinux blocks untrusted_app from shell_data_file), so we place the
+        // script in the app's OWN lib dir (named .so so extractNativeLibs
+        // extracts it) and reference it by a RELATIVE path, which frida resolves
+        // next to the gadget library — a location the app can always read.
+        val scriptBytes = object {}.javaClass.getResourceAsStream("/netflix/native/killads.js")
+            ?.use { it.readBytes() }
+            ?: error("bundleGadgetPatch: /netflix/native/killads.js not found on the patch classpath")
+        get("lib/$abi/libgadget.script.so").apply {
+            parentFile?.mkdirs()
+            writeBytes(scriptBytes)
+        }
+
+        // ── 2b. Gadget config: run the bundled script at load ────────────────
+        // frida-gadget auto-loads "<soname>.config.so" from the same dir; here it
+        // runs the bundled killads script (relative path -> resolved beside
+        // libgadget.so in the extracted lib dir, which is app-readable). No
+        // on_load:"wait", so the app launches NORMALLY and self-applies the kills.
         val config = """
             {
               "interaction": {
-                "type": "listen",
-                "address": "127.0.0.1",
-                "port": 27042,
-                "on_port_conflict": "fail",
-                "on_load": "wait"
+                "type": "script",
+                "path": "libgadget.script.so",
+                "on_change": "reload"
               }
             }
         """.trimIndent()
@@ -86,10 +88,12 @@ val bundleGadgetPatch = resourcePatch(
                     as? org.w3c.dom.Element ?: return@use
             // base.apk ships extractNativeLibs="false"; injected libs that
             // aren't page-aligned fail to mmap → force extraction to sidestep.
+            // Also required so the bundled killads script (libgadget.script.so)
+            // is extracted to the app-readable lib dir for the gadget to load.
             application.setAttribute("android:extractNativeLibs", "true")
-            // debuggable=true makes the dumps in the app's private files dir
-            // pullable via `run-as` without root (see frida/README.md Step 4).
-            application.setAttribute("android:debuggable", "true")
+            // NOTE: shippable build is NOT debuggable — the ad-kill script
+            // self-applies via the gadget and logs proof through liblog
+            // (adb logcat, tags KILL/OBS), so run-as is not needed.
         }
     }
 }

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/nativehook/Fingerprints.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/nativehook/Fingerprints.kt
@@ -13,6 +13,14 @@ import com.android.tools.smali.dexlib2.AccessFlags
 // Lcom/netflix/ninja/NetflixApplication; — see PORTABILITY-ASSESSMENT.md §3.
 // This is the same anchor the assessment named for LoadNativeHookPatch.
 //
+// VERIFIED against real bytecode (androguard, 2026-08-07) on Netflix
+// 13.0.1-25028: the class extends Landroid/app/Application; and defines
+// onCreate ()V with PUBLIC access — this fingerprint resolves. onCreate has
+// .registers 11 (v10 = this) and its instr 0 is already `const-string v0`, so
+// injecting `const-string v0, "gadget"` at index 0 is register-safe (v0 is a
+// scratch local the original body immediately reuses; this/v10 untouched), and
+// lands before invoke-super onCreate and Netflix's native init.
+//
 // Re-verify on every version bump: an onCreate fingerprint anchored to the
 // wrong class silently won't resolve. If it proves brittle, switch to a
 // custom predicate matching the unique Application.onCreate that calls

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/nativehook/Fingerprints.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/nativehook/Fingerprints.kt
@@ -1,0 +1,28 @@
+package ajstrick81.morphe.patches.netflix.nativehook
+
+import app.morphe.patcher.Fingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Application.onCreate — earliest reliable point to load frida-gadget so its
+// script (dump_appboot.js) is live before the nrdp runtime fetches/caches the
+// appboot UI bundle.
+//
+// definingClass resolved from base.apk's AndroidManifest.xml
+// (<application android:name=".NetflixApplication" …>) →
+// Lcom/netflix/ninja/NetflixApplication; — see PORTABILITY-ASSESSMENT.md §3.
+// This is the same anchor the assessment named for LoadNativeHookPatch.
+//
+// Re-verify on every version bump: an onCreate fingerprint anchored to the
+// wrong class silently won't resolve. If it proves brittle, switch to a
+// custom predicate matching the unique Application.onCreate that calls
+// super.onCreate() — but keep it anchored to exactly one method so the
+// loadLibrary isn't injected twice.
+// ─────────────────────────────────────────────────────────────────────────────
+object NetflixApplicationOnCreateFingerprint : Fingerprint(
+    definingClass = "Lcom/netflix/ninja/NetflixApplication;",
+    name = "onCreate",
+    parameters = emptyList(),
+    returnType = "V",
+    accessFlags = listOf(AccessFlags.PUBLIC)
+)

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/nativehook/LoadGadgetPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/nativehook/LoadGadgetPatch.kt
@@ -1,0 +1,48 @@
+package ajstrick81.morphe.patches.netflix.nativehook
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import ajstrick81.morphe.patches.netflix.shared.Constants
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DEX-side half of the non-root capture: load libgadget.so at startup so the
+// frida-gadget script (dump_appboot.js) is armed before the nrdp runtime
+// fetches/caches the appboot UI bundle.
+//
+// Unlike the Prime Video native-hook (which calls an extension's
+// NativeHookLoader.load() for fail-loud logging), the gadget only needs the
+// library on the linker path — so we inline System.loadLibrary("gadget"). No
+// extension DEX is required for capture. The gadget's own config
+// (libgadget.config.so, written by bundleGadgetPatch) drives what runs.
+//
+// Injected at index 0 of Application.onCreate so the gadget loads as early as
+// possible in-process.
+//
+// SCAFFOLD — not registered in the build. To activate:
+//   1. Confirm NetflixApplicationOnCreateFingerprint's definingClass (Fingerprints.kt).
+//   2. Drop the armeabi-v7a frida-gadget at the path bundleGadgetPatch documents.
+//   3. Register bundleGadgetPatch + loadGadgetPatch, gate both on Constants.COMPATIBILITY.
+// This is CAPTURE tooling, not the ad-strip itself — remove it from any shipping
+// build once the appboot schema is in hand and the seam-A transform is written.
+// ─────────────────────────────────────────────────────────────────────────────
+@Suppress("unused")
+val loadGadgetPatch = bytecodePatch(
+    name = "Load frida-gadget (Netflix appboot capture)",
+    description = "Loads libgadget.so at startup to capture the appboot UI bundle " +
+        "in-process on a non-rooted device (post-MSL, post-signature).",
+) {
+    compatibleWith(Constants.COMPATIBILITY)
+
+    // The .so + config must be in lib/<abi>/ before we inject the load call.
+    dependsOn(bundleGadgetPatch)
+
+    execute {
+        NetflixApplicationOnCreateFingerprint.method.addInstructions(
+            0,
+            """
+                const-string v0, "gadget"
+                invoke-static {v0}, Ljava/lang/System;->loadLibrary(Ljava/lang/String;)V
+            """
+        )
+    }
+}

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/shared/Constants.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/shared/Constants.kt
@@ -1,0 +1,16 @@
+package ajstrick81.morphe.patches.netflix.shared
+
+import app.morphe.patcher.patch.AppTarget
+import app.morphe.patcher.patch.Compatibility
+
+// Netflix Android TV (com.netflix.ninja). Target confirmed from base.apk bytes
+// in experimental/netflix-native-adstrip/PORTABILITY-ASSESSMENT.md §3:
+// versionName 13.0.0, versionCode 25009, ABI armeabi-v7a (nrd runtime v26.1).
+object Constants {
+    val COMPATIBILITY = Compatibility(
+        name = "Netflix Android TV",
+        packageName = "com.netflix.ninja",
+        appIconColor = 0xE50914,
+        targets = listOf(AppTarget("13.0.0-25009-armv7a"))
+    )
+}

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/shared/Constants.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/shared/Constants.kt
@@ -3,14 +3,22 @@ package ajstrick81.morphe.patches.netflix.shared
 import app.morphe.patcher.patch.AppTarget
 import app.morphe.patcher.patch.Compatibility
 
-// Netflix Android TV (com.netflix.ninja). Target confirmed from base.apk bytes
-// in experimental/netflix-native-adstrip/PORTABILITY-ASSESSMENT.md §3:
-// versionName 13.0.0, versionCode 25009, ABI armeabi-v7a (nrd runtime v26.1).
+// Netflix Android TV (com.netflix.ninja). Target verified from a re-pulled
+// base.apk (androguard, 2026-08-07): versionName "13.0.1 build 25028",
+// versionCode 25028, ABI armeabi-v7a, requiredSplitTypes base__abi,
+// extractNativeLibs="false". Application subclass Lcom/netflix/ninja/
+// NetflixApplication; and its onCreate()V (public, .registers 11) confirmed
+// against real bytecode — index-0 injection of loadLibrary is register-safe.
+//
+// NOTE: the PORTABILITY-ASSESSMENT.md §3 architecture (Hermes/appboot/milo,
+// MSL, appboot signature) was measured on 13.0.0-25009; Netflix has since
+// bumped to 25028. The Application anchor is unchanged; re-verify the native
+// findings if/when libnetflix.so from this build is analyzed.
 object Constants {
     val COMPATIBILITY = Compatibility(
         name = "Netflix Android TV",
         packageName = "com.netflix.ninja",
         appIconColor = 0xE50914,
-        targets = listOf(AppTarget("13.0.0-25009-armv7a"))
+        targets = listOf(AppTarget("13.0.1-25028-armv7a"))
     )
 }

--- a/patches/src/main/resources/netflix/native/killads.js
+++ b/patches/src/main/resources/netflix/native/killads.js
@@ -27,17 +27,33 @@ function patchB(rs){ if(bDone)return; var p=pat(B_ANCHOR);
   for(var i=0;i<rs.length;i++){var r=rs[i];if(r.size>128*1024*1024)continue;
     try{var h=Memory.scanSync(r.base,r.size,p);for(var j=0;j<h.length;j++){var t=h[j].address.add(7);var cur=null;try{cur=t.readCString(B_OLD.length);}catch(e){}if(cur!==B_OLD)continue;Memory.protect(t,B_NEW.length,'rw-');t.writeByteArray(bytesOf(B_NEW));bDone=true;L('PATCH B: pause z() displayAd->void0 @'+t);}}catch(e){}}
 }
+// ---------- (FP) local network fingerprint minimization (OPT-IN; default OFF) ----------
+// Blanks ip/ipv6/mac/ssid in the c() interface map that feeds the nrdp device signal
+// (u.ifList). ONLY changes what is REPORTED to Netflix, not the device's actual
+// networking (keeps ifname/type). Does NOT stop the server-side "traveling" prompt
+// (that's driven by your public IP). The "Minimize Network Fingerprint" opt-in Morphe
+// patch flips FP_ENABLED to true in this bundled script.
+var FP_ENABLED=false;
+var FP_ANCH='ip:e.ipAddress,ipv6:i(e),mac:e.macAddress,name:e.ifname,ssid:e.ssid';
+var FP_NEW ='ip:""         ,ipv6:[]  ,mac:""          ,name:e.ifname,ssid:""    ';
+var fpDone=false;
+function patchFP(rs){ if(fpDone||!FP_ENABLED)return; if(FP_NEW.length!==FP_ANCH.length){L('FP length mismatch — ABORT');fpDone=true;return;}
+  var p=pat(FP_ANCH);
+  for(var i=0;i<rs.length;i++){var r=rs[i];if(r.size>128*1024*1024)continue;
+    try{var h=Memory.scanSync(r.base,r.size,p);for(var j=0;j<h.length;j++){Memory.protect(h[j].address,FP_NEW.length,'rw-');h[j].address.writeByteArray(bytesOf(FP_NEW));fpDone=true;L('PATCH FP: blank ip/ipv6/mac/ssid @'+h[j].address);}}catch(e){}}
+}
 var tries=0;
 function apply(){ tries++; var rs=Process.enumerateRanges('rw-');
   var loaded=false,gp=pat('nrdp.gibbon');
   for(var i=0;i<rs.length&&!loaded;i++){if(rs[i].size>128*1024*1024)continue;try{if(Memory.scanSync(rs[i].base,rs[i].size,gp).length)loaded=true;}catch(e){}}
-  if(loaded){patchA(rs);patchB(rs);}
-  // Keep polling until BOTH applied. prepareAdBreakStates (A) can load LATER than
-  // the pause module (B) — sometimes only once the ad code is exercised — so we
-  // must NOT give up early or a real ad slips through. This is a find-and-apply
-  // poll, still WRITE-ONCE (aDone/bDone guards) — not a re-patch loop.
-  if(aDone&&bDone){ L('apply DONE: A='+aDone+' B='+bDone+' tries='+tries); return; }
-  if(tries%15===0) L('apply waiting: A='+aDone+' B='+bDone+' tries='+tries);
+  if(loaded){patchA(rs);patchB(rs);patchFP(rs);}
+  // Keep polling until applied. prepareAdBreakStates (A) can load LATER than the
+  // pause module (B) — sometimes only once the ad code is exercised — so we must
+  // NOT give up early or a real ad slips through. WRITE-ONCE (aDone/bDone/fpDone
+  // guards) — not a re-patch loop. FP is only required when enabled.
+  var fpOk=(!FP_ENABLED||fpDone);
+  if(aDone&&bDone&&fpOk){ L('apply DONE: A='+aDone+' B='+bDone+' FP='+(FP_ENABLED?fpDone:'off')+' tries='+tries); return; }
+  if(tries%15===0) L('apply waiting: A='+aDone+' B='+bDone+' FP='+(FP_ENABLED?fpDone:'off')+' tries='+tries);
   if(tries<3600) setTimeout(apply, 2000);   // up to ~2h of find-and-apply polling
 }
 

--- a/patches/src/main/resources/netflix/native/killads.js
+++ b/patches/src/main/resources/netflix/native/killads.js
@@ -42,18 +42,39 @@ function patchFP(rs){ if(fpDone||!FP_ENABLED)return; if(FP_NEW.length!==FP_ANCH.
   for(var i=0;i<rs.length;i++){var r=rs[i];if(r.size>128*1024*1024)continue;
     try{var h=Memory.scanSync(r.base,r.size,p);for(var j=0;j<h.length;j++){Memory.protect(h[j].address,FP_NEW.length,'rw-');h[j].address.writeByteArray(bytesOf(FP_NEW));fpDone=true;L('PATCH FP: blank ip/ipv6/mac/ssid @'+h[j].address);}}catch(e){}}
 }
+// ---------- (GAID) advertising-ID (GAID) minimization (OPT-IN; default OFF) ----------
+// nrdp.device.getSystemValue("advertisingIdDetails", function(e){
+//   var t=!!e&&"advertisingId"in e, a=(null==e?void 0:e.advertisingId)||"",
+//       o="true"===...limitAdTracking, i=o?"":a;
+//   logEvent("AdvertisingIdCollectionEvent","netflix",{advertisingId:i,...}) })
+// We overwrite the property read `e.advertisingId` (15 bytes) with `void 0` (pad to
+// 15) so a="" -> i="" and the actual GAID is never reported in the collection event.
+// Length-preserving; keeps advertisingIdSupported/limitAdTracking booleans truthful.
+// Folded under the "Minimize Network Fingerprint" opt-in (flips GAID_ENABLED true).
+var GAID_ENABLED=false;
+var GAID_ANCH='null==e?void 0:e.advertisingId)';
+var GAID_OFF=15;                 // offset of 'e.advertisingId' within anchor ("null==e?void 0:")
+var GAID_OLD='e.advertisingId';
+var GAID_NEW='void 0         ';  // 15 chars: 'void 0' + 9 spaces
+var gaidDone=false;
+function patchGAID(rs){ if(gaidDone||!GAID_ENABLED)return; if(GAID_NEW.length!==GAID_OLD.length){L('GAID length mismatch — ABORT');gaidDone=true;return;}
+  var p=pat(GAID_ANCH);
+  for(var i=0;i<rs.length;i++){var r=rs[i];if(r.size>128*1024*1024)continue;
+    try{var h=Memory.scanSync(r.base,r.size,p);for(var j=0;j<h.length;j++){var t=h[j].address.add(GAID_OFF);var cur=null;try{cur=t.readCString(GAID_OLD.length);}catch(e){}if(cur!==GAID_OLD)continue;Memory.protect(t,GAID_NEW.length,'rw-');t.writeByteArray(bytesOf(GAID_NEW));gaidDone=true;L('PATCH GAID: e.advertisingId->void0 @'+t);}}catch(e){}}
+}
 var tries=0;
 function apply(){ tries++; var rs=Process.enumerateRanges('rw-');
   var loaded=false,gp=pat('nrdp.gibbon');
   for(var i=0;i<rs.length&&!loaded;i++){if(rs[i].size>128*1024*1024)continue;try{if(Memory.scanSync(rs[i].base,rs[i].size,gp).length)loaded=true;}catch(e){}}
-  if(loaded){patchA(rs);patchB(rs);patchFP(rs);}
+  if(loaded){patchA(rs);patchB(rs);patchFP(rs);patchGAID(rs);}
   // Keep polling until applied. prepareAdBreakStates (A) can load LATER than the
   // pause module (B) — sometimes only once the ad code is exercised — so we must
   // NOT give up early or a real ad slips through. WRITE-ONCE (aDone/bDone/fpDone
   // guards) — not a re-patch loop. FP is only required when enabled.
   var fpOk=(!FP_ENABLED||fpDone);
-  if(aDone&&bDone&&fpOk){ L('apply DONE: A='+aDone+' B='+bDone+' FP='+(FP_ENABLED?fpDone:'off')+' tries='+tries); return; }
-  if(tries%15===0) L('apply waiting: A='+aDone+' B='+bDone+' FP='+(FP_ENABLED?fpDone:'off')+' tries='+tries);
+  var gaidOk=(!GAID_ENABLED||gaidDone);
+  if(aDone&&bDone&&fpOk&&gaidOk){ L('apply DONE: A='+aDone+' B='+bDone+' FP='+(FP_ENABLED?fpDone:'off')+' GAID='+(GAID_ENABLED?gaidDone:'off')+' tries='+tries); return; }
+  if(tries%15===0) L('apply waiting: A='+aDone+' B='+bDone+' FP='+(FP_ENABLED?fpDone:'off')+' GAID='+(GAID_ENABLED?gaidDone:'off')+' tries='+tries);
   if(tries<3600) setTimeout(apply, 2000);   // up to ~2h of find-and-apply polling
 }
 

--- a/patches/src/main/resources/netflix/native/killads.js
+++ b/patches/src/main/resources/netflix/native/killads.js
@@ -1,0 +1,63 @@
+'use strict';
+// Netflix ad-kill (self-contained, single-shot each, NO re-patch loop) + read-only monitor.
+//  (A) manifest pre/mid-roll: AdsState.prepareAdBreakStates -> stamp __adkill, empty metadata.ads=[]
+//  (B) pause overlay: z() saga -> force f=e.displayAd to void 0 -> no ad opportunity
+//  MONITOR (read-only): KILLMARK(__adkill)/rawRealPods = manifest ad kills; rawDisplayAd = server
+//  pause ad delivered; BOOKMARK = distinct resume positions seen (confirms resume/bookmark intact).
+var logw = new NativeFunction(Module.findGlobalExportByName('__android_log_write'),
+  'int', ['int', 'pointer', 'pointer']);
+var TAG = Memory.allocUtf8String('KILL');
+function L(m){ logw(6, TAG, Memory.allocUtf8String(m)); }
+function pat(s){ return s.split('').map(function(c){return ('0'+c.charCodeAt(0).toString(16)).slice(-2);}).join(' '); }
+function bytesOf(s){ var b=[]; for (var i=0;i<s.length;i++) b.push(s.charCodeAt(i)); return b; }
+
+// ---------- (A) manifest patch ----------
+var A_OLD='var f=e.value;f.syncAdStates();f.state.isHydrated&&"viewable"!==f.metadata.source&&f.applyHydration(f.state.hydrationSequenceId)';
+var A_NEW='var f=e.value;f.metadata&&(f.metadata.ads.length&&(f.__adkill=f.metadata.ads.length),f.metadata.ads=[]);f.syncAdStates();/*...*/';
+var aDone=false;
+function patchA(rs){ if(aDone)return; if(A_NEW.length!==A_OLD.length){L('A length mismatch — ABORT');aDone=true;return;}
+  var p=pat(A_OLD);
+  for(var i=0;i<rs.length;i++){var r=rs[i];if(r.size>128*1024*1024)continue;
+    try{var h=Memory.scanSync(r.base,r.size,p);for(var j=0;j<h.length;j++){Memory.protect(h[j].address,A_NEW.length,'rw-');h[j].address.writeByteArray(bytesOf(A_NEW));aDone=true;L('PATCH A: prepareAdBreakStates @'+h[j].address);}}catch(e){}}
+}
+// ---------- (B) pause patch ----------
+var B_ANCHOR='void 0:e.displayAd',B_OLD='e.displayAd',B_NEW='void 0     ';
+var bDone=false;
+function patchB(rs){ if(bDone)return; var p=pat(B_ANCHOR);
+  for(var i=0;i<rs.length;i++){var r=rs[i];if(r.size>128*1024*1024)continue;
+    try{var h=Memory.scanSync(r.base,r.size,p);for(var j=0;j<h.length;j++){var t=h[j].address.add(7);var cur=null;try{cur=t.readCString(B_OLD.length);}catch(e){}if(cur!==B_OLD)continue;Memory.protect(t,B_NEW.length,'rw-');t.writeByteArray(bytesOf(B_NEW));bDone=true;L('PATCH B: pause z() displayAd->void0 @'+t);}}catch(e){}}
+}
+var tries=0;
+function apply(){ tries++; var rs=Process.enumerateRanges('rw-');
+  var loaded=false,gp=pat('nrdp.gibbon');
+  for(var i=0;i<rs.length&&!loaded;i++){if(rs[i].size>128*1024*1024)continue;try{if(Memory.scanSync(rs[i].base,rs[i].size,gp).length)loaded=true;}catch(e){}}
+  if(loaded){patchA(rs);patchB(rs);}
+  // Keep polling until BOTH applied. prepareAdBreakStates (A) can load LATER than
+  // the pause module (B) — sometimes only once the ad code is exercised — so we
+  // must NOT give up early or a real ad slips through. This is a find-and-apply
+  // poll, still WRITE-ONCE (aDone/bDone guards) — not a re-patch loop.
+  if(aDone&&bDone){ L('apply DONE: A='+aDone+' B='+bDone+' tries='+tries); return; }
+  if(tries%15===0) L('apply waiting: A='+aDone+' B='+bDone+' tries='+tries);
+  if(tries<3600) setTimeout(apply, 2000);   // up to ~2h of find-and-apply polling
+}
+
+// ---------- monitor (read-only) ----------
+var KILLMARK=pat('__adkill'),REALPOD=pat('ads":[{'),DISPAD=pat('displayAd":{'),BM=pat('"bookmark":');
+function readNumAfter(addr,skip){ try{var s=addr.add(skip).readCString(14);var m=/^([0-9]{1,12})/.exec(s);return m?parseInt(m[1],10):-1;}catch(e){return -1;} }
+var cyc=0;
+function observe(){ cyc++;
+  var rs=Process.enumerateRanges('rw-');var kill=0,real=0,disp=0;var bset={};
+  for(var i=0;i<rs.length;i++){var r=rs[i];if(r.size>64*1024*1024||r.size<256)continue;
+    try{ kill+=Memory.scanSync(r.base,r.size,KILLMARK).length; real+=Memory.scanSync(r.base,r.size,REALPOD).length; disp+=Memory.scanSync(r.base,r.size,DISPAD).length;
+      var bh=Memory.scanSync(r.base,r.size,BM); for(var k=0;k<bh.length&&k<40;k++){var v=readNumAfter(bh[k].address,11);if(v>0)bset[v]=1;}
+    }catch(e){}
+  }
+  var bks=Object.keys(bset).map(Number).sort(function(a,b){return b-a}).slice(0,6);
+  var tag=(kill>1?'  <<<MANIFEST-KILL':'')+(disp>0?'  <<<server-pauseAd(x'+disp+')':'')+(real>0?'  <<<rawRealPod(x'+real+')':'');
+  L('OBS'+cyc+': KILLMARK='+kill+' rawRealPods='+real+' rawDisplayAd='+disp+' bookmarks='+JSON.stringify(bks)+tag);
+  if(cyc<560) setTimeout(observe,3000);   // ~28 min coverage
+}
+
+L('killads ready (A manifest + B pause, single-shot; ad+resume monitor)');
+setTimeout(apply,5000);
+setTimeout(observe,9000);


### PR DESCRIPTION
## Summary

Adds a self-contained, on-device-verified **ad-strip + privacy** patch set for the real living-room **Netflix (com.netflix.ninja) 13.0.1-25028** on Android TV — no PC, no frida host, no DNS. Netflix on the Onn box is a **Play-signed system app** guarded by two anti-tamper layers; this ships as an installable **clone** (`com.netflix.ninja.clone`) that runs alongside untouched stock and self-applies its patches at launch via a script-mode gadget.

## What it does

**Ad kills (default-on, self-contained):**
- **Pre/mid-roll** — empties `metadata.ads=[]` in the appboot `AdsState.prepareAdBreakStates` chokepoint (both ad paths converge there; byte-identical to Netflix's own empty-pod no-ad path → content plays, no `tvq-pb` errors).
- **Pause overlay** — forces `e.displayAd → void 0` in the `z()` ad-opportunity saga → the pause-ad overlay never builds.

**Two anti-tamper defeats (required to run the clone at all):**
- **DexGuard Java CertCheck** — `return-void` the obfuscated crash `Runnable`, anchored on the unique crash string (survives name rotation).
- **Native `RJni_SignatureCheck`** — the clone injects `<queries><package android:name="com.netflix.ninja"/></queries>` so the native cross-package signature read resolves to genuine stock Netflix's cert (fix for the Android-11 package-visibility block).

**Privacy (opt-in — "Minimize Network Fingerprint"):**
- Blanks the local **IP / IPv6 / MAC / Wi-Fi SSID** the app reports (`u.ifList`), keeping interface name/type.
- **NEW:** minimizes the **advertising ID (GAID)** — overwrites `e.advertisingId → ""` at the appboot `getSystemValue("advertisingIdDetails")` collector so the real GAID is never emitted in `AdvertisingIdCollectionEvent` telemetry. Both fold under the single opt-in.

## Delivery

Gadget in **script mode** runs the bundled `lib/armeabi-v7a/libgadget.script.so` (= `killads.js`) over a relative path (app-readable lib dir, dodges the `/data/local/tmp` SELinux block). Opens normally from the launcher and self-applies; `apply()` polls until every pass lands (pre/mid-roll module can load late). Write-once guards — never a re-patch loop.

## On-device verification (Onn 4K, clone 13.0.1-25028)

- All passes arm every cold start (fast, `tries=2–3`): `apply DONE: A=true B=true FP=true GAID=true`
- Ad suppression proven under stress: `KILLMARK=2` (real server ad-breaks emptied) + server pause-ads suppressed, nothing on screen
- **Zero** error lines (`tvq-pb`/FATAL/SIGABRT/ANR) across repeated force-stop/relaunch + in-player seek/pause/resume stress
- Playback **resume continuity** intact every cycle
- Signed with the Morphe key → `adb install -r` keeps login

## Why a clone (both APKs)

Stock Netflix is a **system app** and can't be replaced in place (`INSTALL_FAILED_UPDATE_INCOMPATIBLE`) and can't be fully uninstalled without root. The clone installs as a **separate package** next to stock. The clone reads **stock's signature** (not version) to pass the native anti-tamper, so stock must stay installed + enabled — but stock auto-updating is fine and doesn't break the clone.

## Test tooling

- `experimental/netflix-native-adstrip/autotest/nf-autotest.sh` — guardrailed autonomous playback/ad test (no blind navigation; foreground-guard; verify-before-stress)
- `experimental/netflix-native-adstrip/autotest/nf-matrix.sh` — deep-link multi-title/scenario matrix

Docs: `experimental/netflix-native-adstrip/{ADS-EMPTY-POD-SEAM,APPBOOT-ADBREAK-SEAM,PAUSE-ADS,PROOF-*}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)