### PR TITLE
docs(peacock): link directly to APKMirror 7.6.100 release page

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ All patches follow the same general workflow using **Morphe Manager**:
 
 ### 🦚 Peacock
 
-1. Open the **[Peacock TV (Android TV) listing on APKMirror](https://www.apkmirror.com/apk/peacock-tv-llc/peacock-tv-android-tv/)** and select version **`7.6.100`**
+1. Open the **[Peacock TV (Android TV) 7.6.100 release on APKMirror](https://www.apkmirror.com/apk/peacock-tv-llc/peacock-tv-android-tv/peacock-tv-stream-tv-movies-android-tv-7-6-100-release/)** directly (this is version **`7.6.100`** — use this link rather than searching, which can land on the similarly-named `7.6.10`)
 2. Download the `.apkm` file
 3. Select it in Morphe Manager
 4. Apply the patch


### PR DESCRIPTION
## What
Point the Peacock install step in the README straight at the verified **[7.6.100 Android TV release page](https://www.apkmirror.com/apk/peacock-tv-llc/peacock-tv-android-tv/peacock-tv-stream-tv-movies-android-tv-7-6-100-release/)** instead of the generic listing that requires selecting a version.

## Why
Reported in #100 (@sillsytuffs): searching APKMirror for `7.6.100` from the Morphe app can land on the similarly-named **`7.6.10`** page. The repo's version data was already correct (`7.6.100` everywhere) — the misroute is in version-search fuzzy matching. A direct release link sidesteps it.

The target URL was verified to return 200 and show version 7.6.100. (The guessable `…android-tv-7-6-100-release/` slug 404s; the correct slug includes the full app name: `peacock-tv-stream-tv-movies-android-tv-7-6-100-release`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)