### PR TITLE
docs(netflix): note ad delivery is downloaded JS (moving target)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ All patches follow the same general workflow using **Morphe Manager**:
 > the app runs itself at launch (no PC, no root, no frida server). Verified
 > on-device: Netflix's servers still deliver real ad breaks and none of them play.
 >
+> ℹ️ **Netflix's ad logic is downloaded JavaScript, not baked into the APK.** That
+> means Netflix can change how ads are delivered server-side at any time, with no
+> app update — so an ad can occasionally reappear until the in-app strip is
+> re-pointed at the new delivery path. The strip already covers several such paths
+> (dynamic server-side insertion **and** the legacy manifest model) and is kept
+> updated to match. If you ever see an ad, first make sure you're on the latest
+> patch; if it persists, please open an issue.
+>
 > 🔐 **Two apps, on purpose — keep BOTH installed.** Netflix on a TV is a
 > preinstalled, Netflix-signed **system app** that can't be replaced or uninstalled
 > without root, so the patch installs as a **separate clone**


### PR DESCRIPTION
Small reader-facing note under the Netflix section: Netflix's ad logic is **downloaded JavaScript**, not baked into the APK, so Netflix can re-architect ad delivery **server-side with no app update**. We've now seen this twice — 2026-08-13 (migration to dynamic server-side ad insertion) and 2026-08-14 (a subset of titles reverting to the legacy `metadata.ads` path, [PR #105](https://github.com/ajstrick81/morphe-androidtv-patches/pull/105)).

The note sets the right expectation: an ad can occasionally reappear until the in-app strip is re-pointed; the strip covers several delivery paths and is kept updated; check for the latest patch and file an issue if it persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)