### PR TITLE
fix(netflix): re-anchor legacy ad-strip to _syncAdsLength (metadata.ads path)

### DIFF
--- a/patches/src/main/resources/netflix/native/killads.js
+++ b/patches/src/main/resources/netflix/native/killads.js
@@ -58,6 +58,25 @@ function patchDAI(rs){ if(daiDone)return; var p=pat(DAI_ANCHOR);
   for(var i=0;i<rs.length;i++){var r=rs[i];if(r.size>128*1024*1024)continue;
     try{var h=Memory.scanSync(r.base,r.size,p);for(var j=0;j<h.length;j++){var t=h[j].address.add(DAI_OFF);var cur=null;try{cur=t.readCString(1);}catch(e){}if(cur!==DAI_EXP)continue;Memory.protect(t,1,'rw-');t.writeByteArray([0x3d]);daiDone=true;L('PATCH DAI: applyDaiPrefetch 0!==->0=== (bypass DAI ad stitch) @'+t);}}catch(e){}}
 }
+// ---------- (A2) legacy metadata.ads presentation gate (2026-08-14 re-anchor) ----------
+// Netflix moved the legacy pre/mid-roll off the compiled-away prepareAdBreakStates hydration
+// reducer (which killed patch-A's source anchor -> A=false) but the ad DATA still lands in each
+// StatefulAdBreak's `metadata.ads`. The single source-resident gate that turns that data into
+// PRESENTABLE ad objects is `_syncAdsLength` (the `ads` getter delegates to it):
+//   {..e=this._statefulAdBreak;e.syncAdStates();
+//    var f=null!==(b=null===(a=e.metadata.ads)||void 0===a?void 0:a.length)&&void 0!==b?b:0;
+//    this._ads.length=f;for(a=0;a<f;a++)(c=this._ads)[a]||(c[a]=new n.AseAd(e,a,this.config));..}
+// Flipping the read `e.metadata.ads` -> `e.metadata.axs` (nonexistent prop) makes a=undefined ->
+// f=0 -> _ads emptied -> zero AseAd objects instantiated for EVERY break, whatever manifest path
+// populated metadata.ads. Length-preserving (3 bytes), verify-before-write. Covers the leaky
+// legacy titles that bypass adverts.adBreaks (ADV) entirely.
+var A2_ANCHOR='e.metadata.ads)||void 0===a?void 0:a.length)&&void 0!==b?b:0;this._ads.length';
+var A2_OFF=11, A2_EXP='ads';   // 'ads' at index 11 of the anchor (e.metadata.[ads])
+var a2Done=false;
+function patchA2(rs){ if(a2Done)return; var p=pat(A2_ANCHOR);
+  for(var i=0;i<rs.length;i++){var r=rs[i];if(r.size>128*1024*1024)continue;
+    try{var h=Memory.scanSync(r.base,r.size,p);for(var j=0;j<h.length;j++){var t=h[j].address.add(A2_OFF);var cur=null;try{cur=t.readCString(3);}catch(e){}if(cur!==A2_EXP)continue;Memory.protect(t,3,'rw-');t.writeByteArray([0x61,0x78,0x73]);a2Done=true;L('PATCH A2: _syncAdsLength metadata.ads->axs (empty legacy ad pods) @'+t);}}catch(e){}}
+}
 // ---------- (B) pause patch ----------
 var B_ANCHOR='void 0:e.displayAd',B_OLD='e.displayAd',B_NEW='void 0     ';
 var bDone=false;
