### PR TITLE
feat(netflix): rebuild ad-strip for dynamic ad insertion + household prompt

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -34,20 +34,29 @@ Modifications:
   Source: https://github.com/crackededed/Xtra
 
 - Nikflix (YidirK/Nikflix), GPL-3.0
-  Reference for the Netflix household / "you're traveling" enforcement
+  Author: YidirK (github.com/YidirK)
+  API-block mechanism contributor: Buckibarnes17 (github.com/Buckibarnes17),
+  credited in the Nikflix v2.0.1 release notes for the GraphQL API-block
+  approach.
+  Reference for the Netflix ad-interstitial / household enforcement
   mechanism. Nikflix (a browser extension) documents that Netflix delivers
-  the household restriction via the CLCSInterstitialPlaybackAndPostPlayback
-  interstitial. That pointer led us to the corresponding machinery in the
-  Netflix Android TV appboot bundle.
+  the playback ad interstitial via the CLCSInterstitialPlaybackAndPostPlayback
+  GraphQL operation, neutralised by returning an empty response. That pointer
+  led us to the corresponding machinery in the Netflix Android TV appboot
+  bundle, where we confirmed the same CLCS interstitial family
+  (clcsInterstitialPlaybackAndPostPlayback for ads, and the sibling
+  clcsInterstitialProfileGate that carries the household / "This is my
+  account" ownership screen).
   Source: https://github.com/YidirK/Nikflix
-  Modifications / independence: our "Suppress Household Prompt" patch shares
-  NO source code with Nikflix. It is an independent implementation for a
-  different target (the com.netflix.ninja Android TV app, not web) using a
-  different mechanism (an in-process appboot-heap byte edit of the native
-  app's redux state, forcing the misdetection saga's
-  setAccountSharingFlags({isActiveMisdetectionSession:true}) dispatch to
-  false), located by grepping our own on-device heap dumps. Nikflix is
-  credited for identifying the household-enforcement seam, not for code.
+  Modifications / independence: our Netflix patches share NO source code with
+  Nikflix. They are an independent implementation for a different target
+  (the com.netflix.ninja Android TV app, not web): rather than overriding
+  window.fetch / XMLHttpRequest in a browser (impossible on the native app,
+  which has no DOM and ships the request over MSL, not plaintext HTTPS), we
+  apply an in-process appboot-heap byte edit inside the app's own JS VM,
+  located by grepping our own on-device heap dumps. YidirK and Buckibarnes17
+  are credited for identifying the CLCS interstitial enforcement seam and the
+  neutralise-the-operation approach, not for code.
 
 Modifications:
 - Twitch techniques independently re-derived via dex disassembly of the

--- a/experimental/netflix-adprobe/README.md
+++ b/experimental/netflix-adprobe/README.md
@@ -1,0 +1,46 @@
+# ADPROBE — JS-VM heap-tap front-end (Netflix) + portability notes
+
+This directory preserves the **app-analysis improvements** developed while re-cracking Netflix
+Android-TV ad delivery on 2026-08-13. It extends the base `adprobe` diagnostic
+(`docs/ADPROBE_DIAGNOSTIC.md`, branch `feat/pluto-adprobe-diagnostic`), which had a **native**
+front-end (Prime Video memcpy GOT hook) and **Java** front-ends (Pluto/Tubi/…) but only
+"recon-stage" notes for JS-VM apps like Netflix.
+
+`adprobe-jsvm-tap.js` is that missing **JS-VM front-end**: a read-only QuickJS/Gibbon heap tap.
+It is a diagnostic, never a patch — it reads and logs only.
+
+## What's new here (the reusable improvements)
+
+1. **Keyword table with per-key context window** `{k, w, b}` — retarget to a new app by swapping
+   the table, not the logic. `w:0` = cheap count-only presence signal.
+2. **Residency classification (code vs data)** — scan CODE forms (`==="ad"`, `.initialSegment`,
+   `fn=function`) beside DATA forms (`"type":"ad"`). Resident code context ⇒ builder/consumer is
+   patchable in-process; data-only ⇒ compiled-away ⇒ source-scan patch impossible. This is how we
+   proved Netflix's old patch-A anchor was dead but the new playgraph builder was alive.
+3. **Seam-lock** — narrow from "which mechanism" → the consumer that branches on the ad
+   discriminator → the single **upstream source** all consumers share (Netflix: `adverts.adBreaks`).
+   One edit at the source closes every downstream path.
+4. **Live-capture discipline** — chatty devices roll the logcat ring buffer fast (Widevine spam),
+   so `logcat -d` misses hits; capture with a live `timeout N adb logcat` window during the actual
+   ad break, and use `w:0` count keys to confirm "0 ad segments" after a patch.
+
+## Netflix result (what it found)
+
+Ads migrated from the legacy `metadata.ads[]` manifest-pod model to **dynamic server-side
+insertion**: ad videos stitched as `type:"ad"` playgraph viewables (`s0:ad-0-x → padend →
+content`), decisioned via the `clcsInterstitialPlaybackAndPostPlayback` GraphQL op (which turned
+out to be **UI only**). All stitchers (`applyDaiPrefetch`, `mergeReplacedAds`, `enrichAds`, the VOD
+`StatefulAdBreak` map) read one upstream source — the manifest→adverts normaliser
+`T.adverts=…{adBreaks:(…?void 0:ba.map(…normalize…))}`. The shipped fix empties it at the source
+(`ba.map` → `[].map`). See repo `NOTICE` and the Netflix ad-strip memory notes.
+
+## Portability to Prime Video
+
+PV's ad decisioning is **native** (libignite / WAMR AoT over downloaded WASM), so the base
+ADPROBE already targets it with a native memcpy GOT hook — that stays the right front-end for the
+WASM ad path. **However**, PV's player/timeline runs in a **QuickJS** layer (see memory
+`primevideo-atv-ignite-wamr-architecture`), and the shipped v1.16.0 strip works via a GOT hook on
+`libignite` memcpy. The JS-VM tap here is worth trying against PV's **QuickJS heap** to see whether
+the timeline/ad-break scheduling (as opposed to the WASM ad-decision blob) exposes resident
+source/data strings — the same residency-classification step decides if a JS-side seam exists
+alongside the native one. Status: **not yet run against PV** — candidate follow-up.

