### PR TITLE
feat(paramount): slate live sports commercial breaks (#91)

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/paramount/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/paramount/Fingerprints.kt
@@ -39,3 +39,25 @@ internal object PauseAdOverlayFingerprint : Fingerprint(
         method.definingClass.endsWith("CbsPauseWithAdsOverlay;")
     },
 )
+
+// ---------------------------------------------------------------------------
+// Patch 3: LIVE ad slate — AviaNetworkInterceptor.intercept(Chain)
+//
+// The AVIA player's okhttp NETWORK interceptor. The live DAI stream (manifest
+// + every segment) flows through intercept(). Live sports ads are Google DAI
+// "pod serving" — separately-addressable ad segments at
+// dai.google.com/linear/pods/v1/... that 302-redirect to googlevideo ad media.
+// We rewrite each ad-pod request to the SAME pod's "slate" rendition
+// (/<pod>/<slot>/<adIdx>/<hash>/ -> /<pod>/slate/0/<hash>/), which is Paramount's
+// own server-served "Commercial in Progress" branded card — a real segment on
+// the live timeline. Matched by okhttp interface method name + AVIA class.
+// okhttp3 is not renamed in this app, so Lokhttp3/* types are used directly.
+// ---------------------------------------------------------------------------
+
+internal object AviaNetworkInterceptorFingerprint : Fingerprint(
+    returnType = "Lokhttp3/Response;",
+    custom = { method, _ ->
+        method.name == "intercept" &&
+            method.definingClass.endsWith("/network/AviaNetworkInterceptor;")
+    },
+)

--- a/patches/src/main/kotlin/app/morphe/patches/paramount/ParamountPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/paramount/ParamountPatch.kt
@@ -30,6 +30,16 @@
  *   ✅ Pause ads                     — CbsPauseWithAdsOverlay state machine
  *   ✅ Live TV                       — preserved; streams cleanly (shouldPlayAd
  *      is shared VOD/live but the live path is unaffected on-device)
