### PR TITLE
feat(pluto): mask live commercial breaks with black screen + mute (#152)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ I'm just like you — I enjoy watching TV and movies without being bored and ann
 | 🟢 Peacock | `com.peacocktv.peacockandroid` | Working — no DNS required | `v7.8.100` | 9/6/26 |
 | 🟢 Tubi | `com.tubitv` | Working | `v10.28.5000` | 7/20/26 |
 | 🟢 ViX | `com.univision.prendetv` | Working | `v4.47.2_tv` | 7/11/26 |
-| 🟢 Pluto TV | `tv.pluto.android` | Working — VOD ad breaks removed (video, markers, beacons); LIVE TV ads are broadcast time and remain | `5.66.0-leanback` | 7/3/26 |
+| 🟢 Pluto TV | `tv.pluto.android` | Working — VOD ad breaks removed (video, markers, beacons); LIVE TV breaks maskable (black screen + mute) via optional patch | `5.66.0-leanback` | 9/7/26 |
 | 🟢 Paramount+ | `com.cbs.ott` | Working — VOD ads removed (movies + TV shows, pre-roll + mid-roll); pause ads removed; live TV preserved | `v16.17.0` | 8/4/26 |
 | 🟢 Twitch | `tv.twitch.android.app` | Working — **Android TV "Starshot" build only; install exactly `13.0.0.2`** (the phone app is not supported — do not use the phone APK). Removes the on-screen ad-pod overlay/countdown ("Ad · 1 of 3") and blanks stitched (SSAI) ad video on live streams. A brief black gap can remain during a break; a VPN set to Albania is fully ad-free — see notes | `13.0.0.2` | 8/22/26 |
 | 🟢 ESPN | `com.espn.score_center` | Working — **Android TV** only. Live commercial breaks masked with a full-screen slate + audio mute (passthrough SSAI can't be removed, only covered); VOD/scheduled ads suppressed. No DNS required | `6.11.1` | 9/5/26 |
@@ -174,14 +174,26 @@ All patches follow the same general workflow using **Morphe Manager**:
 > the content, so there is no ad domain to block and no ad-free tier to unlock.
 > This patch empties the client-side ad-break timeline, which removes **on-demand
 > (VOD)** ad breaks entirely: ad video, timeline markers, overlays, and tracking
-> beacons. **LIVE TV** ads are real broadcast time in the linear feed and are not
-> removable. DNS filters do **not** help here.
+> beacons. **LIVE TV** ads are real broadcast time in the linear feed and cannot be
+> *removed* — but the separate **Mask live ad breaks** patch *hides* them (see below).
+> DNS filters do **not** help here.
 
 1. Open the **[Pluto TV (Android TV) listing on APKMirror](https://www.apkmirror.com/apk/pluto-inc/pluto-tv-android-tv/)** and select version **`5.66.0-leanback`**
 2. ⚠️ Use this **Android TV** listing and pick a **`-leanback`** build — not the phone or Fire TV build
 3. Download the `.apkm` file
 4. Select it in Morphe Manager
 5. Apply the patch
+
+> 📺 **Mask live ad breaks (black screen + mute).** Live/linear Pluto ads occupy real
+> broadcast time and can't be deleted like VOD ads, so this optional patch **masks** the
+> break instead: during a live commercial it covers the player with a **black screen** and
+> **mutes** the audio, then restores both the instant the show returns — so gambling,
+> drinking, or any other live ad is blanked and silenced. It reads Pluto's own ad-state
+> signal, so it needs no polling and works alongside the main **Skip ads** patch. It's
+> **opt-out** (leave it off to watch live ads normally). Runtime tweaks via marker files in
+> the app's external files dir (`Android/data/tv.pluto.android/files/`): create **`slate_off`**
+> to disable it on-device without re-patching, or **`pluto_slate_mode`** containing `black`
+> (cover only) or `mute` (mute only) instead of the default both.
 
 ---
 

--- a/extensions/extension/src/main/java/ajstrick81/morphe/extension/pluto/ads/PlutoLiveSlateHelper.kt
+++ b/extensions/extension/src/main/java/ajstrick81/morphe/extension/pluto/ads/PlutoLiveSlateHelper.kt
@@ -1,0 +1,252 @@
+package ajstrick81.morphe.extension.pluto.ads
+
+import android.app.Activity
+import android.graphics.Color
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import java.lang.ref.WeakReference
+import java.lang.reflect.Method
+
+/**
+ * Pluto TV — LIVE commercial-break MASK (issue #152).
+ *
+ * Live/linear Pluto ads are real broadcast time stitched into the dynamic DASH feed:
+ * they can't be removed the way VOD ad periods are (that's the shipped "Skip ads" strip,
+ * which deliberately passes live manifests through untouched). The accepted ceiling for
+ * live is to **mask** the break — cover the player with a black screen and mute the audio
+ * for the duration, then restore when the show returns. This is the ESPN/Paramount live
+ * slate pattern applied to Pluto.
+ *
+ * DETECTOR (decoded on-device 2026-09-07, real live break). Pluto's own
+ * {@code ID3AdsBeaconTracker.consumeID3(ID3Tag)} fires ONLY while an ad is playing (it is
+ * silent during the show): each ad announces {@code START_OF_MEDIA} then ticks
+ * {@code GENERIC_WTA}/{@code QUARTILE_*} every ~2.5–5s; back-to-back ads chain by new
+ * {@code creativeId}. So every {@code consumeID3} call = "an ad is on screen right now."
+ * We treat each call as an ad tick: show the mask + mute and (re)arm a short hide timer;
+ * when the ticks stop (content resumed), the timer fires and we lift the mask + unmute.
+ * Event-driven, no polling, and it survives "Skip ads" (that only neuters
+ * {@code BeaconTracker.fire}, a different class).
+ *
+ * All app/player calls are reflection BY NAME so the extension never compiles against the
+ * app or Avia modules (and to survive R8 renaming of shared types across the merge).
+ */
+object PlutoLiveSlateHelper {
+
+    private const val TAG = "MORPHE-PLUTO-SLATE"
+    private const val DEBUG = false
+
+    // Runtime opt-out: an empty file named `slate_off` in the app's external files dir
+    // disables the live mask entirely (ads play normally). Lets a user turn it off
+    // without re-patching. VOD ad removal is unaffected (different patch).
+    private const val DISABLE_MARKER = "slate_off"
+
+    // Layout selector: `pluto_slate_mode` marker contents pick the behaviour.
+    //   both  (default) — black cover + mute
+    //   black          — black cover only (audio left alone)
+    //   mute           — mute only (no cover)
+    private const val MODE_MARKER = "pluto_slate_mode"
+
+    // Ad-state ticks arrive at most ~5s apart; if none arrives for this long the break
+    // is over. A little slack past the tick cadence so the mask never lifts mid-break.
+    private const val HIDE_DELAY_MS = 6_500L
+    // Absolute backstop: never leave the mask up longer than this without a tick (guards
+    // against a stuck state if teardown is missed).
+    private const val FAILSAFE_MS = 15L * 60L * 1000L
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    private var activityRef: WeakReference<Activity> = WeakReference(null) // the stable player host Activity
+    @Volatile private var aviaPlayer: Any? = null
+    private var exoPlayer: Any? = null
+    private var mGetVolume: Method? = null
+    private var mSetVolume: Method? = null
+
+    private var overlay: FrameLayout? = null
+    private var shown = false
+    private var muted = false
+    private var savedVolume = 1.0f
+
+    private enum class Mode { BOTH, BLACK, MUTE }
+
+    private val hideRunnable = Runnable { lift("no ad ticks (break ended)") }
+    private val failsafeRunnable = Runnable { lift("failsafe") }
+
+    // ───────────────────────── injected entry points ─────────────────────────
+
+    /** Injected at AviaPlaybackController.<init> (p1 = the AviaPlayer). Captures the player for muting. */
+    @JvmStatic
+    fun setAviaPlayer(player: Any?) {
+        aviaPlayer = player
+        exoPlayer = null // re-resolve lazily against the new player
+        mGetVolume = null
+        mSetVolume = null
+        if (DEBUG) Log.d(TAG, "setAviaPlayer(${player?.javaClass?.simpleName})")
+    }
+
+    /**
+     * Injected at LeanbackMainHostActivity.onCreate (p0 = the Activity). The stable
+     * single-Activity host whose content root covers the player for the whole session
+     * (unlike the live-controls fragment, whose view is destroyed when controls auto-hide).
+     */
+    @JvmStatic
+    fun registerActivity(activity: Activity?) {
+        if (activity != null) activityRef = WeakReference(activity)
+        if (DEBUG) Log.d(TAG, "registerActivity(${activity?.javaClass?.simpleName})")
+    }
+
+    /** Injected at LeanbackMainHostActivity.onDestroy. Host gone — lift and clear. */
+    @JvmStatic
+    fun unregisterActivity(activity: Activity?) {
+        if (activityRef.get() === activity) {
+            mainHandler.post { lift("host activity destroyed") }
+            activityRef = WeakReference(null)
+        }
+    }
+
+    /**
+     * Injected at ID3AdsBeaconTracker.consumeID3(ID3Tag). Every call = an ad is on screen.
+     * Shows the mask + mutes and (re)arms the hide timer; the timer lifts it when ticks stop.
+     */
+    @JvmStatic
+    fun onAdTick(id3Tag: Any?) {
+        mainHandler.post { showOrKeep() }
+    }
+
+    // ───────────────────────────── mask lifecycle ────────────────────────────
+
+    private fun showOrKeep() {
+        val mode = readMode()
+        if (mode == null) { // opt-out marker present
+            if (shown) lift("opt-out marker")
+            return
+        }
+        // Re-arm the timers on every tick.
+        mainHandler.removeCallbacks(hideRunnable)
+        mainHandler.postDelayed(hideRunnable, HIDE_DELAY_MS)
+        if (!shown) {
+            mainHandler.removeCallbacks(failsafeRunnable)
+            mainHandler.postDelayed(failsafeRunnable, FAILSAFE_MS)
+        }
+
+        if (mode == Mode.BOTH || mode == Mode.MUTE) mute()
+        if (mode == Mode.BOTH || mode == Mode.BLACK) showCover()
+        if (!shown) Log.d(TAG, "live ad break -> mask ON (mode=$mode)")
+        shown = true
+    }
+
+    private fun lift(reason: String) {
+        mainHandler.removeCallbacks(hideRunnable)
+        mainHandler.removeCallbacks(failsafeRunnable)
+        if (!shown) return
+        removeCover()
+        unmute()
+        shown = false
+        Log.d(TAG, "live ad break -> mask OFF ($reason)")
+    }
+
+    private fun showCover() {
+        if (overlay != null) return
+        val root = contentRoot() ?: run {
+            Log.w(TAG, "showCover: no content root — fragment activity unavailable")
+            return
+        }
+        val cover = FrameLayout(root.context).apply {
+            setBackgroundColor(Color.BLACK)
+            isClickable = true
+            isFocusable = false
+            // Sit above the player's video surface: max elevation/translationZ so we win
+            // z-order even when the video is a SurfaceView drawn late.
+            elevation = 1_000_000f
+            translationZ = 1_000_000f
+        }
+        root.addView(
+            cover,
+            ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT),
+        )
+        cover.bringToFront()
+        root.invalidate()
+        Log.i(TAG, "showCover: cover added to ${root.javaClass.simpleName} childCount=${root.childCount}")
+        overlay = cover
+    }
+
+    private fun removeCover() {
+        overlay?.let { (it.parent as? ViewGroup)?.removeView(it) }
+        overlay = null
+    }
+
+    // ExoPlayer volume is a float 0f..1f with get + set — read once at mute so we can
+    // restore exactly (the player normally runs at full volume; TV/system controls the
+    // rest). Reflected by name to avoid compiling against Avia/media3-exoplayer.
+    private fun mute() {
+        if (muted) return
+        val exo = resolveExo() ?: return
+        try {
+            val get = mGetVolume ?: exo.javaClass.getMethod("getVolume").also { mGetVolume = it }
+            val set = mSetVolume ?: exo.javaClass.getMethod("setVolume", Float::class.javaPrimitiveType)
+                .also { mSetVolume = it }
+            savedVolume = (get.invoke(exo) as? Float) ?: 1.0f
+            set.invoke(exo, 0.0f)
+            muted = true
+        } catch (t: Throwable) {
+            if (DEBUG) Log.w(TAG, "mute failed: $t")
+        }
+    }
+
+    private fun unmute() {
+        if (!muted) return
+        val exo = resolveExo() ?: run { muted = false; return }
+        try {
+            val set = mSetVolume ?: exo.javaClass.getMethod("setVolume", Float::class.javaPrimitiveType)
+                .also { mSetVolume = it }
+            set.invoke(exo, savedVolume)
+        } catch (t: Throwable) {
+            if (DEBUG) Log.w(TAG, "unmute failed: $t")
+        }
+        muted = false
+    }
+
+    // AviaPlayer.player is a public field of type androidx.media3.exoplayer.ExoPlayer.
+    private fun resolveExo(): Any? {
+        exoPlayer?.let { return it }
+        val avia = aviaPlayer ?: return null
+        return try {
+            val f = avia.javaClass.getField("player")
+            f.get(avia)?.also { exoPlayer = it }
+        } catch (t: Throwable) {
+            if (DEBUG) Log.w(TAG, "resolveExo failed: $t")
+            null
+        }
+    }
+
+    // ─────────────────────────────── helpers ─────────────────────────────────
+
+    private fun contentRoot(): ViewGroup? {
+        val activity = activityRef.get() ?: return null
+        return try {
+            activity.findViewById(android.R.id.content) as? ViewGroup
+        } catch (t: Throwable) {
+            if (DEBUG) Log.w(TAG, "contentRoot failed: $t")
+            null
+        }
+    }
+
+    /** Read the mode marker; null means opt-out (`slate_off` present). Default BOTH. */
+    private fun readMode(): Mode? {
+        val ctx = activityRef.get()
+        val dir = try { ctx?.getExternalFilesDir(null) } catch (_: Throwable) { null } ?: return Mode.BOTH
+        try {
+            if (java.io.File(dir, DISABLE_MARKER).exists()) return null
+        } catch (_: Throwable) {}
+        val token = try {
+            java.io.File(dir, MODE_MARKER).takeIf { it.exists() }?.readText()?.trim()?.lowercase()
+        } catch (_: Throwable) { null }
+        return when (token) {
+            "black" -> Mode.BLACK
+            "mute" -> Mode.MUTE
+            else -> Mode.BOTH
+        }
+    }
+}

--- a/extensions/proguard-rules.pro
+++ b/extensions/proguard-rules.pro
@@ -95,6 +95,15 @@
 }
 -dontwarn androidx.media3.exoplayer.dash.manifest.**
 
+# Pluto LIVE ad-break mask — liveSlatePatch (see LiveSlatePatch.kt). Its @JvmStatic
+# entry points are called only from injected smali, so R8 would strip/rename them.
+-keep class ajstrick81.morphe.extension.pluto.ads.PlutoLiveSlateHelper {
+    public static void onAdTick(java.lang.Object);
+    public static void registerActivity(android.app.Activity);
+    public static void unregisterActivity(android.app.Activity);
+    public static void setAviaPlayer(java.lang.Object);
+}
+
 # HBO Max — SSAI ad-origin filter. HboAdOriginFilter.guard(Object) is called
 # only from injected smali (invoke-static {} at DefaultHttpDataSource.open),
 # so R8 sees it as unreferenced and would strip or rename it. Keep the class

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/pluto/ads/Fingerprints.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/pluto/ads/Fingerprints.kt
@@ -169,6 +169,64 @@ object AviaStartExoplayerFingerprint : Fingerprint(
     returnType = "V",
 )
 
+// ===========================================================================
+// LIVE ad-break MASK (issue #152) — fingerprints for the liveSlatePatch.
+//
+// Live/linear Pluto ads are real broadcast time in the dynamic DASH feed and can't be
+// removed (the VOD strip passes live manifests through untouched). Instead we MASK the
+// break: black cover + mute, lifted when the show returns. Detector + host seams below,
+// all confirmed on 5.66.0-leanback and against a real live break (2026-09-07).
+// ===========================================================================
+
+// Detector — ID3AdsBeaconTracker.consumeID3(ID3Tag): fires ONLY while an ad is playing
+// (silent during the show). Each call = "an ad is on screen now"; the helper re-arms a
+// short hide timer per call and lifts the mask when the ticks stop. Synchronous, void,
+// single param — a clean offset-0 hook. Survives "Skip ads" (that neuters BeaconTracker,
+// a different class).
+object Id3ConsumeFingerprint : Fingerprint(
+    definingClass = "Ltv/pluto/kmm/ads/adsbeacontracker/ID3AdsBeaconTracker;",
+    name = "consumeID3",
+    parameters = listOf("Ltv/pluto/kmm/ads/adsbeacontracker/model/ID3Tag;"),
+    returnType = "V",
+)
+
+// Overlay host — the single-Activity leanback host (LeanbackMainHostActivity). Its content
+// root covers the player for the WHOLE session, unlike the live-controls fragment whose view
+// is destroyed when the on-screen controls auto-hide (which prematurely tore the mask down).
+// onCreate captures the Activity (p0); onDestroy clears it. The cover is added lazily at
+// break time, so registering at onCreate (before the content view exists) is fine.
+object LeanbackHostOnCreateFingerprint : Fingerprint(
+    definingClass = "Ltv/pluto/android/ui/main/LeanbackMainHostActivity;",
+    name = "onCreate",
+    parameters = listOf("Landroid/os/Bundle;"),
+    returnType = "V",
+)
+
+object LeanbackHostOnDestroyFingerprint : Fingerprint(
+    definingClass = "Ltv/pluto/android/ui/main/LeanbackMainHostActivity;",
+    name = "onDestroy",
+    parameters = listOf(),
+    returnType = "V",
+)
+
+// Mute — capture the AviaPlayer (constructor arg p1) so the helper can reflect its
+// media3 ExoPlayer `player` field and get/set its volume (mute = 0f, restored on lift).
+object AviaControllerInitFingerprint : Fingerprint(
+    definingClass = "Ltv/pluto/library/player/impl/avia/AviaPlaybackController;",
+    name = "<init>",
+    parameters = listOf(
+        "Lcom/paramount/android/avia/player/player/core/AviaPlayer;",
+        "Ltv/pluto/library/player/impl/avia/IAviaAccessor;",
+        "Ltv/pluto/library/player/api/IContentController;",
+        "Ltv/pluto/library/player/IAdGroupsDispatcher;",
+        "Ltv/pluto/library/player/api/IPlayerRxEventsAdapter;",
+        "Lio/reactivex/disposables/CompositeDisposable;",
+        "Lio/reactivex/Scheduler;",
+        "Ltv/pluto/library/player/utils/IThreadPoster;",
+    ),
+    returnType = "V",
+)
+
 // ---------------------------------------------------------------------------
 // Tier 2 candidate — VOD auto-skip (NOT wired; requires on-device validation)
 //

--- a/patches/src/main/kotlin/ajstrick81/morphe/patches/pluto/ads/LiveSlatePatch.kt
+++ b/patches/src/main/kotlin/ajstrick81/morphe/patches/pluto/ads/LiveSlatePatch.kt
@@ -1,0 +1,61 @@
+package ajstrick81.morphe.patches.pluto.ads
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import ajstrick81.morphe.patches.pluto.shared.Constants
+
+@Suppress("unused")
+val liveSlatePatch = bytecodePatch(
+    name = "Mask live ad breaks (black screen + mute)",
+    description = "Masks Pluto TV LIVE/linear commercial breaks, which are real broadcast time " +
+        "stitched into the live feed and cannot be removed (unlike VOD ads, which \"Skip ads\" " +
+        "deletes outright). During a live break it covers the player with a black screen and mutes " +
+        "the audio, then restores both the instant the show returns — so gambling, drinking, or any " +
+        "other live ad is blanked and silenced. Detection is driven by Pluto's own ID3 ad-state flow " +
+        "(ID3AdsBeaconTracker), which fires only while an ad plays, so it needs no polling and keeps " +
+        "working alongside \"Skip ads\". Opt-out: leave it OFF to watch live ads normally; runtime " +
+        "controls are marker files in the app's external files dir — `slate_off` disables it, and " +
+        "`pluto_slate_mode` set to `black` or `mute` picks cover-only or mute-only instead of both. " +
+        "Validated on-device, 5.66.0-leanback.",
+) {
+    compatibleWith(Constants.COMPATIBILITY)
+
+    // Bundle the extension the slate hooks call into (shared with "Skip ads").
+    extendWith("extensions/extension.mpe")
+
+    execute {
+        // 1) Detector — ID3AdsBeaconTracker.consumeID3(ID3Tag). Every call = an ad is on
+        //    screen right now; the helper shows the mask + mutes and re-arms a short hide
+        //    timer, lifting when the ticks stop (content resumed). p1 = the ID3Tag.
+        Id3ConsumeFingerprint.method.addInstructions(
+            0,
+            "invoke-static { p1 }, Lajstrick81/morphe/extension/pluto/ads/PlutoLiveSlateHelper;" +
+                "->onAdTick(Ljava/lang/Object;)V",
+        )
+
+        // 2) Overlay host — capture the stable single-Activity leanback host (p0) so the
+        //    helper can reach the Activity content root at break time. Registering at
+        //    onCreate (before the content view exists) is fine — the cover is added lazily.
+        //    onDestroy clears it. Mask lifetime is driven ONLY by ID3 ticks, never by the
+        //    controls view lifecycle.
+        LeanbackHostOnCreateFingerprint.method.addInstructions(
+            0,
+            "invoke-static { p0 }, Lajstrick81/morphe/extension/pluto/ads/PlutoLiveSlateHelper;" +
+                "->registerActivity(Landroid/app/Activity;)V",
+        )
+        LeanbackHostOnDestroyFingerprint.method.addInstructions(
+            0,
+            "invoke-static { p0 }, Lajstrick81/morphe/extension/pluto/ads/PlutoLiveSlateHelper;" +
+                "->unregisterActivity(Landroid/app/Activity;)V",
+        )
+
+        // 3) Mute handle — capture the AviaPlayer (constructor arg p1). p1 is a parameter
+        //    register, valid at offset 0 even before the super() call. The helper reflects
+        //    its media3 ExoPlayer `player` field to get/set volume (mute = 0f, restored).
+        AviaControllerInitFingerprint.method.addInstructions(
+            0,
+            "invoke-static { p1 }, Lajstrick81/morphe/extension/pluto/ads/PlutoLiveSlateHelper;" +
+                "->setAviaPlayer(Ljava/lang/Object;)V",
+        )
+    }
+}


### PR DESCRIPTION
## What

Implements #152 — masks Pluto **live/linear** commercial breaks with a **black screen + mute**, restored the instant the show returns. Live ads are real broadcast time stitched into the dynamic DASH feed and can't be removed the way VOD ads are (the shipped "Skip ads" strip deliberately leaves live manifests untouched), so masking is the correct tool. This covers the gambling/drinking-ad concern from the issue by blanking **every** live break, category-agnostic.

## How it works

**Detector — Pluto's own ID3 ad-state flow.** `ID3AdsBeaconTracker.consumeID3(ID3Tag)` fires *only* while an ad is on screen (silent during the show); each call is an "ad tick". The helper shows the mask + mutes on the first tick and re-arms a short hide timer on every tick, lifting when the ticks stop. Event-driven, no polling, and it **survives "Skip ads"** (which only neuters `BeaconTracker.fire`, a different class). Decoded on-device against a real break (back-to-back 30s/15s ads).

**Hooks** (all un-obfuscated in this build):
- `ID3AdsBeaconTracker.consumeID3(ID3Tag)` → `onAdTick` — the detector.
- `LeanbackMainHostActivity.onCreate/onDestroy` → register/unregister the stable single-Activity host (its content root covers the player for the whole session; the live-controls fragment is *not* usable — its view is destroyed when controls auto-hide, which tore an earlier attempt's mask down mid-break).
- `AviaPlaybackController.<init>` (arg p1) → capture the `AviaPlayer`; the helper reflects its media3 `ExoPlayer` `player` field to get/set volume (mute = 0f, restored exactly on lift).

## Options

Opt-out patch (leave OFF to watch live ads normally). Runtime markers in the app's external files dir: `slate_off` disables it; `pluto_slate_mode` = `black` or `mute` picks cover-only or mute-only instead of the default **both**.

## Verification (Onn 4K, `tv.pluto.android` 5.66.0-leanback)

Across a real live break: screen goes **black and audio mutes** at break start, holds for the **whole** break, then **both clear cleanly the instant the show returns** — `mask ON → OFF` driven purely by the ID3 ticks. Audio transitions were smooth in and out; no crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