--- a/experimental/netflix-adprobe/adprobe-jsvm-tap.js
+++ b/experimental/netflix-adprobe/adprobe-jsvm-tap.js
@@ -1,0 +1,80 @@
+'use strict';
+// ADPROBE — JS-VM heap-tap front-end (read-only ad-seam diagnostic)
+// =================================================================
+// Developed 2026-08-13 while re-cracking Netflix ATV ad delivery after Netflix migrated from the
+// old metadata.ads[] manifest-pod model to DYNAMIC server-side ad insertion. The base ADPROBE
+// (docs/ADPROBE_DIAGNOSTIC.md) had a NATIVE front-end (Prime Video memcpy GOT hook) and Java
+// front-ends (Pluto/Tubi/etc.) but only "recon-stage" notes for Netflix. This is the actual
+// Netflix front-end: a QuickJS/Gibbon HEAP TAP. It is app-agnostic for any app whose ad logic
+// runs in a JS VM whose source/data strings are resident in readable (rw-) memory.
+//
+// It is a DIAGNOSTIC, never a patch: it only reads and logs. Load it in the same in-process
+// gadget you use for patching; call adProbe(Process.enumerateRanges('rw-')) on a timer.
+//
+// WHAT MAKES THIS REUSABLE (the "app analysis" improvements over the base scanner):
+//  1. KEYWORD TABLE with per-key context window: {k, w, b} — k=needle, w=bytes of context to
+//     dump, b=bytes-before to include. w:0 => count-only (cheap presence signal, no dump).
+//     Retarget to a new app by swapping the table; the scan/dump logic is unchanged.
+//  2. RESIDENCY CLASSIFICATION (code vs data): scan for CODE forms (`==="ad"`, `.initialSegment`,
+//     `fn=function`) alongside DATA forms (`"type":"ad"`). If the CODE forms come back with real
+//     minified-function context, the builder/consumer is source-resident => patchable in-process.
+//     If only JSON data appears, the logic is compiled-away => a source-scan patch is impossible
+//     (this is exactly how we proved Netflix's old patch-A anchor was dead and the new playgraph
+//     builder was alive).
+//  3. SEAM-LOCK: once a mechanism is found, narrow the table to the CONSUMER that branches on the
+//     ad discriminator (e.g. isAd getter, SegmentType.ad) to find the exact reroute/kill point,
+//     then to the UPSTREAM SOURCE all consumers share (e.g. Netflix `adverts.adBreaks`) — the
+//     single edit that closes every downstream path at once.
+//  4. LIVE-CAPTURE discipline: on chatty devices the logcat ring buffer rolls fast (Widevine spam
+//     on Netflix), so `logcat -d` misses hits. Capture with a live `timeout N adb logcat` window
+//     during the actual ad break, and use w:0 count keys to confirm "0 ad segments" post-patch.
+//
+// NETFLIX RESULT (for reference): this tap traced all ad-break stitchers (applyDaiPrefetch,
+// mergeReplacedAds, enrichAds, the VOD StatefulAdBreak map) to ONE upstream source — the
+// manifest->adverts normaliser `T.adverts=...{adBreaks:(...?void 0:ba.map(...normalize...))}` —
+// which the shipped fix empties (`ba.map` -> `[].map`). See NOTICE + the Netflix memory notes.
+
+function makeAdProbe(log){
+  var L = log || function(m){ /* wire to your logger */ };
+  function pat(s){ return s.split('').map(function(c){return ('0'+c.charCodeAt(0).toString(16)).slice(-2);}).join(' '); }
+
+  // Default table = the Netflix ad-delivery keyword set. SWAP THIS for a new target app.
+  // {k: needle, w: context-window bytes (0 = count-only), b: bytes-before to include}
+  var KEYS = [
+    // delivery-model discriminators
+    {k:'"ads":[{', w:200, b:24},                                 // legacy manifest ad-pod array
+    {k:'adInsertionType', w:220, b:120},                         // dynamic(DAI) vs static/manifest
+    {k:':ad-0-', w:0, b:0},                                      // stitched ad-segment presence (count)
+    {k:'"type":"ad"', w:0, b:0},                                 // playgraph ad segment (count)
+    // decisioning
+    {k:'clcsInterstitialPlaybackAndPostPlayback', w:200, b:20},  // CLCS interstitial op (UI, not scheduler)
+    // upstream source + stitchers (source-residency + seam-lock)
+    {k:':ba.map(function(a,b){var c=ea.normalize', w:360, b:60}, // adverts.adBreaks normaliser (the source)
+    {k:'return e&&0!==e.size?a.map', w:340, b:60},               // applyDaiPrefetch guard
+    {k:'enrichAds=function', w:420, b:20},
+    {k:'mergeReplacedAds', w:420, b:40}
+  ];
+
+  var seen = {}, pass = 0;
+  function adProbe(rs, keys){
+    var table = keys || KEYS; pass++; var tot = {};
+    for (var pi=0; pi<table.length; pi++){ var K=table[pi]; if(!K.k) continue; var p=pat(K.k);
+      for (var i=0;i<rs.length;i++){ var r=rs[i]; if(r.size>128*1024*1024) continue;
+        try{ var h=Memory.scanSync(r.base,r.size,p);
+          if(h.length) tot[K.k]=(tot[K.k]||0)+h.length;
+          for(var j=0;j<h.length&&j<3;j++){ var key=K.k+'@'+h[j].address; if(seen[key]) continue; seen[key]=1;
+            if(K.w>0){ var s=null; try{ s=h[j].address.sub(K.b).readCString(K.w); }catch(e){}
+              if(s){ s=s.replace(/[^\x20-\x7e]/g,'.'); L('ADPROBE ['+K.k+'] @'+h[j].address+' :: '+s); } }
+          }
+        }catch(e){}
+      }
+    }
+    var names = Object.keys(tot);
+    L('ADPROBE pass'+pass+' counts='+(names.length?JSON.stringify(tot):'{}'));
+  }
+
+  return { adProbe: adProbe, KEYS: KEYS, pat: pat };
+}
+
+// Node/CommonJS export for host tests; harmless in the Frida gadget (module undefined -> skipped).
+if (typeof module !== 'undefined' && module.exports) module.exports = { makeAdProbe: makeAdProbe };

