### PR TITLE
fix(paramount): harden ad-patch fingerprints; verify + support v16.19.0

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/paramount/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/paramount/Fingerprints.kt
@@ -1,8 +1,24 @@
 /*
  * Paramount+ Android TV — Ad Patch Fingerprints
  *
- * Validated against v16.17.0 (versionCode 520000758) — com.cbs.ott.
- * See ParamountPatch.kt for the mechanism write-up.
+ * Validated against v16.17.0 (versionCode 520000758) and v16.19.0
+ * (versionCode 520000827) — com.cbs.ott. All three targets survived the
+ * 16.17 -> 16.19 bump unchanged. See ParamountPatch.kt for the mechanism.
+ *
+ * HARDENING NOTES (survive future version bumps):
+ *   - Each class anchor matches the UNIQUE leaf class name (e.g.
+ *     "/AviaDAIResourceProvider;") rather than the full package path, so a
+ *     package reshuffle inside the AVIA library doesn't break the match. Each
+ *     leaf name was confirmed unique in the APK, and inner classes end in
+ *     "$N;" so they can't be caught by the outer-class anchor.
+ *   - Method-name anchors are used ONLY where the name is stable: shouldPlayAd
+ *     and intercept are readable (AVIA is not name-obfuscated; intercept is a
+ *     fixed okhttp interface method). CbsPauseWithAdsOverlay's render method IS
+ *     R8-renamed (a single letter that changes per version), so it can only be
+ *     found by its log string — see Patch 2.
+ *   - String anchors are kept to the SINGLE most distinctive literal to halve
+ *     the string-drift failure surface (two required strings = two ways to
+ *     break); the chosen literal is specific enough to stay unique in-class.
  */
 
 package app.morphe.patches.paramount
@@ -15,26 +31,32 @@ import app.morphe.patcher.Fingerprint
 // The AVIA DAI provider gates each ad pod through shouldPlayAd(); its position
 // monitor (AviaDAIResourceProvider$3) skips the pod natively when this returns
 // false. Forcing false removes VOD pre-roll ads while the DAI stream keeps
-// playing. Private direct method, matched by name + defining class.
+// playing. Private direct method — matched by its (readable, stable) name +
+// boolean return + unique leaf class name.
 // ---------------------------------------------------------------------------
 
 internal object ShouldPlayAdFingerprint : Fingerprint(
     returnType = "Z",
     custom = { method, _ ->
         method.name == "shouldPlayAd" &&
-            method.definingClass.endsWith(
-                "/player/resource/dai/AviaDAIResourceProvider;",
-            )
+            method.definingClass.endsWith("/AviaDAIResourceProvider;")
     },
 )
 
 // ---------------------------------------------------------------------------
 // Patch 2: Pause ads — CbsPauseWithAdsOverlay state machine
+//
+// The overlay-render method is R8-renamed (a per-version single letter), so it
+// cannot be matched by name. It is instead anchored by its distinctive render
+// log literal + void return + the (stable, resource-referenced) leaf class
+// name. " not updating overlay." is the more distinctive of the two original
+// log strings and is unique within the class; matching it alone means an edit
+// to the "renderState: " prefix no longer breaks the patch.
 // ---------------------------------------------------------------------------
 
 internal object PauseAdOverlayFingerprint : Fingerprint(
     returnType = "V",
-    strings = listOf("renderState: ", " not updating overlay."),
+    strings = listOf(" not updating overlay."),
     custom = { method, _ ->
         method.definingClass.endsWith("CbsPauseWithAdsOverlay;")
     },
@@ -50,7 +72,8 @@ internal object PauseAdOverlayFingerprint : Fingerprint(
 // We rewrite each ad-pod request to the SAME pod's "slate" rendition
 // (/<pod>/<slot>/<adIdx>/<hash>/ -> /<pod>/slate/0/<hash>/), which is Paramount's
 // own server-served "Commercial in Progress" branded card — a real segment on
-// the live timeline. Matched by okhttp interface method name + AVIA class.
+// the live timeline. Matched by the fixed okhttp interface method name
+// (intercept), the okhttp3.Response return, and the unique leaf class name.
 // okhttp3 is not renamed in this app, so Lokhttp3/* types are used directly.
 // ---------------------------------------------------------------------------
 
@@ -58,6 +81,6 @@ internal object AviaNetworkInterceptorFingerprint : Fingerprint(
     returnType = "Lokhttp3/Response;",
     custom = { method, _ ->
         method.name == "intercept" &&
-            method.definingClass.endsWith("/network/AviaNetworkInterceptor;")
+            method.definingClass.endsWith("/AviaNetworkInterceptor;")
     },
 )

--- a/patches/src/main/kotlin/app/morphe/patches/paramount/ParamountPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/paramount/ParamountPatch.kt
@@ -5,6 +5,8 @@
  *   v16.8.0  (versionCode 520000464) — com.cbs.ott  [empty-request era, see history]
  *   v16.12.0 (versionCode 520000571) — com.cbs.ott
  *   v16.17.0 (versionCode 520000758) — com.cbs.ott  [current mechanism]
+ *   v16.19.0 (versionCode 520000827) — com.cbs.ott  [fingerprints re-verified;
+ *                                       all three targets unchanged vs 16.17.0]
  *
  * MECHANISM (v16.17.0, on-device verified 2026-08-04):
  *   The AVIA player's DAI resource provider

--- a/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/compat/AppCompatibilities.kt
@@ -10,6 +10,7 @@ object AppCompatibilities {
     packageName = "com.cbs.ott",
     appIconColor = 0x0064FF,
     targets = listOf(
+        AppTarget("16.19.0"),
         AppTarget("16.17.0"),
         AppTarget("16.12.0"),
         AppTarget("16.8.0"),


### PR DESCRIPTION
## What

Hardens the Paramount+ ad-patch fingerprints against future version bumps, and verifies + adds support for **v16.19.0** (versionCode 520000827).

## Version diff (16.17.0 → 16.19.0)

Decompiled the merged 16.19.0 APK and checked all three ad-patch targets. **All survived the bump unchanged:**

| Patch | Target | 16.19.0 status |
|---|---|---|
| 1 — VOD gate | `AviaDAIResourceProvider.shouldPlayAd(AviaAdPod)Z` | present, same signature |
| 2 — Pause ads | `CbsPauseWithAdsOverlay` render method (R8-renamed) | both log strings present |
| 3 — Live slate | `AviaNetworkInterceptor.intercept(Chain)Lokhttp3/Response;` | present, `.locals 20` |

Added `16.19.0` to the compatibility targets (Morphe requires an exact versionName match to download/patch).

## Hardening

- **Class anchors → unique leaf name.** Each fingerprint now matches on the unique leaf class name (e.g. `/AviaDAIResourceProvider;`) instead of the full package path, so a package reshuffle inside the AVIA library no longer breaks the match. Each leaf name was confirmed unique in the APK; inner classes end in `$N;` so the outer-class anchor can't catch them.
- **Patch 2 → single string.** The pause-overlay render method is R8-renamed (a per-version single letter) so it can only be found by a log literal. It now anchors on the single most distinctive string (`" not updating overlay."`) instead of two, halving the string-drift failure surface while staying unique in-class.
- **Method-name anchors kept only where stable:** `shouldPlayAd` (AVIA is not name-obfuscated) and the fixed okhttp interface method `intercept`.

## Verification

- `:patches:buildAndroid` builds the bundle clean.
- Morphe CLI applies the patch to a merged 16.19.0 APK: **`Applied: Paramount+ Android TV`** with the dex compiling — i.e. all three hardened fingerprints resolve and all injections assemble on the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
