### PR TITLE
fix(espn): simplify slate picker (Video / Video+Score / Overlay / Blank)

### DIFF
--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/espn/ads/EspnAdBreakOverlayHelper.kt
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/espn/ads/EspnAdBreakOverlayHelper.kt
@@ -530,8 +530,12 @@ object EspnAdBreakOverlayHelper {
     private fun fadeAdsHint() {
         if (pickerView != null) return   // viewer is mid-menu; keep the overlay live
         adsHintPill?.let { p -> p.animate().alpha(0f).setDuration(400).withEndAction { p.visibility = View.GONE }.start() }
-        currentOverlay?.let { it.isFocusable = false; it.isFocusableInTouchMode = false; it.setOnKeyListener(null) }
-        Log.d(TAG, "ads hint faded — ad uncovered")
+        // Fade the pill so the ad is visually uncovered, but KEEP the transparent
+        // overlay focusable with its key listener so a D-pad press can still
+        // reopen the picker. Without this, ADS mode trapped the viewer: once the
+        // hint faded there was no way back to the other slate modes.
+        currentOverlay?.let { it.isFocusable = true; it.isFocusableInTouchMode = true; it.requestFocus() }
+        Log.d(TAG, "ads hint faded — ad uncovered (picker still reachable via D-pad)")
     }
 
     private fun hideSlateNow(reason: String) {

--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/espn/ads/EspnAdBreakOverlayHelper.kt
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/espn/ads/EspnAdBreakOverlayHelper.kt
@@ -73,10 +73,12 @@ object EspnAdBreakOverlayHelper {
     private var currentMode: SlateMode = SlateMode.VIDEO
     private var pickerView: LinearLayout? = null
     private var pickerIndex = 0
-    // CARD/SCOREBOARD are intentionally NOT offered in the picker (CARD stays as
-    // the silent fallback when video/overlay assets are missing).
+    // Picker offers only the four viewer-facing choices. CARD/SCOREBOARD are
+    // internal (CARD is the silent fallback when video/overlay assets are
+    // missing); ADS is marker-only (it releases the remote by design, so it must
+    // not be a picker entry or it would strand the viewer).
     private val PICKER_MODES = listOf(
-        SlateMode.VIDEO, SlateMode.VIDEO_SCORE, SlateMode.OVERLAY, SlateMode.ADS, SlateMode.BLANK,
+        SlateMode.VIDEO, SlateMode.VIDEO_SCORE, SlateMode.OVERLAY, SlateMode.BLANK,
     )
     private var adsHintPill: View? = null
     private val adsHintFade = Runnable { fadeAdsHint() }
@@ -530,12 +532,11 @@ object EspnAdBreakOverlayHelper {
     private fun fadeAdsHint() {
         if (pickerView != null) return   // viewer is mid-menu; keep the overlay live
         adsHintPill?.let { p -> p.animate().alpha(0f).setDuration(400).withEndAction { p.visibility = View.GONE }.start() }
-        // Fade the pill so the ad is visually uncovered, but KEEP the transparent
-        // overlay focusable with its key listener so a D-pad press can still
-        // reopen the picker. Without this, ADS mode trapped the viewer: once the
-        // hint faded there was no way back to the other slate modes.
-        currentOverlay?.let { it.isFocusable = true; it.isFocusableInTouchMode = true; it.requestFocus() }
-        Log.d(TAG, "ads hint faded — ad uncovered (picker still reachable via D-pad)")
+        // Release the overlay so the ad is fully uncovered and the remote returns
+        // to the app. (ADS is no longer offered in the picker — it's marker-only —
+        // so this can't strand a picker user.)
+        currentOverlay?.let { it.isFocusable = false; it.isFocusableInTouchMode = false; it.setOnKeyListener(null) }
+        Log.d(TAG, "ads hint faded — ad uncovered")
     }
 
     private fun hideSlateNow(reason: String) {


### PR DESCRIPTION
## Change
Simplifies the on-screen slate picker to the four viewer-facing choices: **Video**, **Video + Score**, **Be Right Back (ESPN Ad-Break Overlay)**, **Blank**.

"Ads (no slate)" is removed from the picker — by design it releases the remote so the ad plays uncovered, which stranded the viewer with no way back to the other modes. It remains reachable via the `slate_mode` marker for anyone who wants it, and its hint-fade reverts to releasing the overlay (no remote-hogging). Card and Scoreboard stay internal (Card is the silent fallback).

## Testing
Deployed to the Onn 4K (`com.espn.score_center` 6.11.1); picker cycles the four modes, no strand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)