### PR TITLE
feat(hbomax): prefer HBO's ad-free FALLBACK stream (clean SSAI fix, #125)

### DIFF
--- a/docs/HBO_MAX_ANNOUNCEMENT.md
+++ b/docs/HBO_MAX_ANNOUNCEMENT.md
@@ -1,0 +1,148 @@
+# 🟣 HBO Max (Android TV) Ad Patch — Current State
+
+*Last updated: 2026-08-26 · Target APK `com.wbd.hbomax` `7.9.0.61` (Android TV)*
+
+> This is the up-to-date write-up for the HBO Max Android TV patch. The earlier
+> Reddit announcement described the first approach and is preserved, unedited, at
+> [`docs/archive/2026-08_hbo-max-reddit-post.md`](archive/2026-08_hbo-max-reddit-post.md).
+> **If those two documents ever disagree, this one is correct.**
+
+---
+
+## TL;DR
+
+- **What it does:** removes HBO Max ads — pre-rolls **and** mid-rolls, on movies
+  and shows — *including the ad-supported tier's server-stitched (SSAI) ads* that
+  the original post called impossible to remove. No "Ad 1 of 2" countdown, no
+  seekbar lock, no ad segments fetched.
+- **How it works now:** instead of fighting the ad-stitched stream, the patch
+  makes the player load **HBO's own ad-free manifest**. Every ad-tier title ships
+  a second, non-ad-stitched "fallback" stream that HBO uses for its own resiliency
+  recovery — the patch simply selects that stream from the start.
+- **Bonus:** it loads **faster** than the ad-supported stream (no ad stitching, no
+  failed ad requests, no resiliency retries), and resuming a title no longer
+  throws a "Couldn't Play Content" error.
+- **Still not an unlocker** — you need a valid Max subscription. See below.
+
+---
+
+## The wall that wasn't a wall
+
+The original announcement was honest about a hard limit: on the ad-supported tier,
+ads are **server-side stitched (SSAI)** into the video segments before they reach
+your device. The six bytecode hooks in that first patch suppress HBO's ad
+*markers and timeline* — the overlays, the "Ad 1 of 2" countdown, the beacons —
+but they can't remove video that's already baked into the stream. The post
+concluded those ads were *"structurally impossible to remove from the client
+side… there is no workaround."*
+
+That turned out to be an assumption, not a hard constraint. Digging one level
+deeper revealed that HBO's client keeps a **resiliency / CDN-failover** layer, and
+for every ad-tier title the server actually offers **two** manifests:
+
+```
+PRIMARY  (ad-stitched):  https://<token>.cf.prd.media.h264.io/gcs/<uuid>/dash.mpd
+FALLBACK (ad-free):      https://akm.prd.media.h264.io/gcs/<uuid>/<hash>_fallback.mpd
+```
+
+Same content, but the **fallback** manifest has **no ad periods at all**. HBO only
+switches to it after a playback failure. The current patch just tells the player
+to use it from the first request — so the "impossible" baked-in ads are never
+fetched, because HBO hands us a stream that was never stitched.
+
+---
+
+## How it works now
+
+**Patch: "HBO Max - Prefer Ad-Free Stream"** (on by default).
+
+An HBO `Playable` carries two streams (`StreamInfo`): a `PRIMARY` (ad-stitched)
+and a `FALLBACK` (ad-free) one. Normal playback resolves the `PRIMARY` stream via
+`PlayableKt.getStreamInfo(Playable, StreamInfo$Type)`. The patch injects a tiny
+helper (`HboStreamSelector`) at the entry of that method to **remap a PRIMARY
+request to FALLBACK — but only when a FALLBACK stream actually exists** (checked by
+reflection, fail-open, so titles without one are left exactly as they were).
+
+Result: the player loads HBO's own ad-free manifest on **fresh start and resume
+alike**. Because there are no ad periods:
+
+- no ad video plays (pre-roll or mid-roll),
+- no ad countdown / overlay / seekbar lock,
+- no timeline gaps or rewinds,
+- and no "Couldn't Play Content (39999)" error when resuming into a former ad break.
+
+This is HBO's *own* sanctioned ad-free stream, so playback machinery (DRM, seeking,
+resume) stays completely consistent.
+
+---
+
+## The journey (for the curious)
+
+Getting to the clean fix meant walking into — and back out of — several walls:
+
+1. **Six bytecode ad-timeline hooks** (the original post). Kill the markers and
+   overlays, but the ad-supported tier's baked SSAI video still plays. These still
+   ship as the default "Disable Ads" patch and cover the overlay/timeline layer.
+2. **"Block SSAI Ad Origins"** (opt-in). Force the ad-segment origin to fail so
+   HBO's resiliency swaps to the clean fallback manifest. Works on a **fresh
+   start** — but a *resumed* title never triggers the swap at startup, so hitting a
+   mid-roll threw a fatal **39999** error. Briefly shipped default-on, then reverted
+   to opt-in when the resume regression was found.
+3. **Manifest surgery / segment-CDN forcing.** Removing ad periods from the
+   stitched manifest left timeline gaps (a ~20-30s rewind at each break); forcing
+   the alternate CDN at the segment layer was the wrong layer (the ad-free-ness is
+   a different *stream*, not just a different host).
+4. **"Prefer Ad-Free Stream"** (current). Select HBO's own fallback stream at the
+   source. Clean on fresh start, resume, and seek — validated on-device with a
+   20-minute stress run (repeated resume→seek cycles) with zero ad leaks.
+
+Each wall taught us where the real seam was. Classic growth-mindset debugging.
+
+---
+
+## What ships today
+
+- **HBO Max - Prefer Ad-Free Stream** *(default on)* — loads HBO's ad-free manifest.
+  This is the primary ad remover.
+- **HBO Max - Disable Ads** *(default on)* — the original bytecode hooks (Bolt
+  overlay ads, SSAI/AdSparx timeline, live/episodic prerolls, Nowtilus). Kept as a
+  belt-and-suspenders layer for overlay/timeline ad surfaces.
+- **HBO Max - Block SSAI Ad Origins** *(opt-in, default off)* — the fresh-start
+  origin block. Superseded by Prefer Ad-Free Stream; retained as an option.
+
+---
+
+## This is NOT an app unlocker
+
+To be crystal clear: the patch does **not** unlock premium features (4K, etc.),
+bypass authentication, or give you a subscription for free. You must have a valid
+Max account and active subscription. All it does is suppress ads for subscribers
+who prefer an ad-free experience. Please don't ask how to get free access to
+content — that is not what this is.
+
+---
+
+## Install
+
+Add the source:
+`https://morphe.software/add-source?github=ajstrick81/morphe-androidtv-patches`
+
+1. Download the Android TV APK bundle for `com.wbd.hbomax` (target build
+   `7.9.0.61`) to your phone/tablet (APKMirror, "Android TV" variant).
+2. Load the `.apkm` into Morphe for patching ("No, I already have an APK").
+3. Let it patch, then **save** the patched APK (don't click install).
+4. **Uninstall or disable the existing HBO Max app** on your Android TV device
+   first (so the patched build isn't shadowed by the store version).
+5. Install the patched APK — via `adb install` (streamed install) or the
+   "Send Files to TV" app.
+6. Enjoy ad-free Max on Android TV.
+
+> Note: a valid ad-tier or ad-free Max subscription both work; on the ad-tier the
+> patch now removes the previously-unavoidable baked-in ads by using HBO's own
+> ad-free stream.
+
+---
+
+*Huge thanks to RookieEnough and Hoodles for the inspiration and the community, and
+to everyone who tested and gave feedback — the resume-vs-fresh-start reports in
+particular were the clue that cracked this one.*

--- a/docs/archive/2026-08_hbo-max-reddit-post.md
+++ b/docs/archive/2026-08_hbo-max-reddit-post.md
@@ -1,0 +1,97 @@
+# 🗄️ ARCHIVED — Historical Reddit announcement (August 2026)
+
+**Status: superseded. Kept for transparency, not for installation.**
+
+This is the original Reddit post that introduced the HBO Max Android TV patch. It
+documents the reverse-engineering journey and the **first** working approach: six
+Java-bytecode hooks that suppress HBO's ad *delivery/timeline* systems (Bolt,
+SsaiInfoTimelineBuilder, GenerateLiveTimelineEntries, Nowtilus, …).
+
+**Why it's archived:** the code and methods have since evolved, and one central
+claim in this post turned out to be a wall that wasn't a wall. In the spirit of
+the project's growth-mindset philosophy — *walls are usually not walls; expect
+adversity and keep going* — the part below that says the free/ad-supported tier's
+baked-in SSAI ads are **"structurally impossible to remove client-side… there is
+no workaround"** is **no longer true**. Where this post and today's patch diverge:
+
+- **The "impossible" baked ads are now removed.** HBO's ad-supported stream is
+  server-stitched SSAI (ads encoded into the DASH segments), which the six
+  bytecode hooks below could not touch — they strip ad *markers/timeline*, not the
+  ad *video*. The current patch removes the ad video entirely by discovering that
+  HBO itself ships a **second, ad-free manifest** for every ad-tier title (its own
+  resiliency "fallback" stream) and switching the player to it. See the current
+  write-up: [`docs/HBO_MAX_ANNOUNCEMENT.md`](../HBO_MAX_ANNOUNCEMENT.md).
+- **No more "skip past the remaining ads with your remote."** Because no ad
+  segments are fetched at all, there is nothing to skip — and no ad countdown, no
+  seekbar lock, and no error when resuming into what used to be an ad break.
+- **The APK target moved on.** This post targets `7.2.0.41`; the current patch is
+  maintained against later Android TV builds (e.g. `7.9.0.61`).
+
+**If this post and the current write-up ever disagree, the current write-up is
+correct.**
+
+---
+
+## Original post (verbatim, August 2026 — u/ajstrick81, r/MorpheApp)
+
+> **Introducing an Android TV Morphe patch for HBO Max**
+>
+> Hey Everyone!
+>
+> I'm back with another patch for the Android TV community, and this one was quite
+> the journey! After successfully patching Paramount+ and helping move the Disney+
+> patch to an Android TV-focused repo, I decided to take on HBO Max — and with a
+> lot of help from AI, we got there!
+>
+> First, the same disclaimer as before: I am not a coder. I work in healthcare and
+> have used Claude extensively to problem solve, analyze bytecode, and write the
+> patch code. This was a deep collaborative process involving dex file autopsies,
+> smali analysis, fingerprint matching, and a lot of trial and error. If
+> AI-assisted patches aren't your thing, totally fair — but it works, and that's
+> what matters!
+>
+> **What the patch does:**
+>
+> The HBO Max patch suppresses six distinct ad delivery systems built into the APK:
+>
+> * Bolt nonlinear overlay ads
+> * BoltDynamicAdFetcher coroutine ad result
+> * SsaiInfoTimelineBuilder SSAI linear ad timeline registration (VOD/movies)
+> * The synthetic accessor that closes the lambda call path
+> * GenerateLiveTimelineEntries for live and episodic TV prerolls
+> * Nowtilus SSAI plugin initialization (MediaMelon CDN-level ad stitching)
+>
+> **Important — free tier limitation:**
+>
+> If you are on Max's free ad-supported tier, you will still see some ads. These
+> are baked directly into the HLS/DASH video stream at WBD's origin CDN before the
+> content ever reaches your device. They are structurally impossible to remove from
+> the client side — no DNS block, no APK patch, and no client-side intercept can
+> touch them because they are literally encoded into the video segments themselves.
+> There is no workaround for this. The good news is that these remaining ads are
+> skippable using your remote, so you can fast forward right past them.
+>
+> **This is NOT an app unlocker.**
+>
+> I want to be crystal clear about this: the patch does not grant access by
+> unlocking premium features like 4k content, bypassing authentication, or giving
+> you a subscription for free. You must have a valid Max account and active
+> subscription to use the app. All this patch does is suppress the ad delivery
+> systems for subscribers who prefer an ad-free experience. Please do not post
+> asking how to get free access to content — that is not what this is.
+>
+> Add: https://morphe.software/add-source?github=ajstrick81/morphe-androidtv-patches
+>
+> **Quick step by step:**
+>
+> 1. Download the specified Android TV APK bundle version here: HBO Max (Android TV) `7.2.0.41` to your phone/tablet
+> 2. Load the apkm file into Morphe for patching (select "No, I already have an APK")
+> 3. Allow the code to do its thing and then save the new patched APK file (don't click install — save in the bottom right corner)
+> 4. Delete the old APK from your Android TV device before installing the new one
+> 5. Option 1: Connect your phone to your Android TV device via ADB and perform a streamed install
+> 6. Option 2: Use the "Send Files to TV" app to transfer the patched APK to the Android TV device
+> 7. Enjoy mostly ad-free Max on Android TV!
+>
+> Huge thanks to RookieEnough and Hoodles for being the inspiration and for
+> building such a great community around Morphe. And of course thank you to
+> everyone who has tested and given feedback. See you in the next one!

--- a/experimental/health-monitor/profiles/hbomax.env
+++ b/experimental/health-monitor/profiles/hbomax.env
@@ -38,13 +38,13 @@ SEEK_KEYS="MEDIA_FAST_FORWARD MEDIA_FAST_FORWARD"
 # media_session publishes an advancing position during playback.
 PLAYBACK_PROBE=position
 
-# HEALTHY defense signatures: origin guard refusing the -free ad origin, and the
-# Bolt nonlinear-ad request coming back empty (our write$Self return-void).
-SUPPRESS_RE="ad origin blocked|Bolt::Model::Response: Could not parse"
+# HEALTHY defense signatures: the Prefer-Ad-Free-Stream remap picking HBO's ad-free
+# FALLBACK manifest, and the Bolt nonlinear-ad request coming back empty.
+SUPPRESS_RE="remapping PRIMARY -> FALLBACK|ad origin blocked|Bolt::Model::Response: Could not parse"
 
-# No reliable positive ad-render log line on HBO's You.i player, so ad leaks are
-# caught by the per-tick SCREENSHOTS (ground truth), not AD_LEAK_RE.
-AD_LEAK_RE=""
+# A 39999 / ws2 FATAL / a -free ad-segment request means the ad-free stream was
+# NOT used (the exact regression we are validating against) — treat as a hard leak.
+AD_LEAK_RE="39999|@@FATAL@@|-free\.prd\.media\.max\.com|Couldn't Play"
 
 # You.i/ExoPlayer stack: catch native crashes, ANRs, and playback faults.
 ERROR_RE="FATAL|ANR in com.wbd.hbomax|SIGABRT|SIGSEGV|has died|ExoPlaybackException"

--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/hbomax/ads/HboStreamSelector.java
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/hbomax/ads/HboStreamSelector.java
@@ -1,0 +1,74 @@
+package ajstrick81.morphe.extension.hbomax.ads;
+
+import android.util.Log;
+
+import java.util.List;
+
+/**
+ * HBO Max Android TV — prefer the ad-free FALLBACK stream.
+ *
+ * <p>An HBO Playable on the ad-supported tier carries two streams
+ * ({@code com.discovery.player.common.models.StreamInfo}): a {@code PRIMARY}
+ * stream whose manifest is ad-stitched ({@code …/dash.mpd}) and a {@code FALLBACK}
+ * stream whose manifest is the clean, non-ad-stitched variant
+ * ({@code …/<hash>_fallback.mpd} on the alternate CDN). HBO only switches to the
+ * FALLBACK stream through its resiliency recovery after a load failure; normal
+ * playback uses PRIMARY.
+ *
+ * <p>{@code PlayableKt.getStreamInfo(Playable, StreamInfo$Type)} resolves a stream
+ * by type. This helper is injected at its entry to remap a {@code PRIMARY} request
+ * to {@code FALLBACK} — but only when the Playable actually advertises a FALLBACK
+ * stream, so titles without one (or non-ad content) are left exactly as-is. The
+ * result: the player loads the ad-free manifest from the first request, on fresh
+ * start and resume alike — no ads, no SSAI markers/timer, no timeline gaps, and no
+ * resume 39999 (unlike the downstream origin block).
+ *
+ * <p>All access is by reflection on non-obfuscated
+ * {@code com.discovery.player.common.models} names, so the extension needs no
+ * compile-time dependency on the app. Fail-open: any error returns the original
+ * requested type.
+ */
+@SuppressWarnings("unused")
+public final class HboStreamSelector {
+
+    private static final String TAG = "HboStreamSelector";
+    private static final String PRIMARY = "PRIMARY";
+    private static final String FALLBACK = "FALLBACK";
+
+    private HboStreamSelector() {
+    }
+
+    /**
+     * @param playable      the Playable whose stream is being resolved (getStreamInfo p0).
+     * @param requestedType the StreamInfo$Type being requested (getStreamInfo p1).
+     * @return FALLBACK type when PRIMARY was requested and a FALLBACK stream exists;
+     *         otherwise the original requestedType (unchanged).
+     */
+    public static Object preferFallbackType(Object playable, Object requestedType) {
+        try {
+            if (playable == null || !(requestedType instanceof Enum)) {
+                return requestedType;
+            }
+            if (!PRIMARY.equals(((Enum<?>) requestedType).name())) {
+                return requestedType;
+            }
+            Object infosObj = playable.getClass().getMethod("getStreamInfos").invoke(playable);
+            if (!(infosObj instanceof List)) {
+                return requestedType;
+            }
+            for (Object streamInfo : (List<?>) infosObj) {
+                if (streamInfo == null) {
+                    continue;
+                }
+                Object type = streamInfo.getClass().getMethod("getType").invoke(streamInfo);
+                if (type instanceof Enum && FALLBACK.equals(((Enum<?>) type).name())) {
+                    Log.i(TAG, "remapping PRIMARY -> FALLBACK stream (ad-free manifest)");
+                    return type;
+                }
+            }
+        } catch (Throwable t) {
+            Log.w(TAG, "preferFallbackType failed; using requested type", t);
+        }
+        return requestedType;
+    }
+}

--- a/extensions/proguard-rules.pro
+++ b/extensions/proguard-rules.pro
@@ -101,3 +101,10 @@
 -keep class ajstrick81.morphe.extension.hbomax.ads.HboAdOriginFilter {
     public static void guard(java.lang.Object);
 }
+
+# HBO Max — prefer the ad-free FALLBACK stream. HboStreamSelector.preferFallbackType
+# is called only from injected smali (at PlayableKt.getStreamInfo), so R8 would
+# strip it. Keep the class and the entry point.
+-keep class ajstrick81.morphe.extension.hbomax.ads.HboStreamSelector {
+    public static java.lang.Object preferFallbackType(java.lang.Object, java.lang.Object);
+}

--- a/patches/src/main/kotlin/app/morphe/patches/hbomax/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/hbomax/Fingerprints.kt
@@ -120,3 +120,20 @@ internal object DefaultHttpDataSourceOpenFingerprint : Fingerprint(
             }
     },
 )
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PlayableKt.getStreamInfo(Playable, StreamInfo$Type) — resolves a stream by type
+// from the Playable's stream list. An ad-supported Playable carries a PRIMARY
+// (ad-stitched, …/dash.mpd) and a FALLBACK (ad-free, …/<hash>_fallback.mpd on the
+// alternate CDN) stream. Remapping a PRIMARY request to FALLBACK (when present)
+// makes the player load the ad-free manifest from the first request — verified
+// primary/fallback URL pair captured on-device 7.9.0.61. Class name not obfuscated.
+// ─────────────────────────────────────────────────────────────────────────────
+
+internal object GetStreamInfoFingerprint : Fingerprint(
+    custom = { method, _ ->
+        method.definingClass ==
+            "Lcom/discovery/player/common/models/PlayableKt;" &&
+            method.name == "getStreamInfo"
+    },
+)

