### PR TITLE
fix(netflix): recognize real version, default-on Clone, clearer patch names + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ I'm just like you — I enjoy watching TV and movies without being bored and ann
 |-----|---------|--------|---------------|------|
 | 🟢 Disney+ | `com.disney.disneyplus` | Working | `26.12.1+rc1-2026.07.15` | 7/21/26 |
 | 🟢 Prime Video | `com.amazon.amazonvideo.livingroom` | Working — native in-app ad strip (movies + TV shows), no DNS required | `6.23.23+v15.5.0.70-armv7a` | 7/30/26 |
+| 🟢 Netflix | `com.netflix.ninja` | Working — native in-app ad strip (pre-roll, mid-roll, pause-screen ad), no DNS required. Installs as a **side-by-side clone**; keep stock Netflix installed | `13.0.1 build 25028` | 8/8/26 |
 | 🟢 HBO Max | `com.wbd.hbomax` | Working | `v7.7.0.78` | 7/18/26 |
 | 🟢 Peacock | `com.peacocktv.peacockandroid` | Working — no DNS required | `v7.6.100` | 7/16/26 |
 | 🟢 Tubi | `com.tubitv` | Working | `v10.28.5000` | 7/20/26 |
@@ -84,6 +85,34 @@ All patches follow the same general workflow using **Morphe Manager**:
 > edge case: very aggressive fast-forward + resume can occasionally nudge the
 > playback position; it self-heals on a full playthrough and normal viewing is
 > unaffected. Please report anything else via an issue.
