### PR TITLE
fix(hbomax): enable Block SSAI Ad Origins by default (#125)

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/hbomax/HBOBlockSsaiOriginsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/hbomax/HBOBlockSsaiOriginsPatch.kt
@@ -5,7 +5,7 @@ import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.shared.compat.AppCompatibilities
 
 // ─────────────────────────────────────────────────────────────────────────────
-// HBO Max — Block SSAI Ad Origins  (OPT-IN, default OFF, EXPERIMENTAL)
+// HBO Max — Block SSAI Ad Origins  (DEFAULT ON — field-verified 7.9.0.61)
 //
 // Reproduces, inside the standalone patched APK, what the community AdGuard Home
 // DNS rule-lists do: strip HBO Max's ads COMPLETELY, not just their markers.
@@ -34,10 +34,14 @@ import app.morphe.patches.shared.compat.AppCompatibilities
 //
 // ⚠️ HONEST SCOPE / RISK: the end effect depends on HBO's resiliency layer
 //   falling back to a clean manifest when the -free origin fails, exactly as it
-//   does for a DNS failure. That is the proven AdGuard behaviour, but the in-app
-//   IOException path must be confirmed on-device to fall back cleanly rather than
-//   stall playback — which is why this ships OPT-IN and separate from the
-//   default-on "Disable Ads" patch until field-verified. The blocked hosts come
+//   does for a DNS failure. That is the proven AdGuard behaviour, and the in-app
+//   IOException path is on-device confirmed to fall back cleanly (Onn 4K, 7.9.0.61:
+//   guard fires, mid-roll markers/ads removed across HBO Original + licensed
+//   theatrical titles). Originally shipped OPT-IN until field-verified; now
+//   promoted to DEFAULT ON — the bytecode timeline patch alone only strips ad
+//   markers (issue #125: users saw all-unskippable stitched ads until this was
+//   enabled). Cost of default-on: a slightly longer initial spinner while the
+//   -free origin is refused and the clean manifest is re-requested. The blocked hosts come
 //   from the ad origins alone (…-free.prd.media.max.com, gmss., fwmrm.net,
 //   dnitv.com); the manifest origin (…h264.io) and QoE telemetry (litix.io,
 //   mediamelon) are intentionally left alone.
@@ -53,8 +57,9 @@ val hboBlockSsaiOriginsPatch = bytecodePatch(
         "segment requests to HBO's SSAI ad origins (amer-free/emea-free.prd.media.max.com, " +
         "gmss, FreeWheel) so the player's resiliency layer falls back to the clean, " +
         "ad-free manifest — removing the stitched ad VIDEO the default Disable Ads patch " +
-        "leaves behind. Opt-in / experimental; verify playback on-device.",
-    default = false,
+        "leaves behind. On by default (field-verified 7.9.0.61); expect a slightly " +
+        "longer initial spinner while the clean manifest is fetched.",
+    default = true,
 ) {
     compatibleWith(AppCompatibilities.HBO_TV)
 


### PR DESCRIPTION
## Problem (#125)
Users on the latest HBO Max patches report **ads returning, and unskippable**. Reproduced by the reporter on *A Minecraft Movie*; a Reddit user reports all ads unskippable on latest but the old `v1.4.55` build "works perfectly."

## Root cause
The default **"Disable Ads"** bytecode patch only empties the parsed ad-break **timeline** (markers/skip UI/beacons). On the ad-supported tier the ad **video is server-side stitched (SSAI)** into the DASH manifest, so the footage keeps playing — and SSAI ads have **no skip control** → they surface as **unskippable** ads.

**"Block SSAI Ad Origins"** is what actually removes them: it fails media3 segment requests to the `-free.prd.media.max.com` ad origin, forcing HBO's `resiliency-v5.1` layer to fall back to the clean, non-stitched manifest. It shipped **opt-in / default-off** (experimental, pending field verification) — so every user who never toggled it on saw the full stitched ads. The old `v1.4.55` "just worked" because its blocking was active by default.

## Fix
Promote **Block SSAI Ad Origins** to **default-ON**. One-line default flip + doc/comment update in `HBOBlockSsaiOriginsPatch.kt`.

## Verification (Onn 4K, HBO Max 7.9.0.61)
On-device with the block active, the origin guard fires and playback falls back cleanly:
- Confirmed ad-free across **HBO Original + licensed theatrical**: *Conan O'Brien Must Go*, *A Minecraft Movie* (the reporter's repro), *A Long Walk*
- **~36 min continuous playback**, position advancing 1:1 real-time — **zero ads, no stalls, no errors**
- Bolt overlay-ad suppression + guard blocking both healthy in logcat

## Tradeoff
Slightly longer **initial spinner** while the `-free` origin is refused and the clean manifest is re-requested (same behavior AdGuard DNS produces). Acceptable for full ad removal.

Refs #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)