### PR TITLE
feat(netflix): opt-in "Suppress Household Prompt" patch

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -33,6 +33,22 @@ Modifications:
   Referenced as prior art for Android-side Twitch ad mitigation
   Source: https://github.com/crackededed/Xtra
 
+- Nikflix (YidirK/Nikflix), GPL-3.0
+  Reference for the Netflix household / "you're traveling" enforcement
+  mechanism. Nikflix (a browser extension) documents that Netflix delivers
+  the household restriction via the CLCSInterstitialPlaybackAndPostPlayback
+  interstitial. That pointer led us to the corresponding machinery in the
+  Netflix Android TV appboot bundle.
+  Source: https://github.com/YidirK/Nikflix
+  Modifications / independence: our "Suppress Household Prompt" patch shares
+  NO source code with Nikflix. It is an independent implementation for a
+  different target (the com.netflix.ninja Android TV app, not web) using a
+  different mechanism (an in-process appboot-heap byte edit of the native
+  app's redux state, forcing the misdetection saga's
+  setAccountSharingFlags({isActiveMisdetectionSession:true}) dispatch to
+  false), located by grepping our own on-device heap dumps. Nikflix is
+  credited for identifying the household-enforcement seam, not for code.
+
 Modifications:
 - Twitch techniques independently re-derived via dex disassembly of the
   official Twitch Android APK v30.2.2, not copied from source code