+
+---
+
+### 🍿 Netflix
+
+> 🟢 **Working — no DNS filter needed.** Pre-rolls, mid-rolls, **and** the
+> full-screen pause-screen ad are removed **in-app** by an in-process script that
+> the app runs itself at launch (no PC, no root, no frida server). Verified
+> on-device: Netflix's servers still deliver real ad breaks and none of them play.
+>
+> 🔐 **Two apps, on purpose — keep BOTH installed.** Netflix on a TV is a
+> preinstalled, Netflix-signed **system app** that can't be replaced or uninstalled
+> without root, so the patch installs as a **separate clone**
+> (`com.netflix.ninja.clone`) next to it. The clone passes Netflix's built-in
+> tamper check by reading the **stock** app's genuine signature — so **stock
+> Netflix must stay installed and enabled** (you just never open it; letting it
+> auto-update is fine). Log into the **clone** and use that. Don't disable or
+> uninstall stock Netflix, or the clone won't start.
+
+1. Open the **[Netflix (Android TV) listing on APKMirror](https://www.apkmirror.com/apk/netflix-inc/netflix-android-tv/)** (publisher **Netflix, Inc.**, package `com.netflix.ninja`) and select version **`13.0.1 build 25028`**
+2. ⚠️ **Netflix is the exception to the "download the .apkm bundle" rule above.** This listing has **no App Bundle** — download the single **`armeabi-v7a`** APK (APKMirror may name the file differently, but the variant row is labeled `armeabi-v7a`). Match **`13.0.1 build 25028`**; Morphe Manager will show it as **Recommended**.
+3. Select the `.apk` in Morphe Manager
+4. Apply the patch — leave **Clone Netflix** and the **Remove Netflix ads** patches enabled (both on by default). Optionally enable **Minimize Network Fingerprint** for the privacy pass (blanks local IP/MAC/SSID + advertising ID).
+5. Install the result **without uninstalling stock Netflix**, then open the new **Netflix clone** app and sign in.
+
+> ⚠️ **Not a subscription bypass.** You need a valid, paid Netflix account and you
+> log in normally. This only removes ads and trims device telemetry inside an app
+> you're already entitled to use.
 
 ---
 

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/misc/clone/CloneAppPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/misc/clone/CloneAppPatch.kt
@@ -40,12 +40,14 @@ private const val CLONE_SUFFIX = "clone"
 // Intent actions and <queries> package targets are left untouched: they are not
 // device-unique and are matched by literal string on both ends.
 //
-// ⚠️ CAPTURE-ONLY / EXPERIMENTAL. This exists to get the frida-gadget appboot
-// capture (bundleGadgetPatch/loadGadgetPatch) installable alongside stock
-// Netflix. Netflix ties ESN/MSL identity and Widevine provisioning to the
-// package name, so the clone may fail login/playback; that's acceptable for the
-// capture goal because the appboot JS bundle loads at boot/browse, before
-// playback. NOT a shipping ad-strip. Opt-in (default = false).
+// REQUIRED on TV boxes: Netflix ships preinstalled + Play-signed, so a
+// Morphe-signed build can't replace it. This installs the patched app as a
+// SEPARATE package (com.netflix.ninja.clone) alongside untouched stock. The
+// clone reads STOCK's genuine signature via the injected <queries> entry to
+// satisfy the native RJni_SignatureCheck anti-tamper (§1b), so stock must stay
+// installed + enabled (it may auto-update freely — the clone keys off the
+// signature, not the version). Verified on-device: the clone logs in, plays,
+// and self-applies the ad kills. Default ON for this Android-TV target.
 //
 // Runs in finalize {} so the rename happens after all other patches, at manifest
 // write time.
@@ -53,12 +55,13 @@ private const val CLONE_SUFFIX = "clone"
 @Suppress("unused")
 val cloneAppPatch = resourcePatch(
     name = "Clone Netflix",
-    description = "Installs the patched Netflix as a separate app alongside the stock one, " +
-        "instead of replacing it. Required on devices where Netflix is a preinstalled system " +
-        "app that can't be uninstalled (Onn, Fire TV, most Android TV boxes). The clone gets its " +
-        "own package (suffix .$CLONE_SUFFIX). EXPERIMENTAL capture tooling — Netflix binds " +
-        "ESN/MSL/Widevine to the package name, so the clone may not log in or play. Opt-in.",
-    default = false,
+    description = "Installs the patched Netflix as a separate app alongside the stock one " +
+        "(package suffix .$CLONE_SUFFIX), instead of replacing it. Required on devices where " +
+        "Netflix is a preinstalled system app that can't be uninstalled (Onn, Fire TV, most " +
+        "Android TV boxes). Keep the stock Netflix installed + enabled — the clone borrows its " +
+        "signature to pass Netflix's native tamper check (stock auto-updating is fine). You just " +
+        "launch the clone instead. Recommended: leave ON.",
+    default = true,
 ) {
     compatibleWith(Constants.COMPATIBILITY)
 

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/nativehook/BundleGadgetPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/nativehook/BundleGadgetPatch.kt
@@ -4,31 +4,34 @@ import app.morphe.patcher.patch.resourcePatch
 import ajstrick81.morphe.patches.netflix.shared.Constants
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Bundles frida-gadget into com.netflix.ninja so we can capture the appboot UI
-// bundle in-process on a NON-rooted Onn (no frida-server needed — the gadget
-// runs inside Netflix's own process). Acquisition tooling for the reopened
-// seam-A/B work; see experimental/netflix-native-adstrip/REOPENING.md and
-// frida/README.md.
+// THE AD REMOVER (delivery half). Bundles a frida-gadget into com.netflix.ninja
+// running in SCRIPT mode against the bundled ad-kill script (killads.js) — the
+// gadget runs inside Netflix's own process at launch, so the ad kills apply with
+// no PC, no root, and no frida server. (The same gadget primitive was originally
+// stood up for non-root appboot capture; it now ships as the ad-strip delivery.)
 //
-// Writes three things into the decoded APK:
+// Writes into the decoded APK:
 //   1. lib/armeabi-v7a/libgadget.so         — the frida-gadget binary (supplied)
-//   2. lib/armeabi-v7a/libgadget.config.so  — gadget config (generated here)
-//   3. manifest flips: extractNativeLibs=true, debuggable=true
+//   2. lib/armeabi-v7a/libgadget.script.so  — the ad-kill script (killads.js)
+//   3. lib/armeabi-v7a/libgadget.config.so  — gadget config (run the script at load)
+//   4. manifest flip: extractNativeLibs=true (so the libs land in an app-readable dir)
 //
 // The gadget binary is NOT checked into the repo (large, ABI-specific, and not
 // ours to redistribute). Drop the armeabi-v7a frida-gadget, renamed to
 // libgadget.so, at:
 //   patches/src/main/resources/netflix/native/armeabi-v7a/libgadget.so
 //
-// SCAFFOLD — not registered in the build. Companion to loadGadgetPatch, which
-// injects the System.loadLibrary("gadget") call and dependsOn() this so the
-// .so + config are in place first.
+// Companion to loadGadgetPatch, which injects the System.loadLibrary("gadget")
+// call and dependsOn() this so the .so + script + config are in place first.
+// Default ON.
 // ─────────────────────────────────────────────────────────────────────────────
 @Suppress("unused")
 val bundleGadgetPatch = resourcePatch(
-    name = "Bundle frida-gadget (Netflix appboot capture)",
-    description = "Packages libgadget.so + its config into com.netflix.ninja for " +
-        "in-process, non-root capture of the appboot UI bundle (post-MSL, post-signature).",
+    name = "Remove Netflix ads (bundle engine)",
+    description = "Bundles the in-process ad-kill script (killads.js) and its loader into the " +
+        "app. This is the ad remover: at launch the app runs the script itself (script mode — no " +
+        "PC, no root, no frida server) and empties Netflix's ad breaks (pre-roll, mid-roll) and " +
+        "the pause-screen ad overlay. Pairs with the loader patch. Default ON.",
 ) {
     compatibleWith(Constants.COMPATIBILITY)
 

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/nativehook/LoadGadgetPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/nativehook/LoadGadgetPatch.kt
@@ -5,31 +5,24 @@ import app.morphe.patcher.patch.bytecodePatch
 import ajstrick81.morphe.patches.netflix.shared.Constants
 
 // ─────────────────────────────────────────────────────────────────────────────
-// DEX-side half of the non-root capture: load libgadget.so at startup so the
-// frida-gadget script (dump_appboot.js) is armed before the nrdp runtime
-// fetches/caches the appboot UI bundle.
+// THE AD REMOVER (loader half). DEX-side: load libgadget.so at startup so the
+// bundled ad-kill script (killads.js, placed by bundleGadgetPatch) is armed as
+// early as possible — before the nrdp runtime schedules any ad break.
 //
-// Unlike the Prime Video native-hook (which calls an extension's
-// NativeHookLoader.load() for fail-loud logging), the gadget only needs the
-// library on the linker path — so we inline System.loadLibrary("gadget"). No
-// extension DEX is required for capture. The gadget's own config
-// (libgadget.config.so, written by bundleGadgetPatch) drives what runs.
+// The gadget only needs the library on the linker path, so we inline
+// System.loadLibrary("gadget"); its config (libgadget.config.so) points it at
+// the bundled script in script mode. No extension DEX required.
 //
-// Injected at index 0 of Application.onCreate so the gadget loads as early as
-// possible in-process.
-//
-// SCAFFOLD — not registered in the build. To activate:
-//   1. Confirm NetflixApplicationOnCreateFingerprint's definingClass (Fingerprints.kt).
-//   2. Drop the armeabi-v7a frida-gadget at the path bundleGadgetPatch documents.
-//   3. Register bundleGadgetPatch + loadGadgetPatch, gate both on Constants.COMPATIBILITY.
-// This is CAPTURE tooling, not the ad-strip itself — remove it from any shipping
-// build once the appboot schema is in hand and the seam-A transform is written.
+// Injected at index 0 of Application.onCreate so it loads as early as possible.
+// Companion to bundleGadgetPatch (dependsOn), which stages the .so + script +
+// config first. Default ON.
 // ─────────────────────────────────────────────────────────────────────────────
 @Suppress("unused")
 val loadGadgetPatch = bytecodePatch(
-    name = "Load frida-gadget (Netflix appboot capture)",
-    description = "Loads libgadget.so at startup to capture the appboot UI bundle " +
-        "in-process on a non-rooted device (post-MSL, post-signature).",
+    name = "Remove Netflix ads (loader)",
+    description = "Arms the ad remover: injects the startup call that loads the in-process " +
+        "ad-kill engine (bundled by the companion patch) as early as possible, so ads are " +
+        "emptied before playback. Requires the bundle-engine patch. Default ON.",
 ) {
     compatibleWith(Constants.COMPATIBILITY)
 

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/shared/Constants.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/shared/Constants.kt
@@ -19,6 +19,11 @@ object Constants {
         name = "Netflix Android TV",
         packageName = "com.netflix.ninja",
         appIconColor = 0xE50914,
-        targets = listOf(AppTarget("13.0.1-25028-armv7a"))
+        // Must equal the APK's ACTUAL versionName so Morphe Manager recognizes
+        // the download as Recommended (not "Unsupported — proceed anyway"). The
+        // armeabi-v7a build on APKMirror reports versionName "13.0.1 build 25028"
+        // (versionCode 25028); a normalized "13.0.1-25028-armv7a" string does NOT
+        // match and trips the version-mismatch warning.
+        targets = listOf(AppTarget("13.0.1 build 25028"))
     )
 }


### PR DESCRIPTION
Follow-ups from real-device install testing of the Netflix patch set.

## Changes

**1. Fix the "Unsupported Version" warning** (`Constants.kt`)
Morphe Manager matches `AppTarget` against the APK's **versionName**. We had declared a synthetic `13.0.1-25028-armv7a`, which doesn't equal Netflix's real versionName `13.0.1 build 25028` — so the genuine armeabi-v7a download was flagged **"Unsupported — proceed anyway"** while our made-up string showed as Recommended. Target now = `13.0.1 build 25028` (same convention as Pluto/Prime Video, whose targets are the apps' literal versionNames). No more scary warning on the correct APK.

**2. "Clone Netflix" default-on** (`CloneAppPatch.kt`)
It's *required* on the Android-TV target (Netflix is a preinstalled system app that can't be replaced), so it shouldn't be opt-in. Flipped `default = true` and replaced the stale "experimental / may not log in" copy with accurate keep-stock-installed guidance.

**3. Clearer names for the ad-remover patches** (`BundleGadgetPatch.kt`, `LoadGadgetPatch.kt`)
The two gadget patches *are* the ad blocker (bundle the in-process `killads.js` + run it in script mode at launch — no PC/root/frida server), but their names still said "appboot capture" from the R&D phase. Renamed to **"Remove Netflix ads (bundle engine)"** / **"Remove Netflix ads (loader)"** and de-scaffolded the header comments. No behavior change — both were already default-on.

**4. README** — new Netflix status-table row + dedicated install section documenting the Netflix-specific gotchas: no `.apkm` bundle (download the single armeabi-v7a APK), side-by-side clone with stock kept installed, default patch selection, and an explicit "not a subscription bypass — valid paid login required" note.

## Verification
- `:patches:compileKotlin` clean.
- Version-match fix derived directly from the Morphe Manager version dialog on-device (selected `13.0.1 build 25028` vs recommended `13.0.1-25028-armv7a`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)