### PR TITLE
fix(paramount): revert live-slate PTS-align off the player hot path (#91)

### DIFF
--- a/experimental/primevideo-libignite-native/jni/.gitignore
+++ b/experimental/primevideo-libignite-native/jni/.gitignore
@@ -1,1 +1,2 @@
 build-v7a/
+build-diag/

--- a/experimental/primevideo-libignite-native/jni/hooks.cpp
+++ b/experimental/primevideo-libignite-native/jni/hooks.cpp
@@ -206,12 +206,40 @@ void maybe_empty_regolith(void* vbuf, size_t n) {
 inline void maybe_empty_regolith(void*, size_t) {}
 #endif
 
+// DIAGNOSTIC (read-only, build with -DPV_LOG_MANIFEST=1): if the in-gate buffer
+// carries the PRS manifest URL, log a window of it. Used to recover the FULL
+// `ta.vod-dash.../iad_2/...` manifest URL structure so we can judge whether an
+// ad-free sibling exists on the same CDN (in-session URL-rewrite pivot). NEVER
+// writes — reads only, so it can't trip the gzip-CRC (CURL 61) failure mode.
+#if defined(PV_LOG_MANIFEST) && PV_LOG_MANIFEST
+void log_manifest_url(const char* s, size_t n) {
+    static const char* kNeedles[] = { "vod-dash", "playbackUrls", ".mpd", "pv-cdn.net" };
+    for (const char* needle : kNeedles) {
+        size_t nl = ::strlen(needle);
+        if (n < nl) continue;
+        for (size_t i = 0; i + nl <= n; ++i) {
+            if (::memcmp(s + i, needle, nl) != 0) continue;
+            // walk back to the opening quote, forward to the closing quote
+            size_t b = i; while (b > 0 && s[b-1] != '"' && (i - b) < 400) --b;
+            size_t e = i; while (e < n && s[e] != '"' && (e - i) < 600) ++e;
+            char buf[640]; size_t len = e - b; if (len > sizeof(buf)-1) len = sizeof(buf)-1;
+            ::memcpy(buf, s + b, len); buf[len] = '\0';
+            LOGI("PVMANIFEST [%s] n=%zu: %s", needle, n, buf);
+            return; // one per buffer is enough
+        }
+    }
+}
+#endif
+
 void maybe_strip(const void* src, size_t n, const void* caller) {
     g_calls_total.fetch_add(1, std::memory_order_relaxed);
     if (src == nullptr || n < kMinScanLen || n > kMaxScanLen) return;
     if (is_decompress_chunk(n)) { g_skipped_chunk.fetch_add(1, std::memory_order_relaxed); return; }
     maybe_empty_regolith(const_cast<void*>(src), n);   // TV: empty regolith ad-decision response (dst-side)
     g_calls_in_gate.fetch_add(1, std::memory_order_relaxed);
+#if defined(PV_LOG_MANIFEST) && PV_LOG_MANIFEST
+    log_manifest_url(static_cast<const char*>(src), n);
+#endif
 
     uint64_t prev_max = g_max_n.load(std::memory_order_relaxed);
     if (n > prev_max) g_max_n.store(n, std::memory_order_relaxed);

--- a/patches/src/main/kotlin/app/morphe/patches/paramount/ParamountPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/paramount/ParamountPatch.kt
@@ -132,24 +132,26 @@ val paramountPatch = bytecodePatch(
         // original body (which re-initializes its own registers), matching the
         // ":morphe_continue nop" fall-through idiom.
         //
-        // Smoothness (PTS alignment): a pure URL-redirect delivers the slate media
-        // with the SLATE asset's own base PTS, stitched onto the live edge — so each
-        // segment boundary and every 0..N loop is a discontinuity → ExoPlayer's live
-        // adjuster jumps/skips ("choppy", issue #91). Instead of letting okhttp follow
-        // the 302, this proceeds the slate request, then hands the ORIGINAL ad URL and
-        // the slate URL to the MorpheTsRewriter extension, which fetches the slate media
-        // out-of-band, PTS-aligns it onto the real ad slot's live-edge timeline
-        // (deterministic podBase + N*SEG_TICKS, real head fetched once per pod), and
-        // returns the rewritten bytes. Those are delivered as a synthetic 200 (Location
-        // removed so okhttp does not follow the redirect). The result is a smooth branded
-        // card that hands back to live content exactly. On ANY failure alignSlateToLive
-        // returns null and we return the original 302 → okhttp follows it to the slate
-        // exactly like the previous redirect behavior (never worse; never real ads).
+        // Smoothness note (v1.30.2 — reverted the PTS-align hot-path): v1.30.1 tried to
+        // smooth the slate by PTS-aligning it in-interceptor via the MorpheTsRewriter
+        // extension — it proceeded the slate request, then SYNCHRONOUSLY out-of-band
+        // fetched the slate media (up to 16MB) + a real-ad head and byte-rewrote PTS/PCR
+        // on the okhttp call thread the player was blocked on. That validated smooth on a
+        // fast Onn 4K + LAN, but on weaker hardware / slower networks (tester report,
+        // issue #91: TiVo Stream 4K) the added serialized latency starved the player
+        // pipeline → AVIA watchdog bailed to the profile-selection screen at EVERY break
+        // (a hard regression vs the merely-choppy v1.29.2). The null-return failsafe only
+        // covered exceptions, not "succeeded but too slow", so slowness had no safety net.
+        // Until the smoother is re-architected OFF the hot path (warm the slate cache
+        // async at break start + a per-segment deadline fallback), this reverts to the
+        // proven pure URL-redirect: proceed the rewritten slate request and return its 302
+        // so okhttp follows it to the slate media (v1.29.2 behavior — choppy on segment
+        // boundaries, but plays on all hardware, never crashes, never real ads). The
+        // MorpheTsRewriter extension + keep-rule are retained unused for that rework.
         //
         // Register note: intercept() carries the Chain in a high param register (p1),
-        // moved to v0 first. v1 = original ad URL (preserved for the aligner), v4 = slate
-        // URL, v5 = proceeded response; v2/v3/v6/v7/v8 scratch. Non-ad requests fall
-        // through to the original body via ":morphe_continue nop".
+        // moved to v0 first. v1 = ad URL, v4 = slate URL, v5 = proceeded response;
+        // v2/v3 scratch. Non-ad requests fall through via ":morphe_continue nop".
         // ------------------------------------------------------------------
         AviaNetworkInterceptorFingerprint.method.addInstructions(
             0,
@@ -211,33 +213,6 @@ val paramountPatch = bytecodePatch(
                 move-result-object v2
                 invoke-interface {v0, v2}, Lokhttp3/Interceptor${'$'}Chain;->proceed(Lokhttp3/Request;)Lokhttp3/Response;
                 move-result-object v5
-                invoke-static {v1, v4}, Lajstrick81/morphe/extension/paramount/ads/MorpheTsRewriter;->alignSlateToLive(Ljava/lang/String;Ljava/lang/String;)[B
-                move-result-object v6
-                if-eqz v6, :morphe_giveback
-                array-length v7, v6
-                if-eqz v7, :morphe_giveback
-                const/4 v7, 0x0
-                invoke-static {v7, v6}, Lokhttp3/ResponseBody;->create(Lokhttp3/MediaType;[B)Lokhttp3/ResponseBody;
-                move-result-object v6
-                invoke-virtual {v5}, Lokhttp3/Response;->newBuilder()Lokhttp3/Response${'$'}Builder;
-                move-result-object v7
-                const/16 v8, 0xc8
-                invoke-virtual {v7, v8}, Lokhttp3/Response${'$'}Builder;->code(I)Lokhttp3/Response${'$'}Builder;
-                move-result-object v7
-                const-string v8, "OK"
-                invoke-virtual {v7, v8}, Lokhttp3/Response${'$'}Builder;->message(Ljava/lang/String;)Lokhttp3/Response${'$'}Builder;
-                move-result-object v7
-                const-string v8, "Location"
-                invoke-virtual {v7, v8}, Lokhttp3/Response${'$'}Builder;->removeHeader(Ljava/lang/String;)Lokhttp3/Response${'$'}Builder;
-                move-result-object v7
-                const-string v8, "Content-Length"
-                invoke-virtual {v7, v8}, Lokhttp3/Response${'$'}Builder;->removeHeader(Ljava/lang/String;)Lokhttp3/Response${'$'}Builder;
-                move-result-object v7
-                invoke-virtual {v7, v6}, Lokhttp3/Response${'$'}Builder;->body(Lokhttp3/ResponseBody;)Lokhttp3/Response${'$'}Builder;
-                move-result-object v7
-                invoke-virtual {v7}, Lokhttp3/Response${'$'}Builder;->build()Lokhttp3/Response;
-                move-result-object v5
-                :morphe_giveback
                 return-object v5
                 :morphe_continue
                 nop


### PR DESCRIPTION
## What

Reverts Paramount+ live-sports slate smoothing (Patch 3) back to the proven **pure slate URL-redirect** — the last build that played reliably on all hardware.

## Why

v1.30.1 (#139) tried to smooth the "Commercial in Progress" slate by PTS-aligning it **inside the AVIA network interceptor**: per ad segment it synchronously fetched the slate media out-of-band (up to 16MB) plus a real-ad head and byte-rewrote PTS/PCR — all on the okhttp call thread the player was blocked on.

That validated smooth on a fast Onn 4K + LAN, but on weaker hardware / slower networks the added serialized latency **starved the player pipeline**. Field tester @pixel8323 (issue #91, TiVo Stream 4K) reported the app bailing to the **profile-selection screen at every commercial break** during a live UFC event and a soccer match — a hard regression versus v1.29.2, which merely stuttered but always played. The null-return failsafe only covered exceptions, not "align succeeded but too slow", so latency had no safety net.

Per the same tester's earlier UFC report, the pure-redirect build was the best *reliable* outcome: the "STAY TUNED… WE'LL BE RIGHT BACK!" slate on most breaks with **no crashes**, mostly smooth (intermittent content-dependent freezes on some breaks, more on soccer).

## Change

Patch 3 now: rewrite the ad-pod request to the `/slate/0/` rendition, keep the self-correcting `?d=` duration learning, `proceed()` once, and return the 302 so okhttp follows it to the slate media. No out-of-band fetch, no PTS rewrite on the hot path.

The `MorpheTsRewriter` extension + `-keep` rule are left in the tree (unused) for a future **off-hot-path** rework: warm the slate cache asynchronously at break start + a per-segment deadline fallback, so smoothing never blocks segment delivery on weak hardware.

## Verification

- `:patches:buildAndroid` builds the bundle clean.
- Reverts to previously-shipped-and-working v1.29.2 interceptor behavior.

Fixes the crash regression reported in #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