--- a/patches/src/main/kotlin/app/morphe/patches/hbomax/HBOPreferFallbackStreamPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/hbomax/HBOPreferFallbackStreamPatch.kt
@@ -1,0 +1,66 @@
+package app.morphe.patches.hbomax.ads
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.shared.compat.AppCompatibilities
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HBO Max — Prefer Ad-Free Stream  (DEFAULT ON — field-verified 7.9.0.61)
+//
+// The clean SSAI fix, using HBO's OWN ad-free manifest.
+//
+// An ad-supported HBO Playable carries TWO streams (StreamInfo): a PRIMARY stream
+// whose DASH manifest is ad-stitched (…/dash.mpd) and a FALLBACK stream whose
+// manifest is the clean, non-stitched variant (…/<hash>_fallback.mpd on the
+// alternate CDN). Captured on-device (7.9.0.61):
+//   PRIMARY : https://<token>.cf.prd.media.h264.io/gcs/<uuid>/dash.mpd
+//   FALLBACK: https://akm.prd.media.h264.io/gcs/<uuid>/<hash>_fallback.mpd
+// HBO only switches to FALLBACK through its resiliency recovery after a load
+// failure — which is why the "Block SSAI Ad Origins" approach reaches it only on a
+// fresh start and fatals (39999) on a resumed mid-roll.
+//
+// PlayableKt.getStreamInfo(Playable, StreamInfo$Type) resolves a stream by type.
+// This patch injects HboStreamSelector.preferFallbackType() at its entry to remap a
+// PRIMARY request to FALLBACK — but ONLY when the Playable actually advertises a
+// FALLBACK stream (reflection-guarded, fail-open), so titles without one are left
+// untouched. The player then loads the ad-free manifest from the very first
+// request, on fresh start AND resume: no ad periods exist, so no ads, no SSAI
+// markers/countdown, no seekbar lock, no timeline gaps, and no post-start -free
+// failure to fatal on. This is HBO's own sanctioned ad-free stream, so playback
+// machinery stays consistent.
+//
+// Field-verified on 7.9.0.61 (Onn 4K): 20-min Health Monitor run with 4
+// resume→seek stress cycles — zero ad leaks, no 39999, no stalls, faster load;
+// the remap fires on every resume. Default ON — this is the clean fix for the
+// returning-ads / resume-39999 reports (#125) and supersedes the downstream
+// approaches (Block SSAI Ad Origins fatal-on-resume).
+// ─────────────────────────────────────────────────────────────────────────────
+@Suppress("unused")
+val hboPreferFallbackStreamPatch = bytecodePatch(
+    name = "HBO Max - Prefer Ad-Free Stream",
+    description = "Loads HBO's own ad-free FALLBACK manifest instead of the ad-stitched " +
+        "PRIMARY one by remapping the stream selection in getStreamInfo (only when a " +
+        "FALLBACK stream exists). Ad-free on fresh start and resume with no markers, no " +
+        "timeline gaps, and no 'Couldn't Play Content' (39999) error — and loads faster " +
+        "since no ads are stitched. On by default; field-verified on 7.9.0.61.",
+    default = true,
+) {
+    compatibleWith(AppCompatibilities.HBO_TV)
+
+    // Merges HboStreamSelector into the patched dex.
+    extendWith("extensions/extension.mpe")
+
+    execute {
+        // getStreamInfo is static: p0=Playable, p1=StreamInfo$Type. Remap p1 at
+        // entry so a PRIMARY lookup resolves the FALLBACK (ad-free) stream when one
+        // is present; the returned type is cast back to StreamInfo$Type.
+        GetStreamInfoFingerprint.method.addInstructions(
+            0,
+            """
+                invoke-static {p0, p1}, Lajstrick81/morphe/extension/hbomax/ads/HboStreamSelector;->preferFallbackType(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+                move-result-object p1
+                check-cast p1, Lcom/discovery/player/common/models/StreamInfo${'$'}Type;
+            """.trimIndent(),
+        )
+    }
+}


