### PR TITLE
fix(pluto): re-map resume bookmark into ad-stripped timeline (#147)

### DIFF
--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/pluto/ads/PlutoDashManifestProbe.java
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/pluto/ads/PlutoDashManifestProbe.java
@@ -53,6 +53,35 @@ public final class PlutoDashManifestProbe {
 
     private static final String TAG = "MORPHE-DASH-MF";
 
+    // ── Resume-overshoot fix (issue #147) ──────────────────────────────────────
+    // Removing ad <Period>s shortens the content timeline (e.g. 29:42 -> 22:02).
+    // Pluto restores a "Continue Watching" bookmark expressed in the ORIGINAL
+    // (ad-inclusive) timeline and Avia bakes it into the media asset as a start
+    // position (AviaPlayer.startExoplayer -> Player.seekTo). If that bookmark sits
+    // past the new, shorter duration, ExoPlayer seeks past the end -> STATE_ENDED
+    // -> Pluto autoplay-advances to the next episode (the one-off skip in #147).
+    //
+    // Fix: remember the ad periods we removed from the most-recently stripped VOD
+    // manifest, keyed by their ORIGINAL start, so {@link #mapResumePosition} can
+    // convert an original-timeline bookmark into stripped-timeline coordinates
+    // (subtract the ad time removed before it) — landing the viewer at the correct
+    // content position instead of clamping them to the end. Only the current title
+    // plays at a time, so the most-recent strip is the right offset table; every
+    // fail-open / live passthrough clears it so no stale mapping is ever applied.
+    private static volatile long[] removedAdStartsMs = new long[0]; // original-timeline starts, ascending
+    private static volatile long[] removedAdDursMs = new long[0];   // matching removed durations
+    private static volatile long lastStrippedDurationMs = 0;        // new (content-only) total, ms
+    // Land a remapped resume slightly inside content so it never lands exactly at
+    // the end (which itself would end the item and autoplay-advance).
+    private static final long RESUME_END_MARGIN_MS = 5_000L;
+
+    /** Clear the resume-offset table (called whenever a manifest is passed through unstripped). */
+    private static void clearResumeOffsets() {
+        removedAdStartsMs = new long[0];
+        removedAdDursMs = new long[0];
+        lastStrippedDurationMs = 0;
+    }
+
     /**
      * True if a period is an AD (an ad spot or the ad bumper), detected by the
      * ad-creative URL signature. Everything that is NOT an ad — real content, whether
@@ -99,6 +128,11 @@ public final class PlutoDashManifestProbe {
         try {
             if (manifest == null) return null;
 
+            // Reset the resume-offset table up front; only a SUCCESSFUL strip below
+            // repopulates it, so every passthrough/fail-open path leaves it cleared
+            // and mapResumePosition() becomes a no-op (issue #147).
+            clearResumeOffsets();
+
             // LIVE TV guard. Only VOD is in scope: on-demand titles are STATIC DASH
             // (manifest.dynamic == false). Live/linear channels are DYNAMIC DASH — a
             // moving live edge and wall-clock timeline; re-basing period startMs there
@@ -113,6 +147,8 @@ public final class PlutoDashManifestProbe {
 
             int n = manifest.getPeriodCount();
             List<Period> kept = new ArrayList<>();
+            // Removed ad periods, keyed by ORIGINAL start, for the resume remap (#147).
+            List<long[]> removedSpans = new ArrayList<>(); // {originalStartMs, durationMs}
             long cursor = 0;
             int removed = 0;
             for (int i = 0; i < n; i++) {
@@ -120,6 +156,8 @@ public final class PlutoDashManifestProbe {
                 long durMs = manifest.getPeriodDurationMs(i);
                 if (isAdPeriod(p)) {
                     removed++;
+                    // p.startMs is the ORIGINAL (ad-inclusive) timeline start.
+                    removedSpans.add(new long[] { p.startMs, durMs });
                 } else {
                     // Rebuild at the re-based start; adaptation sets, event streams and
                     // asset identifier carry through intact (segment timelines are
@@ -157,12 +195,89 @@ public final class PlutoDashManifestProbe {
                 manifest.serviceDescription,
                 manifest.location,
                 kept);
+            // Publish the resume-offset table for this stripped manifest (#147).
+            // removedSpans is already in ascending original-start order (periods are
+            // iterated in timeline order).
+            long[] starts = new long[removedSpans.size()];
+            long[] durs = new long[removedSpans.size()];
+            for (int i = 0; i < removedSpans.size(); i++) {
+                starts[i] = removedSpans.get(i)[0];
+                durs[i] = removedSpans.get(i)[1];
+            }
+            removedAdStartsMs = starts;
+            removedAdDursMs = durs;
+            lastStrippedDurationMs = cursor;
             Log.i(TAG, "STRIPPED " + removed + " ad periods, kept " + kept.size()
                 + " content, newDurationMs=" + cursor + " (was " + manifest.durationMs + ")");
             return out;
         } catch (Throwable t) {
             Log.e(TAG, "strip failed -> original manifest (playback unaffected): " + t.getMessage());
             return manifest;
+        }
+    }
+
+    /**
+     * Resume-overshoot fix (issue #147). Called from injected smali at
+     * {@code AviaPlayer.startExoplayer}, right before the resume seek
+     * {@code Player.seekTo(startPosition)}. Maps a bookmark expressed in the
+     * ORIGINAL (ad-inclusive) timeline into the shortened, ad-stripped timeline so
+     * the player never seeks past the end of the shorter content.
+     *
+     * <p>Behaviour:
+     * <ul>
+     *   <li>If nothing was stripped (live, fail-open, or a non-VOD asset), or the
+     *       bookmark is already within the current (stripped) duration, the value is
+     *       returned unchanged — normal seeks and resumes are untouched.</li>
+     *   <li>Otherwise the bookmark overshoots the shorter content: subtract the ad
+     *       time removed before it (from the strip's offset table) to land at the
+     *       correct content position, then clamp just inside the end.</li>
+     * </ul>
+     * Fully fail-open: any surprise returns the original position, so resume can
+     * never be broken by this hook.
+     *
+     * @param player   the media3 player about to be seeked (for its current duration)
+     * @param originalPos the resume position Avia is about to seek to (original ms)
+     * @return the position to actually seek to (stripped-timeline ms)
+     */
+    public static long mapResumePosition(androidx.media3.common.Player player, long originalPos) {
+        try {
+            if (originalPos <= 0) return originalPos;
+
+            // Authoritative shortened duration: the live player's current window if
+            // known, else the last strip's total. Both reflect the ad-stripped length.
+            long playerDur = -1;
+            try {
+                if (player != null) playerDur = player.getDuration();
+            } catch (Throwable ignored) { /* getDuration can throw before timeline settles */ }
+            long strippedDur = playerDur > 0 ? playerDur : lastStrippedDurationMs;
+
+            // No overshoot (or unknown duration) -> leave the seek exactly as-is.
+            if (strippedDur <= 0 || originalPos <= strippedDur) return originalPos;
+
+            // The bookmark is past the shortened content. Subtract the ad time
+            // removed at or before it to recover the true content position.
+            long[] starts = removedAdStartsMs;
+            long[] durs = removedAdDursMs;
+            long removedBefore = 0;
+            for (int i = 0; i < starts.length && i < durs.length; i++) {
+                if (starts[i] < originalPos) removedBefore += durs[i];
+                else break; // ascending starts
+            }
+            long mapped = originalPos - removedBefore;
+
+            // Clamp just inside content so we resume INTO the show, never at the very
+            // end (an end-seek re-triggers the ENDED -> autoplay-advance this fixes).
+            long maxPos = strippedDur - RESUME_END_MARGIN_MS;
+            if (maxPos < 0) maxPos = 0;
+            if (mapped > maxPos) mapped = maxPos;
+            if (mapped < 0) mapped = 0;
+
+            Log.i(TAG, "resume remap (#147): original=" + originalPos + " removedBefore="
+                + removedBefore + " -> " + mapped + " (strippedDur=" + strippedDur + ")");
+            return mapped;
+        } catch (Throwable t) {
+            Log.e(TAG, "resume remap failed -> original position (resume unaffected): " + t.getMessage());
+            return originalPos;
         }
     }
 }

--- a/extensions/proguard-rules.pro
+++ b/extensions/proguard-rules.pro
@@ -91,6 +91,7 @@
 # runtime (compileOnly).
 -keep class ajstrick81.morphe.extension.pluto.ads.PlutoDashManifestProbe {
     public static androidx.media3.exoplayer.dash.manifest.DashManifest stripAdPeriods(androidx.media3.exoplayer.dash.manifest.DashManifest);
+    public static long mapResumePosition(androidx.media3.common.Player, long);
 }
 -dontwarn androidx.media3.exoplayer.dash.manifest.**
 

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/pluto/ads/Fingerprints.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/pluto/ads/Fingerprints.kt
@@ -145,6 +145,31 @@ object DashManifestParserParseFingerprint : Fingerprint(
 )
 
 // ---------------------------------------------------------------------------
+// Hook 6 — AviaPlayer.startExoplayer(MediaSource) — the RESUME-SEEK seam (issue #147).
+//
+// Pluto plays through Paramount's Avia SDK on top of media3/ExoPlayer (both
+// un-obfuscated in this build). When the media is loaded, startExoplayer reads the
+// resume bookmark off the media asset (getStartPosition(), in the ORIGINAL
+// ad-inclusive timeline) and applies it with a single
+//   Landroidx/media3/common/Player;->seekTo(J)V
+// call — the ONLY seekTo(J) in this method. Because Hook 5 shortened the content
+// timeline, a bookmark past the new (shorter) duration makes ExoPlayer seek past
+// the end -> STATE_ENDED -> Pluto autoplay-advances to the next episode (the
+// one-off skip in #147). The parsed timeline is already live here, so the player's
+// current (stripped) duration is readable. Hook 6 routes the start position through
+// PlutoDashManifestProbe.mapResumePosition(player, pos) just before that seekTo,
+// re-mapping an original-timeline bookmark into stripped-timeline coordinates.
+// Confirmed present in 5.66.0-leanback:
+//   com/paramount/android/avia/player/player/core/AviaPlayer;
+//     ->startExoplayer(Landroidx/media3/exoplayer/source/MediaSource;)V
+object AviaStartExoplayerFingerprint : Fingerprint(
+    definingClass = "Lcom/paramount/android/avia/player/player/core/AviaPlayer;",
+    name = "startExoplayer",
+    parameters = listOf("Landroidx/media3/exoplayer/source/MediaSource;"),
+    returnType = "V",
+)
+
+// ---------------------------------------------------------------------------
 // Tier 2 candidate — VOD auto-skip (NOT wired; requires on-device validation)
 //
 // Because the ad-break timeline is fully client-side, VOD ads *may* be made

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/pluto/ads/SkipAdsPatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/pluto/ads/SkipAdsPatch.kt
@@ -5,6 +5,9 @@ import app.morphe.patcher.patch.bytecodePatch
 import ajstrick81.morphe.patches.pluto.shared.Constants
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 @Suppress("unused")
 val skipAdsPatch = bytecodePatch(
@@ -16,7 +19,10 @@ val skipAdsPatch = bytecodePatch(
         "gone); (2) empties the client-side ad-break timeline (StitcherSession.adBreaks — " +
         "the same data AdGuard strips via jsonprune) and no-ops pause ads and clickable-ad " +
         "overlays, removing the markers/UI/beacons. Fail-open: a manifest it can't rewrite " +
-        "is passed through unchanged (ads remain, playback never breaks). LIVE TV ads are " +
+        "is passed through unchanged (ads remain, playback never breaks). A resume bookmark " +
+        "saved in the original (ad-inclusive) timeline is re-mapped into the shortened " +
+        "timeline so resuming a partially-watched episode no longer overshoots the end and " +
+        "autoplay-skips (issue #147). LIVE TV ads are " +
         "real broadcast time in the linear feed and are not removable. Validated on-device, " +
         "5.66.0-leanback.",
 ) {
@@ -102,6 +108,42 @@ val skipAdsPatch = bytecodePatch(
                 """
                     invoke-static {v$manifestRegister}, Lajstrick81/morphe/extension/pluto/ads/PlutoDashManifestProbe;->stripAdPeriods(Landroidx/media3/exoplayer/dash/manifest/DashManifest;)Landroidx/media3/exoplayer/dash/manifest/DashManifest;
                     move-result-object v$manifestRegister
+                """.trimIndent(),
+            )
+        }
+
+        // Hook 6 — resume-overshoot fix (issue #147).
+        //
+        // Hook 5 shortens the VOD content timeline by dropping ad periods. Pluto
+        // restores a "Continue Watching" bookmark in the ORIGINAL (ad-inclusive)
+        // timeline; Avia applies it as the ExoPlayer start position in
+        // AviaPlayer.startExoplayer via a single Player.seekTo(J). If that bookmark
+        // is past the new, shorter duration, ExoPlayer seeks past the end ->
+        // STATE_ENDED -> Pluto autoplay-advances to the next episode (the one-off
+        // skip in #147). The parsed timeline is already live at this point, so we
+        // route the start position through PlutoDashManifestProbe.mapResumePosition,
+        // which re-maps an original-timeline bookmark into stripped-timeline
+        // coordinates (subtracting ad time removed before it) just before the seek.
+        // Fail-open: mapResumePosition returns the original value on anything
+        // unexpected, so resume can never be broken.
+        AviaStartExoplayerFingerprint.method.apply {
+            val instructions = implementation!!.instructions.toList()
+            val seekIndex = instructions.indexOfFirst {
+                it.opcode == Opcode.INVOKE_INTERFACE &&
+                    ((it as? ReferenceInstruction)?.reference as? MethodReference)?.let { ref ->
+                        ref.definingClass == "Landroidx/media3/common/Player;" && ref.name == "seekTo"
+                    } == true
+            }
+            check(seekIndex >= 0) { "skipAdsPatch Hook 6: no Player.seekTo(J) in startExoplayer" }
+            val seek = instructions[seekIndex] as FiveRegisterInstruction
+            val playerReg = seek.registerC       // ExoPlayer being seeked
+            val posLow = seek.registerD          // start position (wide, low half)
+            val posHigh = seek.registerE         // start position (wide, high half)
+            addInstructions(
+                seekIndex,
+                """
+                    invoke-static {v$playerReg, v$posLow, v$posHigh}, Lajstrick81/morphe/extension/pluto/ads/PlutoDashManifestProbe;->mapResumePosition(Landroidx/media3/common/Player;J)J
+                    move-result-wide v$posLow
                 """.trimIndent(),
             )
         }


### PR DESCRIPTION
## What

Fixes #147 — a resume into a partially-watched Pluto VOD episode could occasionally **autoplay-skip to the next episode once**, then play fine on replay.

## Mechanism

The `Skip ads` DASH period surgery (Hook 5) shortens the content timeline by dropping ad `<Period>`s (e.g. 25:33 → 22:02). Pluto restores a "Continue Watching" bookmark in the **original (ad-inclusive) timeline**, which Avia bakes into the media asset as the ExoPlayer start position (`AviaPlayer.startExoplayer` → `Player.seekTo`). When that bookmark sits past the new, shorter duration, ExoPlayer seeks past the end → `STATE_ENDED` → Pluto autoplay-advances.

## Fix

Chose the issue's **candidate #2 (offset mapping)** over a plain end-clamp — clamping to the end would still end the item and auto-advance, whereas mapping lands the viewer at the correct content position.

- `stripAdPeriods` now records the removed ad periods (original-timeline start + duration) and the new stripped duration; every fail-open / live passthrough clears the table so no stale mapping is applied.
- New `mapResumePosition(player, pos)`: when a resume overshoots the current (stripped) duration, subtract the ad time removed before it to recover the true content position, clamped just inside the end. In-range resumes and fresh starts pass through unchanged.
- **Hook 6** (`AviaStartExoplayerFingerprint`) routes the start position through `mapResumePosition` immediately before the resume `Player.seekTo(J)` in `AviaPlayer.startExoplayer`. media3/Avia are un-obfuscated in this build.

Fully **fail-open**: `mapResumePosition` returns the original position on anything unexpected, so resume can never be broken by this hook.

## Verification (Onn 4K, `tv.pluto.android` 5.66.0-leanback)

- ✅ Both hooks apply (injected call present in dex); app boots with no `VerifyError`.
- ✅ VOD strip intact — 16 & 10 ad periods removed across two titles (incl. the 25:33 → **22:02** case from the report).
- ✅ Live manifests passed through untouched.
- ✅ Multiple resumes play cleanly — no skip, **no false remap** on in-range bookmarks, no crash.

The overshoot itself is intermittent (the issue reproduced it once); the safety property that normal resumes are untouched is confirmed, and the remap is fail-open by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