@@ -191,15 +210,15 @@ var tries=0;
 function apply(){ tries++; var rs=Process.enumerateRanges('rw-');
   var loaded=false,gp=pat('nrdp.gibbon');
   for(var i=0;i<rs.length&&!loaded;i++){if(rs[i].size>128*1024*1024)continue;try{if(Memory.scanSync(rs[i].base,rs[i].size,gp).length)loaded=true;}catch(e){}}
-  if(loaded){patchA(rs);patchADV(rs);patchDAI(rs);patchB(rs);patchFP(rs);patchGAID(rs);patchHH(rs);neuterMhuRenders(rs);}
+  if(loaded){patchA(rs);patchA2(rs);patchADV(rs);patchDAI(rs);patchB(rs);patchFP(rs);patchGAID(rs);patchHH(rs);neuterMhuRenders(rs);}
   // Keep polling until applied. The ad-insertion source (ADV/DAI) and prepareAdBreakStates (A)
   // can load LATER than the pause module (B) — sometimes only once playback is exercised — so we
   // must NOT give up early. WRITE-ONCE per patch (done guards) — not a re-patch loop.
   var fpOk=(!FP_ENABLED||fpDone);
   var gaidOk=(!GAID_ENABLED||gaidDone);
   var hhOk=(!HH_ENABLED||hhDone);
-  if(aDone&&bDone&&fpOk&&gaidOk&&hhOk){ L('apply DONE: A='+aDone+' ADV='+advDone+' DAI='+daiDone+' B='+bDone+' FP='+(FP_ENABLED?fpDone:'off')+' GAID='+(GAID_ENABLED?gaidDone:'off')+' HH='+(HH_ENABLED?hhDone:'off')+' tries='+tries); return; }
-  if(tries%15===0) L('apply waiting: A='+aDone+' ADV='+advDone+' DAI='+daiDone+' B='+bDone+' HH='+(HH_ENABLED?hhDone:'off')+' tries='+tries);
+  if((aDone||a2Done)&&bDone&&fpOk&&gaidOk&&hhOk){ L('apply DONE: A='+aDone+' A2='+a2Done+' ADV='+advDone+' DAI='+daiDone+' B='+bDone+' FP='+(FP_ENABLED?fpDone:'off')+' GAID='+(GAID_ENABLED?gaidDone:'off')+' HH='+(HH_ENABLED?hhDone:'off')+' tries='+tries); return; }
+  if(tries%15===0) L('apply waiting: A='+aDone+' A2='+a2Done+' ADV='+advDone+' DAI='+daiDone+' B='+bDone+' HH='+(HH_ENABLED?hhDone:'off')+' tries='+tries);
   if(tries<3600) setTimeout(apply, 2000);   // up to ~2h of find-and-apply polling
 }
 


### PR DESCRIPTION
## Why

Netflix ads came back on a **subset of titles** with **no app-version bump** (byte-identical APK to the v1.26.0 build verified ad-free the day before). The read-only monitor in `killads.js` told the story:

- `apply waiting: A=false ADV=true DAI=true B=true HH=true` — patchADV/DAI/B/HH all apply; only **patch A is absent** (`A=false`).
- `OBS: rawRealPods 1→3→9, KILLMARK=0` — the legacy `ads":[{` manifest pods are resident and multiplying, unkilled.

Netflix moved the legacy pre/mid-roll **off** the `prepareAdBreakStates` hydration reducer that patch A rewrote — that function is now **compiled to bytecode** (only its interned name survives in the atom table), so patch A's source-scan anchor no longer exists. Meanwhile the **dynamic** `adverts.adBreaks` path is still emptied cleanly by patchADV, so the leaky titles ride the per-`StatefulAdBreak` **`metadata.ads`** path that bypasses ADV entirely.

## How

Re-anchored with the JS-VM heap tap (`experimental/netflix-adprobe/adprobe-jsvm-tap.js`). Residency classification showed the hydration reducer is compiled away, but the **consumer** layer is source-resident. The single gate that turns `metadata.ads` data into presentable `AseAd` objects is **`_syncAdsLength`** (the `ads` getter delegates to it):

```js
{..e=this._statefulAdBreak;e.syncAdStates();
 var f=null!==(b=null===(a=e.metadata.ads)||void 0===a?void 0:a.length)&&void 0!==b?b:0;
 this._ads.length=f;for(a=0;a<f;a++)(c=this._ads)[a]||(c[a]=new n.AseAd(e,a,this.config));..}
```

New **patchA2** flips the read `e.metadata.ads` → `e.metadata.axs` (nonexistent prop) → `a=undefined` → `f=0` → `_ads` emptied → **zero `AseAd` instantiated for every break**, whatever manifest path populated `metadata.ads`. Length-preserving 3-byte flip, verify-before-write, modeled on patchADV/patchDAI. Legacy patch A kept (harmless no-op when its dead anchor is absent). The apply-DONE gate now accepts A2 so the find-and-apply loop terminates instead of polling ~2h.

## Verified on-device

Onn 4K (`com.netflix.ninja.clone` v13.0.1):
- `PATCH A2: _syncAdsLength metadata.ads->axs @0x375e9443` — applies.
- `apply DONE: A=false A2=true ADV=true DAI=true B=true HH=true tries=2`.
- `rawRealPods 3 → 0 → 0 → 0 → 0` across the previously-leaky titles.
- Pre-roll and mid-roll gone; **playback smooth, no stall**; ad-free titles unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)