### PR DESCRIPTION
## The clean fix for #125
Fixes the returning-ads / unskippable-ads reports by loading **HBO's own ad-free manifest** — no side effects, resume-safe, and it loads *faster*.

## Mechanism
An ad-supported HBO Playable carries **two** streams (`StreamInfo`):
- **PRIMARY** — ad-stitched (`…/dash.mpd`)
- **FALLBACK** — ad-free (`…/<hash>_fallback.mpd`, the manifest HBO's own resiliency serves on its alternate CDN)

Captured live on-device (7.9.0.61):
```
PRIMARY : https://<token>.cf.prd.media.h264.io/gcs/<uuid>/dash.mpd
FALLBACK: https://akm.prd.media.h264.io/gcs/<uuid>/<hash>_fallback.mpd
```
Normal playback uses PRIMARY. This patch injects `HboStreamSelector` at the entry of `PlayableKt.getStreamInfo(Playable, StreamInfo$Type)` to remap a **PRIMARY → FALLBACK** request — **only when a FALLBACK stream exists** (reflection on non-obfuscated `getStreamInfos()`/`getType()`, fail-open), so titles without one are untouched.

## Result
The player loads the ad-free manifest from the first request, on **fresh start and resume alike**: no ads, no SSAI markers/countdown, no seekbar lock, no timeline gaps, and **no `Couldn't Play Content` (39999)** — plus faster load (no ad stitching).

## Why this over the alternatives (all tried + reverted this cycle)
| Approach | Wall |
|---|---|
| Block SSAI Ad Origins (shipped opt-in) | fails ad segments downstream; only recovers at video-start → **resumed mid-roll fatals 39999** |
| Strip Stitched Ad Periods | manifest surgery left timeline **gaps + markers + rewind** |
| Force Ad-Free CDN | **wrong layer** (segment CDN, not the manifest) |

This one uses HBO's own sanctioned ad-free stream, so playback machinery stays consistent.

## Verification
On-device (Onn 4K, 7.9.0.61), **20-min Health Monitor run with 4 resume→seek stress cycles**: **zero ad leaks, no 39999, no stalls**; the PRIMARY→FALLBACK remap fires on every resume. Ships **default-on**.

Refs #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)