--- a/README.md
+++ b/README.md
@@ -204,6 +204,11 @@ This patch template is based on the prior work of [ReVanced](https://github.com/
 
 All Twitch techniques were independently re-derived via dex disassembly and are not copied from these projects' source code. See [NOTICE](NOTICE) for full attribution details.
 
+**Netflix household-prompt suppression** is informed by:
+- [Nikflix](https://github.com/YidirK/Nikflix) (YidirK, GPL-3.0) — identified Netflix's household / "you're traveling" enforcement via the `CLCSInterstitialPlaybackAndPostPlayback` interstitial
+
+Our "Suppress Household Prompt" patch shares no source code with Nikflix — it is an independent implementation for the Android TV app (`com.netflix.ninja`), located by analyzing our own on-device appboot heap dumps. Nikflix is credited for identifying the enforcement seam. See [NOTICE](NOTICE).
+
 ---
 
 ## 📜 License

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/misc/household/SuppressHouseholdPromptPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/netflix/misc/household/SuppressHouseholdPromptPatch.kt
@@ -1,0 +1,65 @@
+package ajstrick81.morphe.patches.netflix.misc.household
+
+import app.morphe.patcher.patch.resourcePatch
+import ajstrick81.morphe.patches.netflix.nativehook.bundleGadgetPatch
+import ajstrick81.morphe.patches.netflix.shared.Constants
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Suppress the Netflix household / "you're traveling" prompt (OPT-IN, default OFF).
+//
+// Netflix's living-room app enforces household/account-sharing via a redux-saga in
+// the appboot JS: when the server returns a "misdetection" challenge, the saga
+// stores it and then dispatches
+//   put(setAccountSharingFlags({ isActiveMisdetectionSession: true }))
+// to ACTIVATE the challenge. Traced downstream (killads.js HH block): the challenge
+// UI is gated by  misdetectionAvailable = ("ready"===status) && isActiveMisdetectionSession,
+// and the challenge-action callback guards on the same flag — so this single flag is
+// the operative gate, set true in exactly one place. This patch flips the bundled
+// script's HH_ENABLED, whose runtime pass rewrites the dispatched value true -> false
+// (one byte, length-preserving), so the app receives the challenge but never activates
+// the session and the full-screen prompt is not shown.
+//
+// HONEST SCOPE: this suppresses only the CLIENT-side prompt. It does NOT change what
+// Netflix's servers detect (household detection is public-IP driven and server-side) —
+// only a VPN/proxy changes that. It cannot be verified purely on-device unless the
+// account is actually in a flagged/"misdetected" state; the patch self-reports that it
+// APPLIED via the KILL log (PATCH HH / apply DONE … HH=true).
+//
+// Delivery: the pass lives in the gadget's bundled script (shipped OFF); this patch
+// just turns it on, so it composes with the ad kills without a second script. Kept as
+// its OWN opt-in (not folded into the ad kills or the privacy toggle) because it acts
+// on an account/household control, a deliberate, separate choice.
+//
+// CREDIT: the household-enforcement seam was identified with reference to the Nikflix
+// project (github.com/YidirK/Nikflix, GPL-3.0), a browser extension that documents
+// Netflix's household restriction being delivered via the
+// CLCSInterstitialPlaybackAndPostPlayback interstitial. This patch shares NO code with
+// Nikflix — it is an independent native-app (com.netflix.ninja) implementation using a
+// different mechanism (appboot-heap byte edit of the misdetection redux flag), located
+// by grepping our own on-device heap dumps. See NOTICE for full attribution.
+// ─────────────────────────────────────────────────────────────────────────────
+@Suppress("unused")
+val suppressHouseholdPromptPatch = resourcePatch(
+    name = "Suppress Household Prompt",
+    description = "Hides the Netflix \"you're traveling\" / update-your-household prompt by " +
+        "keeping the client from activating the misdetection challenge session. Does NOT change " +
+        "what Netflix's servers detect (that's driven by your public IP — use a VPN for that); " +
+        "it only suppresses the on-screen prompt. Opt-in / experimental; only takes visible " +
+        "effect when the account would otherwise be prompted.",
+    default = false,
+) {
+    compatibleWith(Constants.COMPATIBILITY)
+
+    // The ad-kill gadget must have written the bundled script first.
+    dependsOn(bundleGadgetPatch)
+
+    execute {
+        val script = get("lib/armeabi-v7a/libgadget.script.so")
+        val text = script.readText()
+        require(text.contains("HH_ENABLED=false")) {
+            "suppressHouseholdPromptPatch: HH_ENABLED flag not found in bundled script — " +
+                "killads.js/BundleGadgetPatch out of sync."
+        }
+        script.writeText(text.replaceFirst("HH_ENABLED=false", "HH_ENABLED=true"))
+    }
+}

--- a/patches/src/main/resources/netflix/native/killads.js
+++ b/patches/src/main/resources/netflix/native/killads.js
@@ -62,19 +62,45 @@ function patchGAID(rs){ if(gaidDone||!GAID_ENABLED)return; if(GAID_NEW.length!==
   for(var i=0;i<rs.length;i++){var r=rs[i];if(r.size>128*1024*1024)continue;
     try{var h=Memory.scanSync(r.base,r.size,p);for(var j=0;j<h.length;j++){var t=h[j].address.add(GAID_OFF);var cur=null;try{cur=t.readCString(GAID_OLD.length);}catch(e){}if(cur!==GAID_OLD)continue;Memory.protect(t,GAID_NEW.length,'rw-');t.writeByteArray(bytesOf(GAID_NEW));gaidDone=true;L('PATCH GAID: e.advertisingId->void0 @'+t);}}catch(e){}}
 }
+// ---------- (HH) household / "traveling" misdetection prompt suppression (OPT-IN; default OFF) ----------
+// The account-sharing redux-saga stores the server's misdetection challenge, then
+// dispatches  put(setAccountSharingFlags({isActiveMisdetectionSession:!0}))  to ACTIVATE
+// the household challenge session. Traced downstream: misdetectionAvailable =
+// ("ready"===status) && isActiveMisdetectionSession, and the challenge-action callback
+// guards on the same flag (p&&…) — so this ONE flag is the operative gate, set true in
+// exactly one place. Forcing the dispatched value !0 -> !1 (one byte) means the app
+// still RECEIVES the challenge but never ACTIVATES the session -> the full-screen
+// household/"you're traveling" prompt is not shown.
+// HONEST SCOPE: this only suppresses the CLIENT-side prompt; it changes nothing the
+// Netflix servers see (household detection is public-IP driven, server-side). Its own
+// opt-in Morphe patch flips HH_ENABLED to true.
+// CREDIT: household-enforcement seam identified with reference to Nikflix
+// (github.com/YidirK/Nikflix, GPL-3.0). No code shared — independent native-app
+// implementation, different mechanism. See NOTICE.
+var HH_ENABLED=false;
+var HH_ANCH='setAccountSharingFlags)({isActiveMisdetectionSession:!0';
+var HH_OFF=HH_ANCH.length-1;   // offset of the final '0' in '!0'
+var HH_OLD='0',HH_NEW='1';
+var hhDone=false;
+function patchHH(rs){ if(hhDone||!HH_ENABLED)return;
+  var p=pat(HH_ANCH);
+  for(var i=0;i<rs.length;i++){var r=rs[i];if(r.size>128*1024*1024)continue;
+    try{var h=Memory.scanSync(r.base,r.size,p);for(var j=0;j<h.length;j++){var t=h[j].address.add(HH_OFF);var cur=null;try{cur=t.readCString(1);}catch(e){}if(cur!==HH_OLD)continue;Memory.protect(t,1,'rw-');t.writeByteArray(bytesOf(HH_NEW));hhDone=true;L('PATCH HH: isActiveMisdetectionSession !0->!1 @'+t);}}catch(e){}}
+}
 var tries=0;
 function apply(){ tries++; var rs=Process.enumerateRanges('rw-');
   var loaded=false,gp=pat('nrdp.gibbon');
   for(var i=0;i<rs.length&&!loaded;i++){if(rs[i].size>128*1024*1024)continue;try{if(Memory.scanSync(rs[i].base,rs[i].size,gp).length)loaded=true;}catch(e){}}
-  if(loaded){patchA(rs);patchB(rs);patchFP(rs);patchGAID(rs);}
+  if(loaded){patchA(rs);patchB(rs);patchFP(rs);patchGAID(rs);patchHH(rs);}
   // Keep polling until applied. prepareAdBreakStates (A) can load LATER than the
   // pause module (B) — sometimes only once the ad code is exercised — so we must
   // NOT give up early or a real ad slips through. WRITE-ONCE (aDone/bDone/fpDone
   // guards) — not a re-patch loop. FP is only required when enabled.
   var fpOk=(!FP_ENABLED||fpDone);
   var gaidOk=(!GAID_ENABLED||gaidDone);
-  if(aDone&&bDone&&fpOk&&gaidOk){ L('apply DONE: A='+aDone+' B='+bDone+' FP='+(FP_ENABLED?fpDone:'off')+' GAID='+(GAID_ENABLED?gaidDone:'off')+' tries='+tries); return; }
-  if(tries%15===0) L('apply waiting: A='+aDone+' B='+bDone+' FP='+(FP_ENABLED?fpDone:'off')+' GAID='+(GAID_ENABLED?gaidDone:'off')+' tries='+tries);
+  var hhOk=(!HH_ENABLED||hhDone);
+  if(aDone&&bDone&&fpOk&&gaidOk&&hhOk){ L('apply DONE: A='+aDone+' B='+bDone+' FP='+(FP_ENABLED?fpDone:'off')+' GAID='+(GAID_ENABLED?gaidDone:'off')+' HH='+(HH_ENABLED?hhDone:'off')+' tries='+tries); return; }
+  if(tries%15===0) L('apply waiting: A='+aDone+' B='+bDone+' FP='+(FP_ENABLED?fpDone:'off')+' GAID='+(GAID_ENABLED?gaidDone:'off')+' HH='+(HH_ENABLED?hhDone:'off')+' tries='+tries);
   if(tries<3600) setTimeout(apply, 2000);   // up to ~2h of find-and-apply polling
 }
 


### PR DESCRIPTION
Adds an opt-in patch (default OFF) that hides the Netflix living-room app's household / "you're traveling" prompt, delivered by the same self-applying gadget script as the ad kills.

## Mechanism (traced on-device)
Netflix enforces household/account-sharing via a redux-saga: on a server "misdetection" challenge it stores the response, then dispatches `put(setAccountSharingFlags({isActiveMisdetectionSession:!0}))` to activate the challenge. Traced downstream — `misdetectionAvailable = ("ready"===status) && isActiveMisdetectionSession`, and the challenge action callback guards on the same flag — so this single flag is the operative gate, set true in exactly one place (anchor verified unique across the appboot dumps). The pass rewrites the dispatched `!0` → `!1` (one byte, length-preserving): the app receives the challenge but never activates the session, so the full-screen prompt isn't shown.

## Scope (honest)
Suppresses only the **client-side prompt**. It changes nothing Netflix's servers detect (household detection is public-IP driven, server-side — only a VPN changes that). Kept as its **own** opt-in, separate from the ad kills and the privacy toggle, because it acts on an account/household control.

## Verification
- **Arms cleanly on-device** (clone 13.0.1-25028, Onn): `PATCH HH: isActiveMisdetectionSession !0->!1` → `apply DONE … HH=true` (tries=2).
- **~12 min brute-force** (two 5-cycle seek/pause/resume stress passes) with a live anomaly monitor: **zero faults** (no `tvq-pb`/crash/ANR/JNI), ad suppression + playback/resume continuity unaffected.
- Visible *prompt* suppression requires an actual misdetected state (server-driven, not forceable on-device), so this ships **proven-to-apply**, opt-in / experimental.

## Attribution
The household-enforcement seam was identified with reference to **[Nikflix](https://github.com/YidirK/Nikflix)** (YidirK, GPL-3.0), which documents Netflix delivering the restriction via `CLCSInterstitialPlaybackAndPostPlayback`. **No source code is shared** — this is an independent native-app (`com.netflix.ninja`) implementation using a different mechanism (appboot-heap byte edit), located via our own on-device heap dumps. Credited in NOTICE, README, the patch, and the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)