### PR TITLE
feat(disney): opt-in Suppress Household Prompt patch

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/disney/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/disney/Fingerprints.kt
@@ -112,3 +112,51 @@ internal object PauseAdStartedFingerprint : Fingerprint(
                 "Lcom/disneystreaming/nve/player/mel/MediaXPauseSession;"
     },
 )
+
+// ---------------------------------------------------------------------------
+// Out-of-household ("Verify Household Network") decision — OPT-IN suppression.
+//
+// The household prompt is a startup-flow gate in
+// com.bamtechmedia.dominguez.accountsharing. On v26.12.1 the app resolves the
+// device's household status through ONE authoritative suspend predicate:
+//
+//   Lv8/x;->y(Lv81/c;)Ljava/lang/Object;   (returns a boxed Boolean)
+//       ≈  (firstCheck && !secondCheck)  →  "device is OUT of household"
+//
+// Every household/verify routing site funnels through this single method:
+//   - Lzy/c1; (startup destination resolver) — two sites: true → returns the
+//     OutOfHouseholdBlock destination (Lzy/h0;->c) instead of continuing to home.
+//   - Ln00/d; — true → navigates to the "verifyDevice" route.
+//   - Lo1/t; — same boolean gate.
+// (Lkf/b; is y()'s own coroutine continuation, not a distinct caller.)
+//
+// Forcing y() to return Boolean.FALSE makes every caller see an in-household
+// device, so none of the block/verify screens are ever routed to and the app
+// proceeds to home exactly as it does for a normal in-household device. This is
+// behaviour-neutral for users who are already in-household (they already get
+// false here); it only changes the out-of-household path.
+//
+// ⚠️ OBFUSCATION-PINNED: Lv8/x; and the method name "y" are R8-minified names,
+// exact for v26.12.1+rc1-2026.07.15 (versionCode 1784077450). They WILL drift on
+// app updates — re-resolve against a fresh decompile and re-pin on each version
+// bump (the patch fails loud if the fingerprint no longer resolves). The stable
+// anchors to re-locate it from: the singleton whose toString() is
+// "OutOfHouseholdBlock" (Lkh/t;/Lzy/h0;), the "verifyDevice" nav string in the
+// n00/d caller, and the router constructor's kept param-name strings
+// ("sessionStateRepository", "completeProfileStateProvider",
+// "huluLinkEligibleProfilesRepository", "sessionConfig").
+//
+// HONEST SCOPE: this suppresses only the CLIENT-side prompt/routing. Disney's
+// out-of-household detection is server/IP-driven; if the server also refuses to
+// serve the stream to an out-of-household device, hiding the prompt will not by
+// itself restore playback. Verified reachable in bytecode; effect must be
+// confirmed by a user actually in a flagged out-of-household state.
+// ---------------------------------------------------------------------------
+
+internal object OutOfHouseholdCheckFingerprint : Fingerprint(
+    returnType = "Ljava/lang/Object;",
+    custom = { method, _ ->
+        method.name == "y" &&
+            method.definingClass == "Lv8/x;"
+    },
+)

