### PR TITLE
feat(hbomax): 7.9.0.61 support + opt-in in-app SSAI ad-origin block

### DIFF
--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/hbomax/ads/HboAdOriginFilter.java
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/hbomax/ads/HboAdOriginFilter.java
@@ -1,0 +1,114 @@
+package ajstrick81.morphe.extension.hbomax.ads;
+
+import android.net.Uri;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+
+/**
+ * HBO Max Android TV — SSAI ad-origin filter (in-app reproduction of the
+ * AdGuard Home DNS block).
+ *
+ * <p>HBO Max serves ad-supported ("ad_light" tier) content as a single
+ * multi-period SSAI DASH manifest. The manifest document itself is served
+ * from a clean origin (e.g. {@code gcp.prd.media.h264.io}), but every media
+ * segment — BOTH the ad periods and the DRM'd content periods — is fetched
+ * from the ad/SSAI segment origin {@code {gcp|akm|cf|fly}.<region>-free.prd.media.max.com}
+ * (region = amer/emea/…). The ad-break timeline metadata comes from
+ * {@code gmss.*.prd.api.discomax.com} and the ad decision from FreeWheel
+ * ({@code *.fwmrm.net}). Verified on 7.9.0.61 by pulling the live manifest:
+ * a 1:42:00 movie was stretched to 2:02:02 by ~20 min of stitched ads, all
+ * from {@code gcp.amer-free.prd.media.max.com}.
+ *
+ * <p>The AdGuard user-rule lists (both the original and the EMEA fork) kill
+ * these ads completely by DNS-blocking those origins with {@code $important}.
+ * Because the {@code -free} origin carries the SSAI *content* segments too,
+ * blocking it forces HBO's client-side "resiliency-v5.1" CDN-failover layer
+ * to abandon the SSAI manifest and re-request a clean, non-stitched manifest
+ * — the ad-free stream. This filter reproduces that by throwing an
+ * {@link IOException} from media3's {@code DefaultHttpDataSource.open(DataSpec)}
+ * whenever the request targets one of those origins, which the ExoPlayer
+ * loader surfaces to the same resiliency layer as a load error (equivalent to
+ * the DNS failure AdGuard produces).
+ *
+ * <p>Deliberately NOT blocked: the manifest origin ({@code *.h264.io}) and the
+ * QoE telemetry hosts ({@code *.litix.io}, {@code beacons-*.mediamelon.com}) —
+ * those are cosmetic and blocking them is unnecessary for ad removal.
+ *
+ * <p>Host matching is by substring so new regional shards
+ * ({@code apac-free}, additional {@code gcp/akm/cf/fly} CDN letters, …) and
+ * FreeWheel/GMSS subdomains are covered without a version bump.
+ */
+@SuppressWarnings("unused")
+public final class HboAdOriginFilter {
+
+    // Substrings identifying HBO's SSAI ad / ad-decision / ad-timeline origins.
+    // Matched against the request URL host (case-insensitive).
+    private static final String[] BLOCKED_HOST_SUBSTRINGS = {
+        "-free.prd.media.max.com", // amer-free / emea-free / any <region>-free SSAI segment origin
+        "gmss.",                   // gmss.*.prd.api.discomax.com — SSAI ad-break timeline
+        "fwmrm.net",               // FreeWheel — ad decision server
+        "dnitv.com",               // DNI TV ad host
+    };
+
+    // Cached reflected DataSpec.uri field. media3's DataSpec exposes its uri as
+    // a public final field, but its class/field names are R8-obfuscated and
+    // vary per build, so we resolve it by type (the first Uri-typed field)
+    // rather than hardcoding a name, and cache the result.
+    private static volatile Field cachedUriField;
+
+    private HboAdOriginFilter() {
+    }
+
+    /**
+     * Called at the entry of {@code DefaultHttpDataSource.open(DataSpec)} via
+     * injected smali. {@code dataSpec} is passed as {@link Object} so the patch
+     * never references the obfuscated DataSpec type.
+     *
+     * @param dataSpec the media3 DataSpec being opened (may be null).
+     * @throws IOException if the request targets a blocked ad origin.
+     */
+    public static void guard(Object dataSpec) throws IOException {
+        if (dataSpec == null) {
+            return;
+        }
+        Uri uri = extractUri(dataSpec);
+        if (uri == null) {
+            return;
+        }
+        String host = uri.getHost();
+        if (host == null) {
+            return;
+        }
+        String lower = host.toLowerCase();
+        for (String needle : BLOCKED_HOST_SUBSTRINGS) {
+            if (lower.contains(needle)) {
+                throw new IOException("HBO Max ad origin blocked: " + host);
+            }
+        }
+    }
+
+    private static Uri extractUri(Object dataSpec) {
+        Field field = cachedUriField;
+        if (field != null && field.getDeclaringClass().isInstance(dataSpec)) {
+            try {
+                return (Uri) field.get(dataSpec);
+            } catch (Exception ignored) {
+                // fall through to rescan
+            }
+        }
+        for (Field candidate : dataSpec.getClass().getFields()) {
+            if (Uri.class.isAssignableFrom(candidate.getType())) {
+                try {
+                    candidate.setAccessible(true);
+                    Uri value = (Uri) candidate.get(dataSpec);
+                    cachedUriField = candidate;
+                    return value;
+                } catch (Exception ignored) {
+                    // try the next Uri-typed field
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/extensions/proguard-rules.pro
+++ b/extensions/proguard-rules.pro
@@ -93,3 +93,11 @@
     public static androidx.media3.exoplayer.dash.manifest.DashManifest stripAdPeriods(androidx.media3.exoplayer.dash.manifest.DashManifest);
 }
 -dontwarn androidx.media3.exoplayer.dash.manifest.**
+
+# HBO Max — SSAI ad-origin filter. HboAdOriginFilter.guard(Object) is called
+# only from injected smali (invoke-static {} at DefaultHttpDataSource.open),
+# so R8 sees it as unreferenced and would strip or rename it. Keep the class
+# and the guard entry point intact.
+-keep class ajstrick81.morphe.extension.hbomax.ads.HboAdOriginFilter {
+    public static void guard(java.lang.Object);
+}

--- a/patches/src/main/kotlin/app/morphe/patches/hbomax/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/hbomax/Fingerprints.kt
@@ -1,6 +1,9 @@
 package app.morphe.patches.hbomax.ads
 
 import app.morphe.patcher.Fingerprint
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.StringReference
 
 // ─────────────────────────────────────────────────────────────────────────────
 // BoltNonLinearAdsRequest — Nonlinear (overlay) ad request serializer
@@ -82,5 +85,38 @@ internal object NowtilusEnabledFingerprint : Fingerprint(
     custom = { method, _ ->
         method.definingClass == "Lcom/mediamelon/core/qubit/ep/RegisterAPI;" &&
             method.name == "isNowtilusEnabled"
+    },
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// media3 DefaultHttpDataSource.open(DataSpec) — the HTTP fetch path for the
+// manifest and every media segment. HBO wires this via
+// com.discovery.player.datasource.HttpURLConnectionDataSourceFactoryCreator,
+// which builds a media3 DefaultHttpDataSource$Factory.
+//
+// The class is R8-renamed per build (was Lx02; on 7.9.0.61), so it is matched
+// by content, not name: the media3 DefaultHttpDataSource is the only class that
+// carries the literal log tag "DefaultHttpDataSource" AND declares the
+// interface method open(DataSpec)J (returns a long, single DataSpec param).
+// This mirrors MLB At Bat's OkHttpDataSourceOpenFingerprint, which anchors on
+// the media3 "media3.datasource.okhttp" tag for the OkHttp variant.
+//
+// The guard is injected at index 0 of open(), before the method's internal
+// try-block, so a thrown IOException propagates straight to the ExoPlayer
+// loader (resiliency-v5.1 CDN failover) rather than being swallowed here.
+// ─────────────────────────────────────────────────────────────────────────────
+
+internal object DefaultHttpDataSourceOpenFingerprint : Fingerprint(
+    returnType = "J",
+    custom = { method, classDef ->
+        method.name == "open" &&
+            method.parameterTypes.size == 1 &&
+            classDef.methods.any { candidate ->
+                candidate.implementation?.instructions?.any { instruction ->
+                    instruction.opcode == Opcode.CONST_STRING &&
+                        ((instruction as ReferenceInstruction).reference as? StringReference)
+                            ?.string == "DefaultHttpDataSource"
+                } == true
+            }
     },
 )

--- a/patches/src/main/kotlin/app/morphe/patches/hbomax/HBOAdsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/hbomax/HBOAdsPatch.kt
@@ -96,17 +96,27 @@ val hboAdsPatch = bytecodePatch(
 
         // ─────────────────────────────────────────────────────────────────────
         // Patch 5: GenerateLiveTimelineEntriesForAdBreakKt.generateLiveTimelineEntriesForAdBreak()
-        // return-void at entry suppresses all AdBreakEntry/AdEntry construction.
-        // The caller does addAll() on the result — since the method now returns
-        // immediately, no ad entries are added to the live timeline while
-        // chapter/content entries are built normally.
-        // Note: cannot return an empty list here since the method returns
-        // List not void — return-void exits the method cleanly and the
-        // caller handles the missing result via its existing null/empty checks.
+        // Return an EMPTY List at entry to suppress all AdBreakEntry/AdEntry
+        // construction. The caller does addAll() on the result, so an empty list
+        // means no ad entries are added to the live timeline while chapter/content
+        // entries are built normally.
+        //
+        // ⚠️ Do NOT use `return-void` here. The method's descriptor returns
+        // Ljava/util/List; — ART's verifier rejects `return-void` in a
+        // non-void method ("[0x0] return-void not expected"), which makes the
+        // WHOLE class fail verification and silently disables this suppression
+        // (observed on 7.9.0.61 via logcat VerifyError). Returning
+        // Collections.emptyList() is the valid form (mirrors Pluto's
+        // StitcherSession.getAdBreaks() empty-list hook). The method has
+        // .locals 8, so v0 is a valid register at entry.
         // ─────────────────────────────────────────────────────────────────────
         GenerateLiveTimelineEntriesForAdBreakFingerprint.method.addInstructions(
             0,
-            "return-void",
+            """
+                invoke-static {}, Ljava/util/Collections;->emptyList()Ljava/util/List;
+                move-result-object v0
+                return-object v0
+            """.trimIndent(),
         )
         
         // ─────────────────────────────────────────────────────────────────────────────

--- a/patches/src/main/kotlin/app/morphe/patches/hbomax/HBOBlockSsaiOriginsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/hbomax/HBOBlockSsaiOriginsPatch.kt
@@ -1,0 +1,82 @@
+package app.morphe.patches.hbomax.ads
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.shared.compat.AppCompatibilities
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HBO Max — Block SSAI Ad Origins  (OPT-IN, default OFF, EXPERIMENTAL)
+//
+// Reproduces, inside the standalone patched APK, what the community AdGuard Home
+// DNS rule-lists do: strip HBO Max's ads COMPLETELY, not just their markers.
+//
+// WHY THIS EXISTS (the ceiling the default "Disable Ads" patch hits):
+//   The default patch empties the parsed ad-break TIMELINE (Bolt / GMSS-AdSparx /
+//   live-timeline / Nowtilus) — it removes ad markers, skip UI, and beacons. But
+//   on the ad-supported ("ad_light") tier the ad VIDEO is server-side stitched
+//   (SSAI): a single multi-period DASH manifest where the ad periods are real
+//   <Period>s. Verified on 7.9.0.61 by pulling the live manifest for a 1:42:00
+//   movie — it was stretched to 2:02:02 by ~20 min of stitched ads across 7
+//   breaks, every segment served from gcp.amer-free.prd.media.max.com. Emptying
+//   the timeline does not remove those segments, so skippable ads still play
+//   (same lesson as Prime Video / MLB native SSAI).
+//
+// HOW THE DNS BLOCK WORKS (and how we mirror it):
+//   The manifest DOCUMENT is served from a clean origin (…h264.io), but ALL its
+//   segments — ad AND content — come from the {gcp|akm|cf|fly}.<region>-free.prd
+//   .media.max.com origin. The AdGuard lists block that origin with $important;
+//   because it also carries the SSAI content segments, HBO's client-side
+//   "resiliency-v5.1" CDN-failover layer abandons the stitched manifest and
+//   re-requests a clean, non-SSAI manifest — the ad-free stream. This patch
+//   throws an IOException from media3's DefaultHttpDataSource.open(DataSpec) for
+//   requests to those origins, which the ExoPlayer loader surfaces to the same
+//   resiliency layer as a load error (the in-app equivalent of the DNS failure).
+//
+// ⚠️ HONEST SCOPE / RISK: the end effect depends on HBO's resiliency layer
+//   falling back to a clean manifest when the -free origin fails, exactly as it
+//   does for a DNS failure. That is the proven AdGuard behaviour, but the in-app
+//   IOException path must be confirmed on-device to fall back cleanly rather than
+//   stall playback — which is why this ships OPT-IN and separate from the
+//   default-on "Disable Ads" patch until field-verified. The blocked hosts come
+//   from the ad origins alone (…-free.prd.media.max.com, gmss., fwmrm.net,
+//   dnitv.com); the manifest origin (…h264.io) and QoE telemetry (litix.io,
+//   mediamelon) are intentionally left alone.
+//
+// The DefaultHttpDataSource class is R8-renamed per build; it is matched by its
+// "DefaultHttpDataSource" log-tag string + the open(DataSpec)J shape rather than
+// by name, so this survives version bumps (see DefaultHttpDataSourceOpenFingerprint).
+// ─────────────────────────────────────────────────────────────────────────────
+@Suppress("unused")
+val hboBlockSsaiOriginsPatch = bytecodePatch(
+    name = "HBO Max - Block SSAI Ad Origins",
+    description = "Reproduces the AdGuard DNS ad-block inside the app: fails media3 " +
+        "segment requests to HBO's SSAI ad origins (amer-free/emea-free.prd.media.max.com, " +
+        "gmss, FreeWheel) so the player's resiliency layer falls back to the clean, " +
+        "ad-free manifest — removing the stitched ad VIDEO the default Disable Ads patch " +
+        "leaves behind. Opt-in / experimental; verify playback on-device.",
+    default = false,
+) {
+    compatibleWith(AppCompatibilities.HBO_TV)
+
+    // Merges HboAdOriginFilter into the patched dex.
+    extendWith("extensions/extension.mpe")
+
+    execute {
+        // Inject the origin guard at the very entry of DefaultHttpDataSource.open()
+        // — before the method's internal try-block, so a thrown IOException
+        // propagates to the ExoPlayer loader (resiliency CDN failover) instead of
+        // being caught and retried inside the data source.
+        //
+        // The DataSpec is p1 (open is an instance method: p0=this, p1=DataSpec).
+        // open() has many locals, so p1 sits in a high register; move it into v0
+        // (dead at entry — the original body only writes v0 later, inside the try)
+        // and pass it as Object so the patch never names the obfuscated DataSpec.
+        DefaultHttpDataSourceOpenFingerprint.method.addInstructions(
+            0,
+            """
+                move-object/from16 v0, p1
+                invoke-static {v0}, Lajstrick81/morphe/extension/hbomax/ads/HboAdOriginFilter;->guard(Ljava/lang/Object;)V
+            """.trimIndent(),
+        )
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
@@ -32,6 +32,7 @@ object AppCompatibilities {
     packageName = "com.wbd.hbomax",
     appIconColor = 0xFFFFFF,
     targets = listOf(
+        AppTarget("7.9.0.61"),
         AppTarget("7.7.0.78"),
         AppTarget("7.5.0.73"),
         AppTarget("7.2.0.41"),


### PR DESCRIPTION
## HBO Max 7.9.0.61 + in-app SSAI ad-origin block

### What
1. **Compat bump** — `AppTarget("7.9.0.61")` on `HBO_TV`. Existing 6-patch "Disable Ads" set resolves and boots clean on the new build.
2. **New opt-in patch: "HBO Max - Block SSAI Ad Origins"** (default OFF, experimental) — reproduces the community AdGuard Home DNS ad-block *inside* the standalone APK, removing the stitched ad **video** the timeline patches can't reach.
3. **Fix** a latent verifier bug in the default "Disable Ads" **Patch 5**.

### Why the timeline patches weren't enough
On the ad-supported (`ad_light`) tier, HBO serves content as one **multi-period SSAI DASH manifest**. The `.mpd` comes from a clean origin (`…h264.io`) but every segment — ads **and** DRM'd content — is served from `{gcp|akm|cf|fly}.<region>-free.prd.media.max.com`. Pulling the live manifest for a 1:42 movie showed it stretched to **2:02 by ads across 7 breaks**, all from `gcp.amer-free.prd.media.max.com`. Emptying the parsed ad-timeline removes markers/UI but not those segments — so skippable ads still played.

### How the block works (verified on-device)
The AdGuard lists block the `-free` origin with `$important`; since it also carries the SSAI *content* segments, HBO's client-side **`resiliency-v5.1`** layer abandons the stitched manifest and requests a clean **`_fallback.mpd`**. This patch throws `IOException` from media3's `DefaultHttpDataSource.open(DataSpec)` for the ad origins (`…-free.prd.media.max.com`, `gmss.`, `fwmrm.net`, `dnitv.com`), which drives exactly that fallback:

- ✅ No pre-rolls, no mid-rolls (confirmed on device **and** by fetching the resulting clean 7-period / 0-ad `_fallback.mpd`)
- ✅ Playback smooth (slightly longer initial buffer = the same "ad origin refused" tax as AGH)
- ✅ `-free` substring covers **EMEA** (Germany, #118) as well as the Americas

### Robustness
`DefaultHttpDataSource` is R8-renamed per build, so it's matched by its `"DefaultHttpDataSource"` log-tag string + `open(DataSpec)J` shape (mirrors MLB's `OkHttpDataSourceOpenFingerprint`). The `DataSpec` is passed to the extension as `Object` and its `Uri` resolved via cached reflection — no obfuscated names hardcoded. Ships **opt-in** while it's field-validated across regions.

### Patch 5 verifier fix
`generateLiveTimelineEntriesForAdBreak` returns `List`, so the injected `return-void` was rejected by ART (`[0x0] return-void not expected`), **silently disabling** the live/episodic timeline suppression. Now returns `Collections.emptyList()` (valid; mirrors Pluto's `getAdBreaks` hook). VerifyError confirmed gone on 7.9.0.61.

Relates to #118 (HBO ads in Germany — EMEA `emea-free` origin covered by the same rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
