### PR TITLE
feat(espn): Clone + Disable auto-updates patches, and make the live slate optional

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/espn/CloneAppPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/espn/CloneAppPatch.kt
@@ -1,0 +1,134 @@
+package app.morphe.patches.espn
+
+import app.morphe.patcher.patch.resourcePatch
+import app.morphe.patches.shared.compat.AppCompatibilities
+import org.w3c.dom.Element
+
+// Suffix appended to the original applicationId for the cloned package, e.g.
+// com.espn.score_center -> com.espn.score_center.mod
+private const val CLONE_SUFFIX = "mod"
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Clone ESPN (side-by-side install)
+//
+// Many Android TVs / TV boxes — and notably Amazon Fire TV devices — ship ESPN
+// as a SYSTEM app that cannot be uninstalled without root. Installing a patched
+// build over the stock system app is impossible, and renaming the applicationId
+// alone is NOT enough:
+//
+//   A ContentProvider's android:authorities and any custom <permission>
+//   android:name must be UNIQUE device-wide, independent of applicationId. They
+//   stay pinned to the original package string, so PackageManager rejects the
+//   install with INSTALL_FAILED_CONFLICTING_PROVIDER (or a duplicate-permission
+//   error) as long as the stock app is present.
+//
+// This patch renames the package AND every package-scoped identifier that must
+// be device-unique (provider authorities + custom permissions), so the clone
+// installs cleanly alongside the stock app. The rewrite is generic: it rewrites
+// any authority/permission whose name is prefixed with the app's own package,
+// and defers @string-backed authorities to the strings.xml pass. It adapts to
+// whatever ESPN's manifest declares in a given build, without a hardcoded list.
+//
+// Intent actions and <queries> package targets are left untouched: they are not
+// device-unique and are matched by literal string on both ends.
+//
+// Runs in finalize {} so the rename happens after all other patches, at manifest
+// write time. Opt-in (default = false): only clone when explicitly selected.
+// ─────────────────────────────────────────────────────────────────────────────
+@Suppress("unused")
+val cloneAppPatch = resourcePatch(
+    name = "Clone ESPN",
+    description = "Installs the patched ESPN as a separate app alongside the stock one, instead of " +
+        "replacing it. Enable this when ESPN is a preinstalled system app that can't be " +
+        "uninstalled — most commonly on Amazon Fire TV, and on some Android TV boxes and Onn " +
+        "devices. The clone gets its own package (suffix .$CLONE_SUFFIX), so it shows up as a " +
+        "second ESPN icon and keeps its own settings. Leave OFF if you were able to uninstall the " +
+        "original ESPN first (a normal in-place install is cleaner). Opt-in.",
+    default = false,
+) {
+    compatibleWith(AppCompatibilities.ESPN_TV)
+
+    finalize {
+        val packageName = packageMetadata.packageName
+        val newPackageName = "$packageName.$CLONE_SUFFIX"
+
+        // Authorities may be an @string/... reference rather than a literal; any
+        // such string resource names are collected here and rewritten below.
+        val providerStringResources = mutableSetOf<String>()
+
+        document("AndroidManifest.xml").use { document ->
+            document.documentElement.setAttribute("package", newPackageName)
+
+            // ── Custom permissions ──────────────────────────────────────────
+            // A <permission> android:name must be device-unique. Rename each
+            // declaration prefixed with the old package, and keep any matching
+            // <uses-permission> in sync so the app can still request its own.
+            val permissions = document.getElementsByTagName("permission")
+            val usesPermissions = document.getElementsByTagName("uses-permission")
+
+            for (i in 0 until permissions.length) {
+                val permission = permissions.item(i) as? Element ?: continue
+                val oldName = permission.getAttribute("android:name")
+                val newName = when {
+                    oldName.startsWith('.') -> continue
+                    oldName.startsWith("$packageName.") ->
+                        oldName.replaceFirst(packageName, newPackageName)
+                    else -> "${newPackageName}_$oldName"
+                }
+                permission.setAttribute("android:name", newName)
+
+                for (j in 0 until usesPermissions.length) {
+                    val usePerm = usesPermissions.item(j) as? Element ?: continue
+                    if (usePerm.getAttribute("android:name") == oldName) {
+                        usePerm.setAttribute("android:name", newName)
+                        break
+                    }
+                }
+            }
+
+            // ── Provider authorities ────────────────────────────────────────
+            // android:authorities is a ';'-separated list; each entry must be
+            // device-unique. Rewrite literals prefixed with the old package and
+            // defer @string references to the strings.xml pass below.
+            val providers = document.getElementsByTagName("provider")
+
+            for (i in 0 until providers.length) {
+                val provider = providers.item(i) as? Element ?: continue
+                val authorities = provider.getAttribute("android:authorities").split(';')
+                val newAuthorities = authorities.map {
+                    when {
+                        it.startsWith("$packageName.") ->
+                            it.replaceFirst(packageName, newPackageName)
+                        it.startsWith('@') -> {
+                            providerStringResources.add(it.removePrefix("@string/"))
+                            it
+                        }
+                        else -> "${newPackageName}_$it"
+                    }
+                }
+                provider.setAttribute("android:authorities", newAuthorities.joinToString(";"))
+            }
+        }
+
+        // ── @string-backed authorities ──────────────────────────────────────
+        // Rewrite any provider authorities that were declared as @string/...
+        // references rather than manifest literals.
+        if (providerStringResources.isNotEmpty()) {
+            document("res/values/strings.xml").use { document ->
+                val children = document.documentElement.childNodes
+                for (i in 0 until children.length) {
+                    val node = children.item(i) as? Element ?: continue
+
+                    if (node.getAttribute("name") in providerStringResources) {
+                        val authority = node.textContent
+                        node.textContent = if (authority.startsWith("$packageName.")) {
+                            authority.replaceFirst(packageName, newPackageName)
+                        } else {
+                            "${newPackageName}_$authority"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/espn/DisableAutoUpdatesPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/espn/DisableAutoUpdatesPatch.kt
@@ -1,0 +1,52 @@
+package app.morphe.patches.espn
+
+import app.morphe.patcher.patch.resourcePatch
+import app.morphe.patches.shared.compat.AppCompatibilities
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Disable Auto Updates (ESPN Android TV)
+//
+// Prevents the Google Play Store from silently updating and replacing the
+// patched ESPN APK with the official unpatched version — which would restore the
+// ad stack and wipe the slate feature with no warning.
+//
+// There is no manifest attribute that turns off Play Store auto-updates: update
+// eligibility is decided entirely by Play Store comparing versionCode against
+// what's installed. So this patch bumps android:versionCode on the <manifest>
+// root far past the real app's value; Play Store only offers an update when its
+// listed versionCode is higher than what's installed, so keeping the patched
+// build's versionCode artificially ahead makes it look already up to date.
+//
+// You can still update deliberately by re-patching a newer APK in Morphe. Does
+// not apply to mount-installed apps.
+// ─────────────────────────────────────────────────────────────────────────────
+@Suppress("unused")
+val disableAutoUpdatesPatch = resourcePatch(
+    name = "Disable auto-updates",
+    description = "Stops the Google Play Store from silently updating ESPN back to the official " +
+        "version and wiping out the patch (which would bring the ads back). Works by setting the " +
+        "patched build's version number far ahead of anything on the Store, so it's treated as " +
+        "already up to date. You can still update deliberately by re-patching a newer APK in " +
+        "Morphe. Recommended to leave ON. Does not apply to mount-installed apps.",
+) {
+    compatibleWith(AppCompatibilities.ESPN_TV)
+
+    execute {
+        // Bump android:versionCode on <manifest> past Play Store's real value.
+        // Clamped to Int.MAX_VALUE since versionCode is a 32-bit signed field.
+        document("AndroidManifest.xml").use { document ->
+            val manifestNode = document
+                .getElementsByTagName("manifest")
+                .item(0)
+
+            val versionCodeAttr = manifestNode
+                .attributes
+                .getNamedItem("android:versionCode")
+
+            val bumpedVersionCode = (versionCodeAttr.nodeValue.toLong() + 10_000_000L)
+                .coerceAtMost(Int.MAX_VALUE.toLong())
+
+            versionCodeAttr.nodeValue = bumpedVersionCode.toString()
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/espn/EspnAdsPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/espn/EspnAdsPatch.kt
@@ -40,13 +40,12 @@ import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 @Suppress("unused")
 val espnAdsPatch = bytecodePatch(
     name = "ESPN Android TV",
-    description = "Suppresses ESPN Android TV VOD/scheduled ads (DMP SGAI isAdDisabled) and masks LIVE " +
-        "passthrough-SSAI commercial breaks with a full-screen \"Commercial Break\" slate + mute " +
-        "(the live ad can't be removed, only covered). Optional slate media is user-supplied local " +
-        "files; disable the live slate with a `slate_off` marker file. No DNS dependency.",
+    description = "Suppresses ESPN Android TV VOD/scheduled ads by forcing DMP SGAI isAdDisabled = " +
+        "true (that one boolean gates all six ad-scheduling sites). Live passthrough-SSAI " +
+        "commercial breaks can't be removed — to MASK them with a slate + mute, also select the " +
+        "\"ESPN live commercial-break slate\" patch. No DNS dependency.",
 ) {
     compatibleWith(AppCompatibilities.ESPN_TV)
-    extendWith("extensions/extension.mpe")
 
     execute {
         // Locate the `iput-boolean pX, ...->isAdDisabled:Z` in the constructor and
@@ -70,62 +69,6 @@ val espnAdsPatch = bytecodePatch(
         method.addInstructions(
             iputIndex,
             "const/16 v$valueRegister, 0x1",
-        )
-
-        // ─────────────────────────────────────────────────────────────────────
-        // LIVE SLATE OVERLAY (the passthrough-SSAI mask).
-        //
-        // isAdDisabled above kills SCHEDULED interstitials / DATERANGE ads (VOD),
-        // but ESPN live ads are native passthrough SSAI played straight from the
-        // main manifest — isAdDisabled is inert against them (proven on-device).
-        // Since there is no content under a live national commercial, the accepted
-        // ceiling is to COVER the ad with an ESPN-style "COMMERCIAL BREAK / WE'LL
-        // BE RIGHT BACK" slate and mute audio.
-        //
-        // Live passthrough breaks emit NO break/interstitial event (proven on-
-        // device 2026-09-03) — the only truth is "playhead inside a break window",
-        // so the helper computes containment from two feeds (see below).
-        // All-bytecode; no native/segment work.
-        // ─────────────────────────────────────────────────────────────────────
-
-        // 1) Register / unregister the slate's host container (PlayerActivity's
-        //    android.R.id.content root) around the visible lifecycle.
-        PlayerActivityOnResumeFingerprint.method.addInstructions(
-            0,
-            "invoke-static { p0 }, Lajstrick81/morphe/extension/espn/ads/EspnAdBreakOverlayHelper;" +
-                "->registerActivity(Landroid/app/Activity;)V",
-        )
-        PlayerActivityOnPauseFingerprint.method.addInstructions(
-            0,
-            "invoke-static { p0 }, Lajstrick81/morphe/extension/espn/ads/EspnAdBreakOverlayHelper;" +
-                "->unregisterActivity(Landroid/app/Activity;)V",
-        )
-
-        // 2) Feed A — playhead position. sessionListener.onEvent(event) receives
-        //    every PlaybackSessionEvent; the helper reads the playhead out of
-        //    TimelineProgressEvent and re-evaluates window containment.
-        SessionListenerOnEventFingerprint.method.addInstructions(
-            0,
-            "invoke-static { p1 }, Lajstrick81/morphe/extension/espn/ads/EspnAdBreakOverlayHelper;" +
-                "->onPlayerEvent(Ljava/lang/Object;)V",
-        )
-
-        // 3) Feed B1 — capture the DMP session so the helper can poll
-        //    session.getBreaks() (works on streams that surface interstitial
-        //    breaks, e.g. with the on-screen countdown). p1 = the session.
-        AttachSessionFingerprint.method.addInstructions(
-            0,
-            "invoke-static { p1 }, Lajstrick81/morphe/extension/espn/ads/EspnAdBreakOverlayHelper;" +
-                "->setSession(Ljava/lang/Object;)V",
-        )
-
-        // 4) Feed B2 — manifest DateRanges. On pure-passthrough streams getBreaks()
-        //    is empty, but SgaiPlaybackSession.playlistRetrieved(DateTime, List<DateRange>)
-        //    always carries the ad windows (absolute dates). p2 = the DateRange list.
-        PlaylistRetrievedFingerprint.method.addInstructions(
-            0,
-            "invoke-static { p2 }, Lajstrick81/morphe/extension/espn/ads/EspnAdBreakOverlayHelper;" +
-                "->onDateRanges(Ljava/lang/Object;)V",
         )
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/espn/EspnLiveSlatePatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/espn/EspnLiveSlatePatch.kt
@@ -1,0 +1,89 @@
+package app.morphe.patches.espn
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.shared.compat.AppCompatibilities
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ESPN live commercial-break SLATE (the passthrough-SSAI mask).
+//
+// The core "ESPN Android TV" patch forces DMP SGAI isAdDisabled = true, which
+// kills SCHEDULED interstitials / DATERANGE ads (VOD). But ESPN LIVE ads are
+// native passthrough SSAI played straight from the main manifest — isAdDisabled
+// is inert against them (proven on-device) and NO Kotlin break event fires.
+// Since there's no content under a live national commercial, the accepted
+// ceiling is to MASK it: detect the break window and cover the player with a
+// full-screen slate (video / image / animated "Be Right Back" overlay) + mute.
+//
+// This is a SEPARATE, deselectable patch so users who only want the VOD ad
+// suppression (no on-screen slate during live breaks) can leave it off. It
+// depends on the core ESPN patch (which provides the DMP suppression) and bundles
+// the extension that the slate hooks call into.
+//
+// Window truth comes from two feeds (playhead + manifest DateRanges); the helper
+// (EspnAdBreakOverlayHelper) computes containment and drives the overlay + mute.
+// Slate media is user-supplied local files in the app's external files dir —
+// NOTHING is bundled. Runtime opt-out: a `slate_off` marker disables it without
+// re-patching; `slate_mode` picks the layout; the animated overlay lives under
+// files/espn_overlay/. See slates/espn_overlay/README.md.
+//
+// Verified on Onn 4K, ESPN 6.11.1: live breaks masked with correct rotation,
+// clean lifts, player muted.
+// ─────────────────────────────────────────────────────────────────────────────
+@Suppress("unused")
+val espnLiveSlatePatch = bytecodePatch(
+    name = "ESPN live commercial-break slate",
+    description = "Masks LIVE ESPN commercial breaks (which are passthrough SSAI and can't be " +
+        "removed) with a full-screen slate + mute: your own video/image clips, or the animated " +
+        "\"Be Right Back\" overlay with a live countdown. Includes an on-screen D-pad picker to " +
+        "switch styles. Leave OFF if you only want the VOD ad suppression and no on-screen slate " +
+        "during live breaks. Runtime opt-out: a `slate_off` marker file.",
+) {
+    compatibleWith(AppCompatibilities.ESPN_TV)
+    // The core patch provides the DMP isAdDisabled suppression; run after it.
+    dependsOn(espnAdsPatch)
+    // Bundle the extension the slate hooks call into.
+    extendWith("extensions/extension.mpe")
+
+    execute {
+        // 1) Register / unregister the slate's host container (PlayerActivity's
+        //    android.R.id.content root) around the visible lifecycle.
+        PlayerActivityOnResumeFingerprint.method.addInstructions(
+            0,
+            "invoke-static { p0 }, Lajstrick81/morphe/extension/espn/ads/EspnAdBreakOverlayHelper;" +
+                "->registerActivity(Landroid/app/Activity;)V",
+        )
+        PlayerActivityOnPauseFingerprint.method.addInstructions(
+            0,
+            "invoke-static { p0 }, Lajstrick81/morphe/extension/espn/ads/EspnAdBreakOverlayHelper;" +
+                "->unregisterActivity(Landroid/app/Activity;)V",
+        )
+
+        // 2) Feed A — playhead position. sessionListener.onEvent(event) receives
+        //    every PlaybackSessionEvent; the helper reads the playhead out of
+        //    TimelineProgressEvent and re-evaluates window containment.
+        SessionListenerOnEventFingerprint.method.addInstructions(
+            0,
+            "invoke-static { p1 }, Lajstrick81/morphe/extension/espn/ads/EspnAdBreakOverlayHelper;" +
+                "->onPlayerEvent(Ljava/lang/Object;)V",
+        )
+
+        // 3) Feed B1 — capture the DMP session so the helper can poll
+        //    session.getBreaks() (works on streams that surface interstitial
+        //    breaks, e.g. with the on-screen countdown). p1 = the session.
+        AttachSessionFingerprint.method.addInstructions(
+            0,
+            "invoke-static { p1 }, Lajstrick81/morphe/extension/espn/ads/EspnAdBreakOverlayHelper;" +
+                "->setSession(Ljava/lang/Object;)V",
+        )
+
+        // 4) Feed B2 — manifest DateRanges. On pure-passthrough streams getBreaks()
+        //    is empty, but SgaiPlaybackSession.playlistRetrieved(DateTime, List<DateRange>)
+        //    always carries the ad windows (absolute dates). p2 = the DateRange list.
+        PlaylistRetrievedFingerprint.method.addInstructions(
+            0,
+            "invoke-static { p2 }, Lajstrick81/morphe/extension/espn/ads/EspnAdBreakOverlayHelper;" +
+                "->onDateRanges(Ljava/lang/Object;)V",
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Adds two standard install-time patches to ESPN and makes the live slate deselectable, following the repo's existing per-app patterns.

### Changes
- **Disable auto-updates** (new, on by default) — bumps `android:versionCode` far ahead so the Play Store treats the patched build as already up to date and won't silently reinstall the official ESPN APK (which would restore ads). Mirrors Pluto/Peacock/Prime.
- **Clone ESPN** (new, opt-in / off by default) — renames the package plus every device-unique identifier (provider authorities, custom permissions) so a patched ESPN installs alongside a stock **system-app** ESPN (Fire TV, some Android TV boxes) instead of being rejected with `INSTALL_FAILED_CONFLICTING_PROVIDER`. Generic rewrite from the shared clone pattern.
- **Live slate now a separate patch** — the live commercial-break slate overlay hooks move out of the core "ESPN Android TV" patch into a new **"ESPN live commercial-break slate"** patch (on by default, `dependsOn` the core). The core now does only the DMP `isAdDisabled` VOD/scheduled-ad suppression (always on), so users who only want ad suppression can deselect the slate.

### Testing
On the Onn 4K (`com.espn.score_center` 6.11.1): default set applies **3 patches** (core + slate + disable-updates), **Clone correctly skipped** (opt-in). Installed build boots clean (no crash), `versionCode` bumped to 11109107 (disable-updates confirmed). Slate hooks are the same ones already verified masking live breaks. Clone not installed here (no stock system-app ESPN on this unit) — compile/patch-verified; confirm on a Fire TV.

Note: independent of the picker-simplification in #157 (different files); either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)