--- a/patches/src/main/resources/netflix/native/killads.js
+++ b/patches/src/main/resources/netflix/native/killads.js
@@ -1,9 +1,12 @@
 'use strict';
 // Netflix ad-kill (self-contained, single-shot each, NO re-patch loop) + read-only monitor.
-//  (A) manifest pre/mid-roll: AdsState.prepareAdBreakStates -> stamp __adkill, empty metadata.ads=[]
-//  (B) pause overlay: z() saga -> force f=e.displayAd to void 0 -> no ad opportunity
-//  MONITOR (read-only): KILLMARK(__adkill)/rawRealPods = manifest ad kills; rawDisplayAd = server
-//  pause ad delivered; BOOKMARK = distinct resume positions seen (confirms resume/bookmark intact).
+//  (A)   manifest pre/mid-roll (legacy model): AdsState hydration -> empty metadata.ads=[]
+//  (ADV) dynamic ad-insertion master kill: empty adverts.adBreaks at its single manifest source
+//  (DAI) dynamic ad-insertion belt: applyDaiPrefetch returns content unchanged when ads present
+//  (B)   pause overlay: z() saga -> force f=e.displayAd to void 0 -> no ad opportunity
+//  (FP/GAID) privacy opt-ins (default OFF); (HH/MHU) household-prompt opt-in (default OFF)
+//  MONITOR (read-only): KILLMARK(__adkill)/rawRealPods = legacy manifest ad kills; rawDisplayAd =
+//  server pause ad delivered; BOOKMARK = distinct resume positions seen (resume/bookmark intact).
 var logw = new NativeFunction(Module.findGlobalExportByName('__android_log_write'),
   'int', ['int', 'pointer', 'pointer']);
 var TAG = Memory.allocUtf8String('KILL');