--- a/patches/src/main/kotlin/app/morphe/patches/disney/SuppressHouseholdPromptPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/disney/SuppressHouseholdPromptPatch.kt
@@ -1,0 +1,67 @@
+package app.morphe.patches.disney
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.shared.compat.AppCompatibilities
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Suppress the Disney+ out-of-household ("Verify Household Network") prompt.
+// OPT-IN, default OFF, EXPERIMENTAL.
+//
+// Unlike Netflix's household prompt (which lives in a V8 JS VM and could not be
+// beaten from bytecode), Disney's enforcement is entirely Java/Kotlin bytecode in
+// com.bamtechmedia.dominguez.accountsharing, and it funnels through a single
+// authoritative suspend predicate: Lv8/x;->y(Lv81/c;) returns a boxed Boolean
+// meaning "device is OUT of household". Three routing sites consume it — the
+// startup destination resolver (Lzy/c1;, → OutOfHouseholdBlock screen), the
+// device-verify router (Ln00/d;, → "verifyDevice"), and Lo1/t; — so forcing y()
+// to return Boolean.FALSE makes every one of them see an in-household device and
+// the app proceeds to home exactly as normal. See Fingerprints.kt for the full
+// trace and the re-pin anchors.
+//
+// Behaviour-neutral for in-household users (y() already returns false for them);
+// it only changes the out-of-household path. Kept as its own opt-in — separate
+// from the default-on ad patch — because it acts on an account/household control,
+// a deliberate and distinct choice.
+//
+// ⚠️ HONEST SCOPE: this suppresses only the CLIENT-side prompt/routing. Disney's
+// out-of-household detection is server/IP-driven; if the server ALSO refuses to
+// serve the stream to an out-of-household device, hiding the prompt will not by
+// itself restore playback (a home-region VPN is the only fix for that). The seam
+// is verified reachable in bytecode; the end-to-end effect can only be confirmed
+// by a user actually in a flagged out-of-household state, since the state is not
+// reproducible on demand.
+//
+// ⚠️ OBFUSCATION-PINNED to v26.12.1+rc1-2026.07.15 (versionCode 1784077450).
+// Lv8/x;/"y" are R8-minified names and WILL drift on app updates; the fingerprint
+// fails loud (patch errors) if it no longer resolves — re-pin against a fresh
+// decompile on each version bump.
+// ─────────────────────────────────────────────────────────────────────────────
+@Suppress("unused")
+val suppressHouseholdPromptPatch = bytecodePatch(
+    name = "Suppress Household Prompt",
+    description = "Hides the Disney+ \"Verify Household Network\" / out-of-household prompt by " +
+        "forcing the client's out-of-household check to report in-household, so the app routes " +
+        "straight to home. Does NOT change what Disney's servers detect (that's driven by your " +
+        "public IP — use a VPN for that); it only suppresses the on-screen prompt/routing. " +
+        "Opt-in / experimental; only takes visible effect when the device would otherwise be " +
+        "prompted.",
+    default = false,
+) {
+    compatibleWith(AppCompatibilities.DISNEY_PLUS_TV)
+
+    execute {
+        // Prepend `return Boolean.FALSE;` so the out-of-household predicate always
+        // resolves to "in household". The method is a Kotlin suspend function
+        // returning Object; a synchronous non-suspending return of Boolean.FALSE is
+        // valid (callers already handle a direct Boolean result vs COROUTINE_SUSPENDED),
+        // and the original body — including the real async checks — is never reached.
+        OutOfHouseholdCheckFingerprint.method.addInstructions(
+            0,
+            """
+                sget-object v0, Ljava/lang/Boolean;->FALSE:Ljava/lang/Boolean;
+                return-object v0
+            """.trimIndent(),
+        )
+    }
+}


### PR DESCRIPTION
## What

Adds an **opt-in (default OFF), experimental** Disney+ Android TV patch that suppresses the out-of-household **"Verify Household Network"** prompt.

## How

Disney's household enforcement — unlike Netflix's (a V8 JS-VM timing wall, unreachable from bytecode) — is entirely Java/Kotlin in `com.bamtechmedia.dominguez.accountsharing` and funnels through **one authoritative suspend predicate**:

```
Lv8/x;->y(Lv81/c;)Ljava/lang/Object;   // boxed Boolean = "device is OUT of household"
    ≈ (firstCheck && !secondCheck)
```

Every prompt/verify routing site consumes it:
- `Lzy/c1;` — startup destination resolver (×2 sites) → `OutOfHouseholdBlock` screen
- `Ln00/d;` → `"verifyDevice"` route
- `Lo1/t;` — same gate

The patch prepends `return Boolean.FALSE` to `y()`, so every caller sees an in-household device and the app routes straight to home. **Behaviour-neutral for in-household users** (`y()` already returns false for them); only the out-of-household path changes.

## Verified on-device (Onn 4K, v26.12.1+rc1, versionCode 1784077450)

- Both patches apply (`Applied: Disney+ Android TV`, `Applied: Suppress Household Prompt`); opt-in shows `Enabled: false`.
- In-place `-r` install (device app already Morphe-signed) → **login preserved**.
- App launches clean: no `FATAL`/`VerifyError`/`ClassCastException`/coroutine `IllegalState`; normal session boot (`session:initialize` 200, `getDictionaries` 200). Patch is inert on the in-household path.

## Honest scope / why experimental

The out-of-household state is **server/IP-driven and not reproducible on demand** (VPN attempt didn't trigger it), so end-to-end suppression can't be verified locally — hence **opt-in + experimental**, for field verification by a user actually in a flagged state. That will also answer whether Disney's enforcement is a soft client nag (this wins) or hard server-side (prompt gone but stream still blocked → needs a home-region VPN).

⚠️ `Lv8/x;`/`"y"` are R8-minified names **pinned to v26.12.1**; the fingerprint fails loud and must be re-pinned on version bumps. Re-locate anchors: `toString()` `"OutOfHouseholdBlock"`, the `"verifyDevice"` nav string, and the router constructor's kept param names (`sessionStateRepository`, `completeProfileStateProvider`, `huluLinkEligibleProfilesRepository`, `sessionConfig`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