+ *
+ * LIVE SPORTS ADS (v16.17.0, on-device verified 2026-08-16 — Patch 3):
+ *   Live ads can't be seeked past (no content past the live edge), so the
+ *   shouldPlayAd gate doesn't remove them. They are Google DAI pod-serving —
+ *   separately-addressable ad segments — and the same pod exposes a "slate"
+ *   rendition (Paramount's "Commercial in Progress" branded card). Patch 3
+ *   rewrites each ad-pod request at the AviaNetworkInterceptor okhttp seam to
+ *   that slate rendition. On a real live sports break the card renders and the
+ *   stream recovers cleanly to the game; content requests are untouched. Full
+ *   slate segment coverage confirmed on-device across multiple breaks.
  */
 
 package app.morphe.patches.paramount
@@ -41,7 +51,8 @@ import app.morphe.patches.shared.compat.AppCompatibilities
 @Suppress("unused")
 val paramountPatch = bytecodePatch(
     name = "Paramount+ Android TV",
-    description = "Removes VOD pre-roll ads and pause ads while preserving live TV.",
+    description = "Removes VOD pre-roll/mid-roll ads and pause ads, and replaces live sports " +
+        "commercial breaks with the \"Commercial in Progress\" slate, while preserving playback.",
 ) {
     compatibleWith(AppCompatibilities.PARAMOUNT_TV)
 
@@ -70,6 +81,96 @@ val paramountPatch = bytecodePatch(
             0,
             """
                 return-void
+            """.trimIndent(),
+        )
+
+        // ------------------------------------------------------------------
+        // Patch 3: LIVE ad slate — AviaNetworkInterceptor.intercept(Chain)
+        //
+        // Live sports ads can't be skipped by seeking (no content past the live
+        // edge), so shouldPlayAd (Patch 1) doesn't cover them. But live ads are
+        // Google DAI "pod serving": separately-addressable ad segments at
+        // dai.google.com/linear/pods/v1/.../<pod>/<slot>/<adIdx>/<hash>/N.ts|.aac
+        // that 302-redirect to googlevideo ad media. The SAME pod also exposes a
+        // "slate" rendition (/<pod>/slate/0/<hash>/N...) — Paramount's own server
+        // -served "Commercial in Progress" branded card, a real segment carrying
+        // correct live-timeline PTS.
+        //
+        // This prepends a request diverter at intercept() entry: for an ad-pod
+        // request (path contains "/linear/pods/v1/" and not already "/slate/"),
+        // rewrite the pod/slot/adIdx path segment to "slate/0" and proceed() with
+        // the rewritten request, returning that Response. All non-ad requests
+        // (content manifests + segments) fall through to the original interceptor
+        // body untouched (CMCD headers etc. preserved). Exactly one proceed() per
+        // path — required: this is a NETWORK interceptor.
+        //
+        // On-device verified (v16.17.0, live sports break): the branded card
+        // renders and the stream recovers cleanly to the game. Full slate segment
+        // coverage observed (every 0..N segment resolves). The tail segment of a
+        // pod already carries its own "?d=" duration query, so "?d=4972" is only
+        // appended when the rewritten URL has no query (avoids a malformed
+        // "?d=..?d=.." double query, which the DAI endpoint rejects with 400).
+        //
+        // Register note: intercept() carries the Chain in a high param register
+        // (p1), so it is moved to v0 (move-object/from16) before any invoke — a
+        // bare invoke-interface {p1} would exceed the 4-bit argument-register
+        // limit. v0..v3 are scratch; they are dead once we fall through to the
+        // original body (which re-initializes its own registers), matching the
+        // ":morphe_continue nop" fall-through idiom.
+        //
+        // Fallback mechanism (not shipped here): if a future event's slate
+        // coverage differs, the alternative is a PTS-aligned muxed black+silent
+        // fill at this same seam (proceed original -> body-replace) — proven to
+        // suppress + recover. See experimental/live-dai-probe/ and memory
+        // paramount-live-sports-ads-podserving.
+        // ------------------------------------------------------------------
+        AviaNetworkInterceptorFingerprint.method.addInstructions(
+            0,
+            """
+                move-object/from16 v0, p1
+                invoke-interface {v0}, Lokhttp3/Interceptor${'$'}Chain;->request()Lokhttp3/Request;
+                move-result-object v1
+                invoke-virtual {v1}, Lokhttp3/Request;->url()Lokhttp3/HttpUrl;
+                move-result-object v1
+                invoke-virtual {v1}, Lokhttp3/HttpUrl;->toString()Ljava/lang/String;
+                move-result-object v1
+                const-string v2, "/linear/pods/v1/"
+                invoke-virtual {v1, v2}, Ljava/lang/String;->contains(Ljava/lang/CharSequence;)Z
+                move-result v2
+                if-eqz v2, :morphe_continue
+                const-string v2, "/slate/"
+                invoke-virtual {v1, v2}, Ljava/lang/String;->contains(Ljava/lang/CharSequence;)Z
+                move-result v2
+                if-nez v2, :morphe_continue
+                const-string v2, "/([0-9]+)/([0-9]+)/([0-9]+)/([0-9a-fA-F]{32})/"
+                const-string v3, "/${'$'}1/slate/0/${'$'}4/"
+                invoke-virtual {v1, v2, v3}, Ljava/lang/String;->replaceFirst(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+                move-result-object v1
+                const-string v2, "?"
+                invoke-virtual {v1, v2}, Ljava/lang/String;->contains(Ljava/lang/CharSequence;)Z
+                move-result v2
+                if-nez v2, :morphe_haveq
+                new-instance v2, Ljava/lang/StringBuilder;
+                invoke-direct {v2}, Ljava/lang/StringBuilder;-><init>()V
+                invoke-virtual {v2, v1}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+                const-string v3, "?d=4972"
+                invoke-virtual {v2, v3}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+                invoke-virtual {v2}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+                move-result-object v1
+                :morphe_haveq
+                invoke-interface {v0}, Lokhttp3/Interceptor${'$'}Chain;->request()Lokhttp3/Request;
+                move-result-object v2
+                invoke-virtual {v2}, Lokhttp3/Request;->newBuilder()Lokhttp3/Request${'$'}Builder;
+                move-result-object v2
+                invoke-virtual {v2, v1}, Lokhttp3/Request${'$'}Builder;->url(Ljava/lang/String;)Lokhttp3/Request${'$'}Builder;
+                move-result-object v2
+                invoke-virtual {v2}, Lokhttp3/Request${'$'}Builder;->build()Lokhttp3/Request;
+                move-result-object v2
+                invoke-interface {v0, v2}, Lokhttp3/Interceptor${'$'}Chain;->proceed(Lokhttp3/Request;)Lokhttp3/Response;
+                move-result-object v2
+                return-object v2
+                :morphe_continue
+                nop
             """.trimIndent(),
         )
     }


### PR DESCRIPTION
## What

Adds **Patch 3** to the Paramount+ Android TV patch: replaces **live sports commercial breaks** with Paramount's own **"Commercial in Progress"** slate card. Closes the remaining gap in #91 (VOD ads were already removed in v1.19.0).

## Why the existing patch didn't cover live

`shouldPlayAd → false` (Patch 1) removes VOD ads by letting the provider seek past the pod — impossible at the live edge. Live ads are **Google DAI pod-serving**: separately-addressable ad segments at `dai.google.com/linear/pods/v1/.../<pod>/<slot>/<adIdx>/<hash>/N.ts|.aac` that 302-redirect to googlevideo ad media.

## Mechanism

The same ad pod exposes a **`slate` rendition** (`/<pod>/slate/0/<hash>/N...`) — a real segment on the live timeline carrying correct PTS. Patch 3 prepends a request diverter at `AviaNetworkInterceptor.intercept()`:

- ad-pod request → rewrite `/<pod>/<slot>/<adIdx>/<hash>/` → `/<pod>/slate/0/<hash>/`, `proceed()` once with the rewritten request, return that response
- all non-ad requests fall through to the original interceptor body untouched (CMCD headers etc. preserved)
- exactly one `proceed()` per path (required — it's a network interceptor)
- `?d=4972` appended only when the rewritten URL has no query, so the pod's tail segment (which already carries its own `?d=`) isn't turned into a malformed `?d=..?d=..` (the DAI endpoint 400s that)

Inline `addInstructions` (no extension module); `move-object/from16` for the high `Chain` param register; tubi-Hook-7 `:continue nop` fall-through idiom.

## Verification

- ✅ On-device across **multiple real live sports breaks** (v16.17.0): branded card renders, stream **recovers cleanly to the game**, **full slate segment coverage** (every `0…N` segment resolves, including the tail once the double-`?d` bug was fixed).
- ✅ Production build (this patch, via Morphe CLI) **applies cleanly** (fingerprint matched, dex compiled) and is installed on the test device.
- ⏳ Final production-build break-verify pending a live event; the injected smali is byte-identical to the hand-patched build that was verified, and users will report back.

## Notes

- No VOD regression (the inline diverter only touches `/linear/pods/v1/` requests).
- Fallback mechanism if a future event's slate coverage differs: a PTS-aligned muxed black+silent fill at the same seam (proven to suppress + recover) — documented in `experimental/live-dai-probe/` and the RE trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)