### PR TITLE
docs(readme): HBO Max fully ad-free by default (v1.30.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ I'm just like you — I enjoy watching TV and movies without being bored and ann
 | 🟢 Disney+ | `com.disney.disneyplus` | Working | `26.12.1+rc1-2026.07.15` | 7/21/26 |
 | 🟢 Prime Video | `com.amazon.amazonvideo.livingroom` | Working — native in-app ad strip (movies + TV shows), no DNS required | `6.23.23+v15.5.0.70-armv7a` | 7/30/26 |
 | 🟢 Netflix | `com.netflix.ninja` | Working — native in-app ad strip (pre-roll, mid-roll, pause-screen ad), no DNS required. Installs as a **side-by-side clone**; keep stock Netflix installed | `13.0.1 build 25028` | 8/14/26 |
-| 🟢 HBO Max | `com.wbd.hbomax` | Working — removes ad markers/UI by default. Optional **Block SSAI Ad Origins** patch (opt-in, off by default) removes the stitched ad *video* entirely (no pre-rolls/mid-rolls) by failing the SSAI ad origins so the app falls back to the clean stream — reproduces the AdGuard DNS block in-app; covers US & EU regions | `v7.9.0.61` | 8/18/26 |
+| 🟢 HBO Max | `com.wbd.hbomax` | Working — **fully ad-free by default** (v1.30.0). The **Prefer Ad-Free Stream** patch loads HBO's own ad-free manifest (its resiliency-fallback stream), so pre-rolls, mid-rolls, and even the ad-tier's stitched **SSAI baked-in ads** are gone — along with the ad markers/countdown — on both fresh start and resume, and it loads faster. No DNS required. (Legacy opt-in **Block SSAI Ad Origins** is now off by default and superseded.) | `v7.9.0.61` | 8/26/26 |
 | 🟢 Peacock | `com.peacocktv.peacockandroid` | Working — no DNS required | `v7.6.100` | 7/16/26 |
 | 🟢 Tubi | `com.tubitv` | Working | `v10.28.5000` | 7/20/26 |
 | 🟢 ViX | `com.univision.prendetv` | Working | `v4.47.2_tv` | 7/11/26 |


### PR DESCRIPTION
Updates the HBO Max status row to reflect the **Prefer Ad-Free Stream** fix shipped in v1.30.0 (loads HBO's own ad-free fallback manifest — removes the ad-tier's stitched SSAI ads too, resume-safe, faster load) and bumps the date. Legacy Block SSAI Ad Origins noted as off-by-default/superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)