### PR TITLE
chore: ignore off-drive archive scratch (scratchmlb, apks-archive)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ local.properties
 # patch classpath" (frida-gadget is redistributable under its wxWindows licence).
 patches/src/main/resources/netflix/native/**/*.so
 !patches/src/main/resources/netflix/native/armeabi-v7a/libgadget.so
+scratchmlb/

--- a/testing/.gitignore
+++ b/testing/.gitignore
@@ -19,3 +19,6 @@ config/device.env
 *.apks
 *.xapk
 *.mpp
+
+# Junction to D:\morphe-archivepks (large APK library, off-drive)
+apks-archive/


### PR DESCRIPTION
## What
Add two `.gitignore` entries for local-only, off-drive working storage:

- `scratchmlb/` — MLB.tv slate-capture working tree (archived to the D: USB drive)
- `testing/apks-archive/` — Windows junction pointing to the D: APK library

## Why
C: was running critically low on space. Bulky capture trees and the large APK
library now live on the D: USB drive; a junction (`testing/apks-archive/`)
gives the repo quick access to archived APKs without keeping the bytes on C:.
These are local-only working paths and should never be tracked.

Hygiene only — no behavior change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)