### PR TITLE
fix(pluto): detect VOD ads positively so un-DRM'd-content titles don't break (#144)

### DIFF
--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/pluto/ads/PlutoDashManifestProbe.java
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/pluto/ads/PlutoDashManifestProbe.java
@@ -25,12 +25,28 @@ import java.util.List;
  * touches the streaming OkHttp client (wrapping that black-screens playback), so it
  * cannot break the fetch pipeline.
  *
- * <p>Classification (on-device, tv.pluto.android 5.66.0-leanback): content periods
- * carry a DRM rendition path ({@code 720pDRM}/{@code 1080pDRM}/…); BOTH ad flavors
- * are un-DRM'd — {@code siloh…/_ad/creative/…} and {@code …/head(…)/sign/v1/…}. So a
- * {@code pDRM} rendition marker rendition-independently identifies content (verified:
- * 14 content periods = the exact 2:18:41 runtime, 62 un-DRM'd ad periods = 31:17,
- * zero unclassified; 2:49:58 → 2:18:41 with mid-rolls gone).
+ * <p><b>Classification (issue #144 fix, 2026-09-03, on-device recon of two titles):</b>
+ * detect ADS <i>positively</i> by the ad-creative URL signature and keep everything
+ * else. The old heuristic — "content == a {@code pDRM} rendition path" — was WRONG:
+ * <ul>
+ *   <li>Some titles serve their real content <b>un-DRM'd</b> (Supermarket Sweep:
+ *       {@code siloh…/627_Fremantle/clip/…_Supermarket_Sweep_Episode_1151/720p/…}),
+ *       so the pDRM test dropped all content and collapsed the episode to a 10s stub
+ *       → the player looped / skipped / autoplay-advanced (the #144 report).</li>
+ *   <li>The only {@code pDRM} period on that title was a 10s <b>ad bumper</b>
+ *       ({@code …/196_Pluto_TV_OandO/clip/…_ad_bumper_animation…/1080pDRM/}), so the
+ *       pDRM test actually KEPT the ad and threw away the show. That same bumper rides
+ *       along on DRM'd titles too, where the old code silently kept it.</li>
+ * </ul>
+ * Both ad flavors carry an unambiguous marker that content never does:
+ * <ul>
+ *   <li>ad spots → {@code _ad/creative} in the path (URL-encoded {@code _ad%2Fcreative}
+ *       under {@code /v1/mp4/…/p(…)}),</li>
+ *   <li>the bumper → {@code _ad_bumper}.</li>
+ * </ul>
+ * Content clips ({@code …/clip/{id}_{ShowName}_{Episode}/…}) contain neither, DRM or
+ * not. Verified: catches all ad spots + both bumpers across Supermarket Sweep (un-DRM'd
+ * content) and Workaholics (DRM'd content) with zero content false-positives.
  */
 @SuppressWarnings("unused")
 public final class PlutoDashManifestProbe {
@@ -38,24 +54,32 @@ public final class PlutoDashManifestProbe {
     private static final String TAG = "MORPHE-DASH-MF";
 
     /**
-     * True if a period is real movie CONTENT (not an ad): any representation BaseUrl
-     * carries a DRM rendition path ({@code pDRM}). Both ad flavors are un-DRM'd.
+     * True if a period is an AD (an ad spot or the ad bumper), detected by the
+     * ad-creative URL signature. Everything that is NOT an ad — real content, whether
+     * DRM'd or not, and any unrecognized period — is kept, so the strip can never drop
+     * content it doesn't recognize (the failure mode behind issue #144). At worst an
+     * ad flavor we don't yet know stays in (an ad plays), never a lost episode.
      */
-    static boolean isContentPeriod(Period period) {
+    static boolean isAdPeriod(Period period) {
         try {
             for (AdaptationSet set : period.adaptationSets) {
                 for (Representation rep : set.representations) {
                     List<BaseUrl> baseUrls = rep.baseUrls;
                     if (baseUrls == null) continue;
                     for (BaseUrl base : baseUrls) {
-                        if (base.url != null && base.url.contains("pDRM")) {
-                            return true;
-                        }
+                        if (base.url == null) continue;
+                        String u = base.url;
+                        // ad spots: "_ad/creative" — the '/' arrives percent-encoded
+                        // (%2F) in the stitched manifest, so match both forms.
+                        if (u.contains("_ad%2Fcreative") || u.contains("_ad/creative")) return true;
+                        // the pDRM ad-bumper animation between pods
+                        if (u.contains("_ad_bumper")) return true;
                     }
                 }
             }
         } catch (Throwable ignored) {
-            // Defensive: any structural surprise -> treat as content (never over-strip).
+            // Defensive: any structural surprise -> treat as NOT an ad (keep it), so we
+            // never drop content on a parse we couldn't fully inspect.
         }
         return false;
     }
@@ -64,29 +88,24 @@ public final class PlutoDashManifestProbe {
      * Called from injected smali at the return of {@code DashManifestParser.parse}.
      * Removes ad periods and rebuilds a contiguous content-only manifest.
      *
-     * <p>Keeps only content periods ({@link #isContentPeriod}), re-bases each kept
-     * period's {@code startMs} to run immediately after the previous one (closing the
-     * gaps the removed ad periods leave — a gap would strand media3 on a missing
-     * period), and rebuilds the {@link DashManifest} with the shrunken duration.
-     * Fail-open: if anything is unexpected (no content periods found, any exception)
-     * it returns the ORIGINAL manifest untouched, so playback never breaks — at worst
-     * the ads remain.
+     * <p>Drops the ad periods ({@link #isAdPeriod}), re-bases each kept period's
+     * {@code startMs} to run immediately after the previous one (closing the gaps the
+     * removed ad periods leave — a gap would strand media3 on a missing period), and
+     * rebuilds the {@link DashManifest} with the shrunken duration. Fail-open on every
+     * edge (dynamic/live manifest, nothing kept, an implausible over-strip, or any
+     * exception) → returns the ORIGINAL manifest untouched, so playback never breaks.
      */
     public static DashManifest stripAdPeriods(DashManifest manifest) {
         try {
             if (manifest == null) return null;
 
             // LIVE TV guard. Only VOD is in scope: on-demand titles are STATIC DASH
-            // (manifest.dynamic == false, a fixed set of periods with a known total
-            // duration). Live/linear channels are DYNAMIC DASH — the manifest is
-            // continuously re-issued with a moving live edge and a wall-clock
-            // timeline, and re-basing period startMs there corrupts that timeline:
-            // the player can't advance past a period boundary and loops/rebuffers on
-            // the same few seconds (reported on Nvidia Shield, v1.17.0). Live ads are
-            // real broadcast time and were never removable anyway, so leave dynamic
-            // manifests completely untouched. (VOD briefly serves a dynamic startup
-            // manifest too; passing it through is harmless — the ad periods live in
-            // the static full manifest that follows.)
+            // (manifest.dynamic == false). Live/linear channels are DYNAMIC DASH — a
+            // moving live edge and wall-clock timeline; re-basing period startMs there
+            // corrupts it (player loops/rebuffers, reported on Nvidia Shield v1.17.0).
+            // Live ads are real broadcast time and were never removable. VOD's brief
+            // dynamic startup manifest is passed through harmlessly (the ad periods live
+            // in the static full manifest that follows).
             if (manifest.dynamic) {
                 Log.i(TAG, "dynamic (live) manifest -> untouched, periods=" + manifest.getPeriodCount());
                 return manifest;
@@ -99,18 +118,29 @@ public final class PlutoDashManifestProbe {
             for (int i = 0; i < n; i++) {
                 Period p = manifest.getPeriod(i);
                 long durMs = manifest.getPeriodDurationMs(i);
-                if (isContentPeriod(p)) {
+                if (isAdPeriod(p)) {
+                    removed++;
+                } else {
                     // Rebuild at the re-based start; adaptation sets, event streams and
                     // asset identifier carry through intact (segment timelines are
                     // period-relative, so re-basing startMs keeps them addressable).
                     kept.add(new Period(p.id, cursor, p.adaptationSets, p.eventStreams, p.assetIdentifier));
                     cursor += durMs;
-                } else {
-                    removed++;
                 }
             }
             if (kept.isEmpty()) {
-                Log.w(TAG, "no content periods found (of " + n + ") -> passthrough");
+                Log.w(TAG, "no content periods kept (of " + n + ") -> passthrough");
+                return manifest;
+            }
+            // FAIL-SAFE GUARD (issue #144 backstop): real ad load is ~18-30% of runtime
+            // (content stays >=~70%). If we'd keep less than 40% of the original
+            // duration, an unrecognized content shape has probably been mis-dropped;
+            // bail to the original so a future stitching change can never re-introduce
+            // the collapse-to-stub regression. With the positive ad-detector this should
+            // not trip on known titles — it's a safety net, not the primary mechanism.
+            if (manifest.durationMs > 0 && cursor < manifest.durationMs * 4 / 10) {
+                Log.w(TAG, "GUARD tripped: kept " + kept.size() + "/" + n + " -> "
+                        + cursor + "ms of " + manifest.durationMs + "ms (<40%) -> passthrough");
                 return manifest;
             }
             DashManifest out = new DashManifest(

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/pluto/ads/SkipAdsPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/pluto/ads/SkipAdsPatch.kt
@@ -82,9 +82,13 @@ val skipAdsPatch = bytecodePatch(
         // obfuscated in this build, so we route the parsed manifest through
         // stripAdPeriods at DashManifestParser.parse's return (post-download,
         // post-parse — it never touches the streaming OkHttp client, which
-        // black-screens playback when wrapped). It keeps only content periods
-        // (DRM rendition path; both ad flavors — siloh/_ad/creative and head/sign —
-        // are un-DRM'd), re-bases them contiguous, and rebuilds the manifest.
+        // black-screens playback when wrapped). It DROPS the ad periods, detected
+        // positively by the ad-creative URL signature (_ad/creative on the spots,
+        // _ad_bumper on the pod bumper), and keeps everything else (content, DRM'd
+        // or not) — re-bases the kept periods contiguous and rebuilds the manifest.
+        // Positive ad-detection (vs trusting a DRM marker for content) is the issue
+        // #144 fix: some titles serve content un-DRM'd, so the old content==pDRM test
+        // dropped the whole episode to a 10s stub -> skip/restart.
         // Fail-open: any surprise returns the original manifest (ads remain,
         // playback never breaks). See the pluto-adbreaks-suppression note and the
         // PLUTO_VOD_ADREMOVAL_HANDOFF doc for how this seam was mapped.


### PR DESCRIPTION
## Problem (fixes #144)

Patched Pluto On-Demand videos would **skip or restart randomly** on some titles (not on stock). Root-caused on-device with a Health-Monitor run + a per-period recon build.

Hook 5's DASH period strip classified a `<Period>` as **content** only if a BaseUrl carried a `pDRM` rendition path — assuming content is always DRM'd and ads never are. That's false:

- Some shows serve their real content **un-DRM'd** — e.g. Supermarket Sweep: `siloh.../627_Fremantle/clip/..._Supermarket_Sweep_Episode_1151/720p/...`. The classifier dropped every content period.
- The **only** `pDRM` period on that title was a 10-second **ad bumper** (`.../196_Pluto_TV_OandO/clip/..._ad_bumper_animation.../1080pDRM/`), so the old logic kept the ad and threw the show away.

Result on-device: `STRIPPED 19 ad periods, kept 1 content, newDurationMs=10000 (was 1767908)` — the episode collapsed to a 10s stub → `ExoPlaybackException` → re-parse loop → the stub "ends" → Pluto autoplay-advances the episode. Exactly the reporter's symptom.

## Fix

Invert the classifier — detect **ads positively** by the ad-creative URL signature and keep everything else:

- ad spots → `_ad/creative` (arrives percent-encoded as `_ad%2Fcreative`)
- inter-pod bumper → `_ad_bumper`

Content clips (`.../clip/{id}_{ShowName}_{Episode}/...`) match neither, DRM'd or not. An unrecognized period now defaults to **content** and is never dropped — at worst an unknown ad flavor plays, never a lost episode. A `<40%` over-strip **fail-safe guard** is added as a backstop against future stitching changes.

## Verification (on-device, 5.66.0-leanback, Onn 4K)

| Title | Content DRM? | Before | After |
|---|---|---|---|
| Supermarket Sweep | un-DRM'd | `kept 1 → 10s` (broken, skips/restarts) | `STRIPPED 17, kept 4 content, 29:42 → 22:02` — no ads, no glitch ✅ |
| Workaholics | DRM'd | `kept 6` (incl. a kept ad-bumper) | `STRIPPED 20, kept 5 content` — bumper now removed, stable across re-parses, no ads ✅ |

Zero `ExoPlaybackException`, positions advance monotonically, ad-free on both.

## Known follow-up (separate, tracked)

A resume-from-bookmark **overshoot** can autoplay-skip once when a saved position (in the original ad-inclusive timeline) exceeds the shortened stripped duration; it self-heals on replay. Pre-existing to any timeline-shortening strip, not introduced here. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
