### PR TITLE
fix(twitchatv): strip client-side ad-pod tags so the "Ad 1 of 3" break is gone

### DIFF
--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/twitchatv/ads/TwitchAtvWebViewHelper.java
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/twitchatv/ads/TwitchAtvWebViewHelper.java
@@ -225,10 +225,32 @@ public final class TwitchAtvWebViewHelper {
     }
 
     /**
-     * Keeps the playlist intact (headers, dateranges, per-segment tags) but
-     * rewrites each ad segment's URI (the URI following an #EXTINF whose title is
-     * not "live") to a per-segment sentinel we serve a black TS for. This keeps
-     * the timeline advancing so the ad completes server-side and content resumes.
+     * True for the client-side ad-pod {@code #EXT-X-DATERANGE} lines — the ones
+     * carrying {@code X-TV-TWITCH-AD-*} / {@code X-TTV-MAF-AD-*} attributes, or the
+     * {@code CLASS="twitch-stitched-ad"} marker. On-device diagnosis (2026-08-14)
+     * showed a real ATV preroll ships a full client-side pod inline in the weaver
+     * playlist (ROLL-TYPE, POD-LENGTH, CREATIVE-ID, RADS-TOKEN, ad-decision URL,
+     * verification/tracking beacons). We already blank the stitched VIDEO segments,
+     * but Twitch's in-WebView ad coordinator still reads these tags and runs the
+     * "Ad · 1 of 3" pod overlay/gate — so ads still "play" (a black wait). Stripping
+     * these metadata lines removes the signal the coordinator acts on. The benign
+     * dateranges ({@code twitch-stream-source}, {@code twitch-trigger},
+     * {@code twitch-session}, {@code timestamp}) are left untouched.
+     */
+    private static boolean isAdDaterange(String trimmed) {
+        return trimmed.startsWith("#EXT-X-DATERANGE")
+            && (trimmed.contains("X-TV-TWITCH-AD")
+                || trimmed.contains("X-TTV-MAF-AD")
+                || trimmed.contains("twitch-stitched-ad"));
+    }
+
+    /**
+     * Keeps the playlist intact (headers, benign dateranges, per-segment tags) but
+     * (a) rewrites each ad segment's URI (the URI following an #EXTINF whose title is
+     * not "live") to a per-segment sentinel we serve a black TS for — keeping the
+     * timeline advancing so the ad completes server-side and content resumes — and
+     * (b) strips the client-side ad-pod dateranges ({@link #isAdDaterange}) so the
+     * WebView's ad coordinator has no {@code X-TV-TWITCH-AD-*} pod to gate on.
      */
     static String blankAdSegments(String playlist) {
         String[] lines = playlist.split("\n", -1);
@@ -239,6 +261,10 @@ public final class TwitchAtvWebViewHelper {
 
         for (String line : lines) {
             String t = line.trim();
+            if (isAdDaterange(t)) {
+                // Drop the client-side ad-pod signal entirely (see isAdDaterange).
+                continue;
+            }
             if (t.startsWith("#EXT-X-DISCONTINUITY")) {
                 // Break boundary — Twitch stitches the pod as one continuous
                 // timeline after this tag, so restart the blank timeline here.


### PR DESCRIPTION
## What

Twitch Android-TV (Starshot WebView, `tv.twitch.android.app` v13.0.0.2) live ad breaks were still presenting as an "Ad · 1 of 3" black wait even though the scrubber was blanking the SSAI ad video. This strips the client-side ad-pod signal so the break is no longer gated as an ad.

## Why

On-device diagnosis of a real preroll (Onn 4K) found the weaver playlist carries a **full client-side ad pod inline** via `#EXT-X-DATERANGE`:
`X-TV-TWITCH-AD-ROLL-TYPE`, `POD-LENGTH`, `POD-FILLED-DURATION`, `CREATIVE-ID`, `RADS-TOKEN`, an `adclick.g.doubleclick.net` decision URL, plus amazon-adsystem tracking/verification beacons. The old scrubber blanked the SSAI *segments* but left these tags in place, so Twitch's in-WebView ad coordinator still ran the "Ad · 1 of 3" pod overlay and gated the timeline through the break.

A full probe capture confirmed this is the **only** ad path on ATV (no MAF / `edge.ads.twitch.tv` / audio / display / PbYP / LL-HLS parts), so stripping it covers the whole observed surface.

## Change

`blankAdSegments` now drops any `#EXT-X-DATERANGE` line carrying `X-TV-TWITCH-AD` / `X-TTV-MAF-AD` / `twitch-stitched-ad` (`isAdDaterange`), while keeping the benign dateranges (`twitch-stream-source` / `-trigger` / `-session` / `timestamp`) and still blanking the SSAI segments. +30/-4, one file.

## Verification

- **End-to-end on-device:** real Rainbow6 preroll → scrubber blanked 52×, screen black with **no "Ad · 1 of 3" overlay, no countdown, no "Ad" badge** (vs. pre-patch which showed all of them) → content resumed clean, no stall.
- **Deterministic transform test:** 12/12 (tags stripped, benign dateranges kept, ad segments blanked, discontinuities/timeline intact).

## Known limitation

The brief **black gap** during the blanked window remains — that's the live-SSAI ceiling. A re-probe of the `usher` `player_type=pulsar→embed` lever confirmed usher *accepts* the spoof but ads still stitch, because the decision follows the **signed GQL access token** (POST body), which Android `shouldInterceptRequest` can't reach. Removing the black entirely needs an out-of-band path (region / MITM proxy).

Refs #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)