@@ -11,7 +14,9 @@ function L(m){ logw(6, TAG, Memory.allocUtf8String(m)); }
 function pat(s){ return s.split('').map(function(c){return ('0'+c.charCodeAt(0).toString(16)).slice(-2);}).join(' '); }
 function bytesOf(s){ var b=[]; for (var i=0;i<s.length;i++) b.push(s.charCodeAt(i)); return b; }
 
-// ---------- (A) manifest patch ----------
+// ---------- (A) manifest patch — legacy metadata.ads[] pod model ----------
+// Kept for anyone still served the old model. Newer appboots deliver dynamic ads (see ADV/DAI);
+// on those this anchor simply isn't present and patchA no-ops harmlessly.
 var A_OLD='var f=e.value;f.syncAdStates();f.state.isHydrated&&"viewable"!==f.metadata.source&&f.applyHydration(f.state.hydrationSequenceId)';
 var A_NEW='var f=e.value;f.metadata&&(f.metadata.ads.length&&(f.__adkill=f.metadata.ads.length),f.metadata.ads=[]);f.syncAdStates();/*...*/';
 var aDone=false;
@@ -19,6 +24,39 @@ function patchA(rs){ if(aDone)return; if(A_NEW.length!==A_OLD.length){L('A lengt
   var p=pat(A_OLD);
   for(var i=0;i<rs.length;i++){var r=rs[i];if(r.size>128*1024*1024)continue;
     try{var h=Memory.scanSync(r.base,r.size,p);for(var j=0;j<h.length;j++){Memory.protect(h[j].address,A_NEW.length,'rw-');h[j].address.writeByteArray(bytesOf(A_NEW));aDone=true;L('PATCH A: prepareAdBreakStates @'+h[j].address);}}catch(e){}}
+}
+// ---------- (ADV) empty adverts.adBreaks at its single source — the master ad kill ----------
+// Netflix migrated clone ads to DYNAMIC server-side insertion — ad videos stitched as separate
+// "playgraph" viewables (type:"ad", s0:ad-0-x -> padend -> content). ALL ad-break stitchers
+// (applyDaiPrefetch, mergeReplacedAds, enrichAds, the VOD StatefulAdBreak map) read ONE upstream
+// source: the manifest->adverts normaliser builds
+//   T.adverts=__assign(__assign({},T.manifest.adverts),{adBreaks:(null===(ba=T.manifest.adverts.
+//     adBreaks)||void 0===ba ? void 0 : ba.map(function(a,b){var c=ea.normalize(a.location...)})) })
+// Change `ba.map` -> `[].map` (2 bytes, length-preserving): when ads ARE present this yields an
+// EMPTY array, so every downstream `.adverts.adBreaks.length` is 0 and the ad-break orchestrator
+// hits its `else return` (no StatefulAdBreaks built, enrichers get nothing) — one edit closes all
+// ad paths at the source. The no-ads branch (ternary `void 0`) is untouched -> no crash on ad-free
+// content. On-device verified (v13.0.1): pre-roll + mid-roll gone across movies, no crash.
+var ADV_ANCHOR=':ba.map(function(a,b){var c=ea.normalize';  // unique source site
+var ADV_OFF=1, ADV_EXP='ba';
+var advDone=false;
+function patchADV(rs){ if(advDone)return; var p=pat(ADV_ANCHOR);
+  for(var i=0;i<rs.length;i++){var r=rs[i];if(r.size>128*1024*1024)continue;
+    try{var h=Memory.scanSync(r.base,r.size,p);for(var j=0;j<h.length;j++){var t=h[j].address.add(ADV_OFF);var cur=null;try{cur=t.readCString(2);}catch(e){}if(cur!==ADV_EXP)continue;Memory.protect(t,2,'rw-');t.writeByteArray([0x5b,0x5d]);advDone=true;L('PATCH ADV: adverts.adBreaks source ba.map->[].map (empty all ad breaks) @'+t);}}catch(e){}}
+}
+// ---------- (DAI) dynamic ad-insertion bypass — belt-and-suspenders alongside ADV ----------
+//   a.prototype.applyDaiPrefetch=function(a,b){ b=this.getDaiPrefetcher(b);
+//     var e=(b==null)?void 0:b.getAds();
+//     return e&&0!==e.size ? a.map(function(a){...map break->ad if adBreakTriggerId in e...}) : a }
+// `a` = the content breaks; the map INSERTS the prefetched DAI ads. Flipping the guard
+// `0!==e.size` -> `0===e.size` (one byte, `!`->`=`) makes it return `a` UNCHANGED whenever ads
+// ARE present -> no DAI ads stitched. Length-preserving, verify-before-write.
+var DAI_ANCHOR='return e&&0!==e.size?a.map';   // '!' at index 11 (return e&&0[!]==e.size...)
+var DAI_OFF=11, DAI_EXP='!';
+var daiDone=false;
+function patchDAI(rs){ if(daiDone)return; var p=pat(DAI_ANCHOR);
+  for(var i=0;i<rs.length;i++){var r=rs[i];if(r.size>128*1024*1024)continue;
+    try{var h=Memory.scanSync(r.base,r.size,p);for(var j=0;j<h.length;j++){var t=h[j].address.add(DAI_OFF);var cur=null;try{cur=t.readCString(1);}catch(e){}if(cur!==DAI_EXP)continue;Memory.protect(t,1,'rw-');t.writeByteArray([0x3d]);daiDone=true;L('PATCH DAI: applyDaiPrefetch 0!==->0=== (bypass DAI ad stitch) @'+t);}}catch(e){}}
 }
 // ---------- (B) pause patch ----------
 var B_ANCHOR='void 0:e.displayAd',B_OLD='e.displayAd',B_NEW='void 0     ';
@@ -62,45 +100,106 @@ function patchGAID(rs){ if(gaidDone||!GAID_ENABLED)return; if(GAID_NEW.length!==
   for(var i=0;i<rs.length;i++){var r=rs[i];if(r.size>128*1024*1024)continue;
     try{var h=Memory.scanSync(r.base,r.size,p);for(var j=0;j<h.length;j++){var t=h[j].address.add(GAID_OFF);var cur=null;try{cur=t.readCString(GAID_OLD.length);}catch(e){}if(cur!==GAID_OLD)continue;Memory.protect(t,GAID_NEW.length,'rw-');t.writeByteArray(bytesOf(GAID_NEW));gaidDone=true;L('PATCH GAID: e.advertisingId->void0 @'+t);}}catch(e){}}
 }
-// ---------- (HH) household / "traveling" misdetection prompt suppression (OPT-IN; default OFF) ----------
-// The account-sharing redux-saga stores the server's misdetection challenge, then
-// dispatches  put(setAccountSharingFlags({isActiveMisdetectionSession:!0}))  to ACTIVATE
-// the household challenge session. Traced downstream: misdetectionAvailable =
-// ("ready"===status) && isActiveMisdetectionSession, and the challenge-action callback
-// guards on the same flag (p&&…) — so this ONE flag is the operative gate, set true in
-// exactly one place. Forcing the dispatched value !0 -> !1 (one byte) means the app
-// still RECEIVES the challenge but never ACTIVATES the session -> the full-screen
-// household/"you're traveling" prompt is not shown.
-// HONEST SCOPE: this only suppresses the CLIENT-side prompt; it changes nothing the
-// Netflix servers see (household detection is public-IP driven, server-side). Its own
-// opt-in Morphe patch flips HH_ENABLED to true.
-// CREDIT: household-enforcement seam identified with reference to Nikflix
-// (github.com/YidirK/Nikflix, GPL-3.0). No code shared — independent native-app
-// implementation, different mechanism. See NOTICE.
+// ---------- (HH) household / "traveling" misdetection + ownership prompt suppression (OPT-IN) ----------
+// Default OFF; the "Suppress Household Prompt" Morphe patch flips HH_ENABLED to true.
+// The account-sharing redux-saga stores the server's misdetection challenge, then dispatches
+//   put(setAccountSharingFlags({isActiveMisdetectionSession:!0}))  to ACTIVATE the challenge.
+// The consumer hook computes  "ready"===status && (y=f, w=h)  ->  {misdetectionAvailable:y,
+// netflixHouseholdAvailable:w}, where f=isActiveMisdetectionSession ("you're traveling") and
+// h=isNetflixHouseholdAvailable ("This is my account / Create an account" ownership screen — a
+// SEPARATE gate). We flip BOTH dispatch flags !0 -> !1 (WRITE side) AND force the render outputs
+// f/h -> 0 (READ side); all length-preserving 1-byte edits. On a fresh launch these land (+~11s)
+// before the gate materialises (~+30s) so the app proceeds with no prompt.
+// HONEST SCOPE: client-side prompt suppression only; household detection is server-side/public-IP.
+// CREDIT: CLCS-interstitial enforcement seam identified with reference to Nikflix
+// (github.com/YidirK/Nikflix, GPL-3.0) — author YidirK and API-block contributor Buckibarnes17
+// (github.com/Buckibarnes17), credited in the Nikflix v2.0.1 release notes. No code shared —
+// independent native-app implementation (appboot-heap byte edit, not fetch/XHR override). See NOTICE.
 var HH_ENABLED=false;
-var HH_ANCH='setAccountSharingFlags)({isActiveMisdetectionSession:!0';
-var HH_OFF=HH_ANCH.length-1;   // offset of the final '0' in '!0'
-var HH_OLD='0',HH_NEW='1';
-var hhDone=false;
+var HH_ANCHORS=[
+  {a:'setAccountSharingFlags)({isActiveMisdetectionSession:!0', chr:'0', to:'1', lbl:'flag:isActiveMisdetectionSession'},
+  {a:'setAccountSharingFlags)({isNetflixHouseholdAvailable:!0', chr:'0', to:'1', lbl:'flag:isNetflixHouseholdAvailable'},
+  {a:'(y=null!=f&&f,', off:12, chr:'f', to:'0', lbl:'render:misdetectionAvailable(y)'},
+  {a:'w=null!=h&&h)',  off:11, chr:'h', to:'0', lbl:'render:netflixHouseholdAvailable(w)'}
+];
+var hhFlipped={},hhDone=false;
 function patchHH(rs){ if(hhDone||!HH_ENABLED)return;
-  var p=pat(HH_ANCH);
-  for(var i=0;i<rs.length;i++){var r=rs[i];if(r.size>128*1024*1024)continue;
-    try{var h=Memory.scanSync(r.base,r.size,p);for(var j=0;j<h.length;j++){var t=h[j].address.add(HH_OFF);var cur=null;try{cur=t.readCString(1);}catch(e){}if(cur!==HH_OLD)continue;Memory.protect(t,1,'rw-');t.writeByteArray(bytesOf(HH_NEW));hhDone=true;L('PATCH HH: isActiveMisdetectionSession !0->!1 @'+t);}}catch(e){}}
+  for(var ai=0;ai<HH_ANCHORS.length;ai++){ var AN=HH_ANCHORS[ai]; if(hhFlipped[AN.lbl])continue;
+    var p=pat(AN.a),off=(AN.off!=null?AN.off:AN.a.length-1),exp=(AN.chr||'0'),nb=(AN.to||'1').charCodeAt(0);
+    for(var i=0;i<rs.length;i++){var r=rs[i];if(r.size>128*1024*1024)continue;
+      try{var h=Memory.scanSync(r.base,r.size,p);for(var j=0;j<h.length;j++){var t=h[j].address.add(off);var cur=null;try{cur=t.readCString(1);}catch(e){}if(cur!==exp)continue;Memory.protect(t,1,'rw-');t.writeByteArray([nb]);hhFlipped[AN.lbl]=true;L('PATCH HH: '+AN.lbl+' '+exp+'->'+(AN.to||'1')+' @'+t);}}catch(e){}}
+  }
+  // Completion = the household READ gate flipped (the operative gate for the ownership screen).
+  if(hhFlipped['render:netflixHouseholdAvailable(w)'])hhDone=true;
 }
+// Aggressive early HH patcher: the appboot source materialises ~20-30s in. This tight 100ms loop
+// (no gibbon gate, no initial delay) flips the anchors + neuters the MHU screens the instant they
+// appear, to win the parse race by minimising scan latency.
+var _fastHHn=0;
+function fastHH(){ if(!HH_ENABLED||hhDone)return; _fastHHn++;
+  try{ var _r=Process.enumerateRanges('rw-'); patchHH(_r); neuterMhuRenders(_r); }catch(e){}
+  if(hhDone){ L('fastHH: all HH anchors flipped by pass '+_fastHHn); return; }
+  if(_fastHHn<450) setTimeout(fastHH, 100);   // ~45s of tight scanning
+}
+// ---------- (MHU) household-screen render neuter — belt-and-suspenders (follows HH opt-in) ----------
+// LAYER 2 of household suppression. LAYER 1 (HH_ANCHORS/fastHH) neuters the DECISION so the app
+// PROCEEDS — the actual fix. This layer is a fallback: if the decision flip loses the ~30s race,
+// null the household screens' render() so the prompt shows BLANK instead of the ownership UI.
+// Each CLCS screen is registered as <PATTERN>,render:function(e){<DECLS>\nreturn(0,u.j)(...)}; we
+// overwrite <DECLS> (just after '{' up to the first newline) with 'return null;' + spaces, leaving
+// the original '\nreturn(...)' as valid unreachable code -> render() returns null, module parses.
+// Newline located at RUNTIME (resilient across the household screens). Household (Mhu*) patterns
+// only — the profile picker ("who's watching") is a different, non-Mhu screen and is never touched.
+var MHU_ENABLED=HH_ENABLED;   // ships with the "Suppress Household Prompt" opt-in (flips HH_ENABLED).
+var MHU_PATS=[
+  'MHU_RESOLUTION_LANDING','MHU_MANAGE_HOUSEHOLD',
+  'MHU_SET_PRIMARY_HOUSEHOLD_CONTEXT','MHU_SET_PRIMARY_HOUSEHOLD_EMAIL_CONFIRM',
+  'MHU_SET_PRIMARY_HOUSEHOLD_TEXT_CONFIRM','MHU_SET_PRIMARY_HOUSEHOLD_VERIFY',
+  'MHU_SET_PRIMARY_HOUSEHOLD_LATER','MHU_SET_PRIMARY_HOUSEHOLD_SUCCESS',
+  'MHU_CREATE_ACCOUNT_PARTNER','MHU_CREATE_ACCOUNT_RENDEZVOUS_CONTEXT',
+  'MHU_CREATE_ACCOUNT_RENDEZVOUS_EMAIL','MHU_CREATE_ACCOUNT_RENDEZVOUS_EMAIL_CONFIRM',
+  'MHU_CREATE_ACCOUNT_RENDEZVOUS_PHONE','MHU_CREATE_ACCOUNT_RENDEZVOUS_PHONE_CONFIRM',
+  'MHU_VERIFY_TRAVEL','MHU_CHALLENGE_ERROR'
+];
+var MHU_PREFIX='return null;';        // 12 bytes; padded with spaces to the decls length
+var mhuDoneSet={}, mhuHits=0;
+function neuterMhuRenders(rs){ if(!MHU_ENABLED)return;
+  for(var pi=0;pi<MHU_PATS.length;pi++){ var nm=MHU_PATS[pi]; if(mhuDoneSet[nm])continue;
+    var anchor=nm+',render:function(e){', p=pat(anchor);
+    for(var i=0;i<rs.length;i++){var r=rs[i];if(r.size>128*1024*1024)continue;
+      try{var h=Memory.scanSync(r.base,r.size,p);
+        for(var j=0;j<h.length;j++){
+          var body=h[j].address.add(anchor.length);          // first byte after '{'
+          var head=null; try{head=body.readCString(4);}catch(e){}
+          if(head==='retu'){ mhuDoneSet[nm]=true; continue; } // already neutered
+          if(head!=='var '){ continue; }                      // unexpected layout — abort this hit
+          var bytes=null; try{bytes=body.readByteArray(400);}catch(e){continue;}
+          var u8=new Uint8Array(bytes), nlIdx=-1;
+          for(var k=0;k<u8.length;k++){ if(u8[k]===0x0a){ nlIdx=k; break; } }
+          if(nlIdx<MHU_PREFIX.length){ continue; }            // no newline in range / decls too short
+          var repl=MHU_PREFIX; while(repl.length<nlIdx) repl+=' ';
+          Memory.protect(body,nlIdx,'rw-'); body.writeByteArray(bytesOf(repl));
+          mhuDoneSet[nm]=true; mhuHits++;
+          L('PATCH MHU: '+nm+' render->null ('+nlIdx+'B decls) @'+body);
+        }
+      }catch(e){}
+    }
+  }
+}
+
 var tries=0;
 function apply(){ tries++; var rs=Process.enumerateRanges('rw-');
   var loaded=false,gp=pat('nrdp.gibbon');
   for(var i=0;i<rs.length&&!loaded;i++){if(rs[i].size>128*1024*1024)continue;try{if(Memory.scanSync(rs[i].base,rs[i].size,gp).length)loaded=true;}catch(e){}}
-  if(loaded){patchA(rs);patchB(rs);patchFP(rs);patchGAID(rs);patchHH(rs);}
-  // Keep polling until applied. prepareAdBreakStates (A) can load LATER than the
-  // pause module (B) — sometimes only once the ad code is exercised — so we must
-  // NOT give up early or a real ad slips through. WRITE-ONCE (aDone/bDone/fpDone
-  // guards) — not a re-patch loop. FP is only required when enabled.
+  if(loaded){patchA(rs);patchADV(rs);patchDAI(rs);patchB(rs);patchFP(rs);patchGAID(rs);patchHH(rs);neuterMhuRenders(rs);}
+  // Keep polling until applied. The ad-insertion source (ADV/DAI) and prepareAdBreakStates (A)
+  // can load LATER than the pause module (B) — sometimes only once playback is exercised — so we
+  // must NOT give up early. WRITE-ONCE per patch (done guards) — not a re-patch loop.
   var fpOk=(!FP_ENABLED||fpDone);
   var gaidOk=(!GAID_ENABLED||gaidDone);
   var hhOk=(!HH_ENABLED||hhDone);
-  if(aDone&&bDone&&fpOk&&gaidOk&&hhOk){ L('apply DONE: A='+aDone+' B='+bDone+' FP='+(FP_ENABLED?fpDone:'off')+' GAID='+(GAID_ENABLED?gaidDone:'off')+' HH='+(HH_ENABLED?hhDone:'off')+' tries='+tries); return; }
-  if(tries%15===0) L('apply waiting: A='+aDone+' B='+bDone+' FP='+(FP_ENABLED?fpDone:'off')+' GAID='+(GAID_ENABLED?gaidDone:'off')+' HH='+(HH_ENABLED?hhDone:'off')+' tries='+tries);
+  if(aDone&&bDone&&fpOk&&gaidOk&&hhOk){ L('apply DONE: A='+aDone+' ADV='+advDone+' DAI='+daiDone+' B='+bDone+' FP='+(FP_ENABLED?fpDone:'off')+' GAID='+(GAID_ENABLED?gaidDone:'off')+' HH='+(HH_ENABLED?hhDone:'off')+' tries='+tries); return; }
+  if(tries%15===0) L('apply waiting: A='+aDone+' ADV='+advDone+' DAI='+daiDone+' B='+bDone+' HH='+(HH_ENABLED?hhDone:'off')+' tries='+tries);
   if(tries<3600) setTimeout(apply, 2000);   // up to ~2h of find-and-apply polling
 }
 
@@ -121,6 +220,7 @@ function observe(){ cyc++;
   if(cyc<560) setTimeout(observe,3000);   // ~28 min coverage
 }
 
-L('killads ready (A manifest + B pause, single-shot; ad+resume monitor)');
+L('killads ready (A/ADV/DAI ad-kill + B pause, single-shot; ad+resume monitor)');
 setTimeout(apply,5000);
 setTimeout(observe,9000);
+if(HH_ENABLED){ L('fastHH armed (household prompt suppression, early race-win scanner)'); setTimeout(fastHH,200); }


### PR DESCRIPTION
## Why

Netflix migrated the clone's ads from the legacy `metadata.ads[]` manifest-pod model (the target of the old in-process patch) to **dynamic server-side ad insertion**, delivered as downloaded appboot JS — so no app-version bump, and ads quietly returned for everyone using the Netflix ad patch. This rebuilds the strip against the new pipeline and, in the same file, completes the opt-in household-prompt suppression.

## How the new ad pipeline works (traced on-device with a read-only JS-VM heap tap)

Ad videos are now stitched as `type:"ad"` "playgraph" viewables (`s0:ad-0-x → padend → content`), decisioned via a `clcsInterstitialPlaybackAndPostPlayback` GraphQL op (which turned out to be **UI only**, not the scheduler). Every stitcher — `applyDaiPrefetch`, `mergeReplacedAds`, `enrichAds`, the VOD `StatefulAdBreak` map — reads **one upstream source**: the manifest→adverts normaliser that builds `adverts.adBreaks`.

## Changes

**Ad-strip** (`killads.js`, always-on with "Remove Netflix ads"):
- **ADV** — empty `adverts.adBreaks` at its single normaliser source (`ba.map` → `[].map`, 2 bytes, length-preserving). Closes all downstream stitchers at once; the ad-break orchestrator hits its own `else return`. The no-ads branch is untouched → no crash on ad-free content.
- **DAI** — flip the `applyDaiPrefetch` guard (`0!==` → `0===`) as belt-and-suspenders.
- Keep legacy **patch A** for anyone still served the old manifest-pod model (no-ops harmlessly when its anchor is absent).

**Household** (`SuppressHouseholdPromptPatch` opt-in, default OFF):
- Flip both account-sharing flags + the render gates, and null the `MHU_*` ownership screens. On a fresh launch these land (~+11s) before the gate materialises (~+30s), so the app proceeds with no ownership/"traveling" prompt.

## Verification

On-device (`com.netflix.ninja.clone` v13.0.1, Onn 4K): pre-roll **and** mid-roll gone across many movies and shows (heap ad-segment count 0), household ownership prompt suppressed, no crash/ANR. All diagnostics stripped from the shipped script.

## Credit

The CLCS-interstitial enforcement seam was identified with reference to **Nikflix** (github.com/YidirK/Nikflix) — author **YidirK** and API-block contributor **Buckibarnes17**, credited in the Nikflix v2.0.1 release notes. No code shared; independent native-app implementation. See `NOTICE`.

## Also included

`docs(adprobe)` commit preserves the reusable JS-VM heap-tap diagnostic + methodology under `experimental/netflix-adprobe/` (diagnostic only, not wired into any patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)