### PR TITLE
feat(peacock): support v7.8.100

### DIFF
--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/SkipAdsPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/ads/SkipAdsPatch.kt
@@ -16,7 +16,7 @@ val skipAdsPatch = bytecodePatch(
     description = "Disables ad delivery via Sky SDK surgical targets (FreeWheel DI module " +
         "skip, MediaTailor SSAI layers, ad-break-started no-op), AdBlockInterceptor wiring " +
         "on both the app NetworkingKt OkHttp client and the Sky SDK addon network client, " +
-        "and a WebView shouldInterceptRequest wrapper. Validated v7.5.102 and v7.6.100.",
+        "and a WebView shouldInterceptRequest wrapper. Validated v7.5.102, v7.6.100 and v7.8.100.",
 ) {
     compatibleWith(Constants.COMPATIBILITY)
 

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/shared/Constants.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/peacock/shared/Constants.kt
@@ -11,6 +11,7 @@ object Constants {
         targets = listOf(
             AppTarget("7.5.102"),
             AppTarget("7.6.100"),
+            AppTarget("7.8.100"),
         )
     )
 }


### PR DESCRIPTION
## Summary
Adds Peacock TV Android TV **v7.8.100** to the Skip-ads / Clone / Disable-auto-updates patch targets (previously 7.5.102 and 7.6.100).

All 9 Skip-ads seams matched the 7.8.100 dex **unchanged** — no fingerprint rework needed:
- Target classes/methods at identical paths (L1 `getProxyHost`, L3 MT service string, L4 `getSsaiConfigurationProvider`, L5 `handleAdBreakStarted`, L6 `getOkHttpClient`, L9 `NativeNetworkApi.<init>`)
- **L8** freewheelModule still at exact instruction index **16/17** in `AddonInjectorImpl.di$lambda$0` (6 imports ahead, unchanged ordering)
- **L7** all three `XTVWebView` constructors present; setWebViewClient located dynamically

## Changes
- `Constants.kt`: add `AppTarget("7.8.100")`
- `SkipAdsPatch.kt`: description now reads "Validated v7.5.102, v7.6.100 and v7.8.100"

`patches-list.json` is intentionally **not** touched here — `release.yml` regenerates it from source on release.

## Verification (Onn 4K, 192.168.12.211)
- Morphe CLI: both patches `Applied` on the merged 7.8.100 universal APK
- Installed clean, `versionName=7.8.100`, process alive, **0** VerifyError / NoClassDefFound / FATAL
- Runtime logcat confirms Layer 7 is live:
  ```
  MORPHE-PCK-WV: wrapClient() — Layer 7 active (randomized responses)
  MORPHE-PCK-WV: BLOCKED [ad]: https://sas.peacocktv.com/commerce/activation/activate
  MORPHE-PCK-WV: BLOCKED [analytics]: https://nbcstreaming.sc.omtrdc.net/ee/v2/interact
  ```

**Not** field-confirmed: ad-free video playback (test unit is not signed into Peacock). Build + boot-safety + ad/analytics interception are confirmed on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)