### PR TITLE
feat(testing): autotest profile for Prime Video .mod clone

### DIFF
--- a/experimental/autotest/profiles/primevideo-mod.env
+++ b/experimental/autotest/profiles/primevideo-mod.env
@@ -1,0 +1,10 @@
+# Prime Video CLONE (side-by-side ".mod" package) — autotest profile.
+# Same as primevideo.env but targets the clone built with "Clone Prime Video"
+# (package suffix .mod), so it can run alongside a stock/differently-signed PV.
+PKG=com.amazon.amazonvideo.livingroom.mod
+LAUNCH=monkey
+RESUME_KEYS="DPAD_CENTER DPAD_CENTER"
+PLAYBACK_PROBE=state
+ARMED_RE="pvhook loaded"
+ORACLE_RE="PV(KILL|OBS) [^\r]*"
+ORACLE_BASELINE_RE="PVOBS movieBlanked=0 tvEmptied=0"


### PR DESCRIPTION
Companion to `primevideo.env` targeting the "Clone Prime Video" build (package suffix `.mod`), so the autonomous app tester can run against the modded clone alongside a stock/differently-signed PV install.

Tiny experimental config file — no patch/shipping impact. Completes the profile set (`_template`, `netflix`, `primevideo`, and now `primevideo-mod`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)